### PR TITLE
Focus nested form-dialog fields when a nested level is pushed

### DIFF
--- a/src/dialogs/form/dialog-form.ts
+++ b/src/dialogs/form/dialog-form.ts
@@ -144,58 +144,17 @@ export class DialogForm
     return prev;
   }
 
-  private async _waitForActiveForm(options?: {
-    waitForCustomElements?: boolean;
-  }): Promise<void> {
+  private async _afterFormRender(): Promise<void> {
     await this.updateComplete;
     await this._form?.updateComplete;
     await nextRender();
+  }
 
-    if (!options?.waitForCustomElements) {
+  private _focusFirstControl(root = this._form): void {
+    if (!root) {
       return;
     }
 
-    const selectors = this._form?.shadowRoot?.querySelectorAll("ha-selector");
-    if (selectors?.length) {
-      await Promise.all(
-        Array.from(selectors, (element) =>
-          "updateComplete" in element
-            ? (element as LitElement).updateComplete
-            : undefined
-        )
-      );
-    }
-
-    const pending = this._undefinedCustomElements(this._form);
-    if (pending.length) {
-      await Promise.all(pending.map((tag) => customElements.whenDefined(tag)));
-      await nextRender();
-    }
-  }
-
-  private _undefinedCustomElements(root?: ParentNode): string[] {
-    const tags = new Set<string>();
-    const visit = (node: ParentNode) => {
-      if (node instanceof Element && node.shadowRoot) {
-        visit(node.shadowRoot);
-      }
-      for (const child of Array.from(node.children)) {
-        if (
-          child.localName.includes("-") &&
-          !customElements.get(child.localName)
-        ) {
-          tags.add(child.localName);
-        }
-        visit(child);
-      }
-    };
-    if (root) {
-      visit(root);
-    }
-    return [...tags];
-  }
-
-  private _firstFocusable(root: ParentNode): HTMLElement | undefined {
     const visit = (node: ParentNode): HTMLElement | undefined => {
       if (node instanceof Element && node.shadowRoot) {
         const inShadow = visit(node.shadowRoot);
@@ -204,16 +163,10 @@ export class DialogForm
         }
       }
 
-      for (const child of Array.from(node.children)) {
-        if (!(child instanceof HTMLElement) || child.hidden) {
-          continue;
-        }
+      for (const child of node.children) {
         if (
-          !child.hasAttribute("disabled") &&
-          (child.matches(
-            "input:not([type=hidden]), textarea, select, button, [href]"
-          ) ||
-            child.tabIndex >= 0)
+          child instanceof HTMLElement &&
+          child.matches("input, textarea, select, button")
         ) {
           return child;
         }
@@ -226,26 +179,19 @@ export class DialogForm
       return undefined;
     };
 
-    return visit(root);
-  }
-
-  private _focusForm(form?: HaForm): void {
-    if (!form) {
-      return;
-    }
-    (this._firstFocusable(form) ?? form).focus();
+    visit(root)?.focus();
   }
 
   private async _focusActiveForm(
     expectedParams: FormDialogParams
   ): Promise<void> {
-    await this._waitForActiveForm({ waitForCustomElements: true });
+    await this._afterFormRender();
 
     if (!this._open || this._params !== expectedParams) {
       return;
     }
 
-    this._focusForm(this._form);
+    this._focusFirstControl();
   }
 
   private async _restoreFocusAndScroll(
@@ -253,7 +199,7 @@ export class DialogForm
     expectedParams: FormDialogParams,
     focusTarget?: Element
   ): Promise<void> {
-    await this._waitForActiveForm();
+    await this._afterFormRender();
 
     if (!this._open || this._params !== expectedParams || !this._dialog) {
       return;
@@ -262,7 +208,7 @@ export class DialogForm
     if (focusTarget instanceof HTMLElement && focusTarget.isConnected) {
       focusTarget.focus();
     } else {
-      this._focusForm(this._form);
+      this._focusFirstControl();
     }
 
     this._dialog.bodyContainer.scrollTop = scrollTop;

--- a/src/dialogs/form/dialog-form.ts
+++ b/src/dialogs/form/dialog-form.ts
@@ -150,6 +150,49 @@ export class DialogForm
     await nextRender();
   }
 
+  private async _waitForSelectorElements(): Promise<void> {
+    const selectors = this._form?.shadowRoot?.querySelectorAll("ha-selector");
+    if (selectors?.length) {
+      await Promise.all(
+        Array.from(selectors, (element) =>
+          "updateComplete" in element
+            ? (element as LitElement).updateComplete
+            : undefined
+        )
+      );
+    }
+
+    const pending = this._undefinedCustomElements(this._form);
+    if (!pending.length) {
+      return;
+    }
+
+    await Promise.all(pending.map((tag) => customElements.whenDefined(tag)));
+    await nextRender();
+  }
+
+  private _undefinedCustomElements(root?: ParentNode): string[] {
+    const tags = new Set<string>();
+    const visit = (node: ParentNode) => {
+      if (node instanceof Element && node.shadowRoot) {
+        visit(node.shadowRoot);
+      }
+      for (const child of node.children) {
+        if (
+          child.localName.includes("-") &&
+          !customElements.get(child.localName)
+        ) {
+          tags.add(child.localName);
+        }
+        visit(child);
+      }
+    };
+    if (root) {
+      visit(root);
+    }
+    return [...tags];
+  }
+
   private _focusFirstControl(root = this._form): void {
     if (!root) {
       return;
@@ -186,6 +229,12 @@ export class DialogForm
     expectedParams: FormDialogParams
   ): Promise<void> {
     await this._afterFormRender();
+
+    if (!this._open || this._params !== expectedParams) {
+      return;
+    }
+
+    await this._waitForSelectorElements();
 
     if (!this._open || this._params !== expectedParams) {
       return;

--- a/src/dialogs/form/dialog-form.ts
+++ b/src/dialogs/form/dialog-form.ts
@@ -10,6 +10,7 @@ import deepClone from "deep-clone-simple";
 import { deepActiveElement } from "../../common/dom/deep-active-element";
 import type { HASSDomEvent } from "../../common/dom/fire_event";
 import { fireEvent } from "../../common/dom/fire_event";
+import { nextRender } from "../../common/util/render-status";
 import "../../components/ha-button";
 import "../../components/ha-dialog";
 import "../../components/ha-dialog-footer";
@@ -123,6 +124,7 @@ export class DialogForm
     this._initialData = deepClone(this._data);
     this._error = undefined;
     this._resetDirtyTracking();
+    void this._focusActiveForm(nested);
   };
 
   private _popStack(): StackEntry | undefined {
@@ -142,16 +144,116 @@ export class DialogForm
     return prev;
   }
 
+  private async _waitForActiveForm(options?: {
+    waitForCustomElements?: boolean;
+  }): Promise<void> {
+    await this.updateComplete;
+    await this._form?.updateComplete;
+    await nextRender();
+
+    if (!options?.waitForCustomElements) {
+      return;
+    }
+
+    const selectors = this._form?.shadowRoot?.querySelectorAll("ha-selector");
+    if (selectors?.length) {
+      await Promise.all(
+        Array.from(selectors, (element) =>
+          "updateComplete" in element
+            ? (element as LitElement).updateComplete
+            : undefined
+        )
+      );
+    }
+
+    const pending = this._undefinedCustomElements(this._form);
+    if (pending.length) {
+      await Promise.all(pending.map((tag) => customElements.whenDefined(tag)));
+      await nextRender();
+    }
+  }
+
+  private _undefinedCustomElements(root?: ParentNode): string[] {
+    const tags = new Set<string>();
+    const visit = (node: ParentNode) => {
+      if (node instanceof Element && node.shadowRoot) {
+        visit(node.shadowRoot);
+      }
+      for (const child of Array.from(node.children)) {
+        if (
+          child.localName.includes("-") &&
+          !customElements.get(child.localName)
+        ) {
+          tags.add(child.localName);
+        }
+        visit(child);
+      }
+    };
+    if (root) {
+      visit(root);
+    }
+    return [...tags];
+  }
+
+  private _firstFocusable(root: ParentNode): HTMLElement | undefined {
+    const visit = (node: ParentNode): HTMLElement | undefined => {
+      if (node instanceof Element && node.shadowRoot) {
+        const inShadow = visit(node.shadowRoot);
+        if (inShadow) {
+          return inShadow;
+        }
+      }
+
+      for (const child of Array.from(node.children)) {
+        if (!(child instanceof HTMLElement) || child.hidden) {
+          continue;
+        }
+        if (
+          !child.hasAttribute("disabled") &&
+          (child.matches(
+            "input:not([type=hidden]), textarea, select, button, [href]"
+          ) ||
+            child.tabIndex >= 0)
+        ) {
+          return child;
+        }
+        const found = visit(child);
+        if (found) {
+          return found;
+        }
+      }
+
+      return undefined;
+    };
+
+    return visit(root);
+  }
+
+  private _focusForm(form?: HaForm): void {
+    if (!form) {
+      return;
+    }
+    (this._firstFocusable(form) ?? form).focus();
+  }
+
+  private async _focusActiveForm(
+    expectedParams: FormDialogParams
+  ): Promise<void> {
+    await this._waitForActiveForm({ waitForCustomElements: true });
+
+    if (!this._open || this._params !== expectedParams) {
+      return;
+    }
+
+    this._focusForm(this._form);
+  }
+
   private async _restoreFocusAndScroll(
     scrollTop: number,
     expectedParams: FormDialogParams,
     focusTarget?: Element
   ): Promise<void> {
-    await this.updateComplete;
-    await this._form?.updateComplete;
-    await new Promise<void>((resolve) => {
-      requestAnimationFrame(() => resolve());
-    });
+    await this._waitForActiveForm();
 
     if (!this._open || this._params !== expectedParams || !this._dialog) {
       return;
@@ -159,6 +261,8 @@ export class DialogForm
 
     if (focusTarget instanceof HTMLElement && focusTarget.isConnected) {
       focusTarget.focus();
+    } else {
+      this._focusForm(this._form);
     }
 
     this._dialog.bodyContainer.scrollTop = scrollTop;

--- a/test/dialogs/form/dialog-form.test.ts
+++ b/test/dialogs/form/dialog-form.test.ts
@@ -7,10 +7,6 @@ import type {
 import type { DialogForm } from "../../../src/dialogs/form/dialog-form";
 import "../../../src/dialogs/form/dialog-form";
 
-const mockForm = vi.hoisted(() => ({
-  delayedTag: undefined as string | undefined,
-}));
-
 vi.mock("../../../src/components/ha-button", () => {
   customElements.define("ha-button", class extends HTMLElement {});
   return {};
@@ -38,19 +34,14 @@ vi.mock("../../../src/components/ha-form/ha-form", () => {
       public reportValidity = vi.fn(() => true);
 
       public connectedCallback(): void {
-        this.tabIndex = -1;
         if (this.shadowRoot) {
           return;
         }
-        this.attachShadow({ mode: "open" });
-        if (mockForm.delayedTag) {
-          this.shadowRoot.append(document.createElement(mockForm.delayedTag));
-          return;
-        }
         const selector = document.createElement("div");
-        selector.attachShadow({ mode: "open" });
-        selector.shadowRoot!.append(document.createElement("input"));
-        this.shadowRoot.append(selector);
+        selector
+          .attachShadow({ mode: "open" })
+          .append(document.createElement("input"));
+        this.attachShadow({ mode: "open" }).append(selector);
       }
     }
   );
@@ -121,7 +112,6 @@ const cancel = (dialog: DialogForm) =>
   (getInternals(dialog)["_cancel"] as () => void)();
 
 afterEach(() => {
-  mockForm.delayedTag = undefined;
   document.body.replaceChildren();
   vi.clearAllMocks();
 });
@@ -220,35 +210,6 @@ describe("dialog-form mounted nested forms", () => {
 
     await vi.waitUntil(
       () => deepActiveElement() === formControl(getForms(dialog)[0])
-    );
-  });
-
-  it("focuses a nested control after its selector custom element upgrades", async () => {
-    const tag = `ha-test-delayed-selector-${crypto.randomUUID()}`;
-    const dialog = await openDialog();
-    const parent = getForms(dialog)[0];
-    const opener = document.createElement("button");
-    parent.append(opener);
-    opener.focus();
-
-    mockForm.delayedTag = tag;
-    await showNestedDialog(dialog, parent, nestedParams());
-
-    customElements.define(
-      tag,
-      class extends HTMLElement {
-        public connectedCallback(): void {
-          if (this.shadowRoot) {
-            return;
-          }
-          this.attachShadow({ mode: "open" });
-          this.shadowRoot.append(document.createElement("input"));
-        }
-      }
-    );
-
-    await vi.waitUntil(
-      () => deepActiveElement() === formControl(getForms(dialog)[1])
     );
   });
 

--- a/test/dialogs/form/dialog-form.test.ts
+++ b/test/dialogs/form/dialog-form.test.ts
@@ -27,7 +27,14 @@ vi.mock("../../../src/components/ha-dialog-footer", () => {
   return {};
 });
 
+const mockForm = vi.hoisted(() => ({
+  delayedTag: undefined as string | undefined,
+}));
+
 vi.mock("../../../src/components/ha-form/ha-form", () => {
+  if (!customElements.get("ha-selector")) {
+    customElements.define("ha-selector", class extends HTMLElement {});
+  }
   customElements.define(
     "ha-form",
     class extends HTMLElement {
@@ -35,6 +42,14 @@ vi.mock("../../../src/components/ha-form/ha-form", () => {
 
       public connectedCallback(): void {
         if (this.shadowRoot) {
+          return;
+        }
+        if (mockForm.delayedTag) {
+          const selector = document.createElement("ha-selector");
+          selector
+            .attachShadow({ mode: "open" })
+            .append(document.createElement(mockForm.delayedTag));
+          this.attachShadow({ mode: "open" }).append(selector);
           return;
         }
         const selector = document.createElement("div");
@@ -54,10 +69,30 @@ const getInternals = (dialog: DialogForm) =>
 const getForms = (dialog: DialogForm): HTMLElement[] =>
   Array.from(dialog.shadowRoot!.querySelectorAll("ha-form"));
 
-const formControl = (form: HTMLElement): HTMLElement | null =>
-  (form.shadowRoot?.firstElementChild?.shadowRoot?.querySelector(
-    "input, textarea, button"
-  ) as HTMLElement | null) ?? null;
+const formControl = (form: HTMLElement): HTMLElement | null => {
+  const visit = (node: ParentNode): HTMLElement | null => {
+    if (node instanceof Element && node.shadowRoot) {
+      const inShadow = visit(node.shadowRoot);
+      if (inShadow) {
+        return inShadow;
+      }
+    }
+    for (const child of node.children) {
+      if (
+        child instanceof HTMLElement &&
+        child.matches("input, textarea, button")
+      ) {
+        return child;
+      }
+      const found = visit(child);
+      if (found) {
+        return found;
+      }
+    }
+    return null;
+  };
+  return visit(form);
+};
 
 const outerParams = (data: FormDialogData = {}): FormDialogParams => ({
   title: "Outer",
@@ -112,6 +147,7 @@ const cancel = (dialog: DialogForm) =>
   (getInternals(dialog)["_cancel"] as () => void)();
 
 afterEach(() => {
+  mockForm.delayedTag = undefined;
   document.body.replaceChildren();
   vi.clearAllMocks();
 });
@@ -210,6 +246,36 @@ describe("dialog-form mounted nested forms", () => {
 
     await vi.waitUntil(
       () => deepActiveElement() === formControl(getForms(dialog)[0])
+    );
+  });
+
+  it("focuses a nested control after a cold selector chunk upgrades", async () => {
+    const tag = `ha-test-delayed-selector-${crypto.randomUUID()}`;
+    const dialog = await openDialog();
+    const parent = getForms(dialog)[0];
+    const opener = document.createElement("button");
+    parent.append(opener);
+    opener.focus();
+
+    mockForm.delayedTag = tag;
+    await showNestedDialog(dialog, parent, nestedParams());
+
+    customElements.define(
+      tag,
+      class extends HTMLElement {
+        public connectedCallback(): void {
+          if (this.shadowRoot) {
+            return;
+          }
+          this.attachShadow({ mode: "open" }).append(
+            document.createElement("input")
+          );
+        }
+      }
+    );
+
+    await vi.waitUntil(
+      () => deepActiveElement() === formControl(getForms(dialog)[1])
     );
   });
 

--- a/test/dialogs/form/dialog-form.test.ts
+++ b/test/dialogs/form/dialog-form.test.ts
@@ -7,6 +7,10 @@ import type {
 import type { DialogForm } from "../../../src/dialogs/form/dialog-form";
 import "../../../src/dialogs/form/dialog-form";
 
+const mockForm = vi.hoisted(() => ({
+  delayedTag: undefined as string | undefined,
+}));
+
 vi.mock("../../../src/components/ha-button", () => {
   customElements.define("ha-button", class extends HTMLElement {});
   return {};
@@ -32,6 +36,22 @@ vi.mock("../../../src/components/ha-form/ha-form", () => {
     "ha-form",
     class extends HTMLElement {
       public reportValidity = vi.fn(() => true);
+
+      public connectedCallback(): void {
+        this.tabIndex = -1;
+        if (this.shadowRoot) {
+          return;
+        }
+        this.attachShadow({ mode: "open" });
+        if (mockForm.delayedTag) {
+          this.shadowRoot.append(document.createElement(mockForm.delayedTag));
+          return;
+        }
+        const selector = document.createElement("div");
+        selector.attachShadow({ mode: "open" });
+        selector.shadowRoot!.append(document.createElement("input"));
+        this.shadowRoot.append(selector);
+      }
     }
   );
   return {};
@@ -42,6 +62,11 @@ const getInternals = (dialog: DialogForm) =>
 
 const getForms = (dialog: DialogForm): HTMLElement[] =>
   Array.from(dialog.shadowRoot!.querySelectorAll("ha-form"));
+
+const formControl = (form: HTMLElement): HTMLElement | null =>
+  (form.shadowRoot?.firstElementChild?.shadowRoot?.querySelector(
+    "input, textarea, button"
+  ) as HTMLElement | null) ?? null;
 
 const outerParams = (data: FormDialogData = {}): FormDialogParams => ({
   title: "Outer",
@@ -96,6 +121,7 @@ const cancel = (dialog: DialogForm) =>
   (getInternals(dialog)["_cancel"] as () => void)();
 
 afterEach(() => {
+  mockForm.delayedTag = undefined;
   document.body.replaceChildren();
   vi.clearAllMocks();
 });
@@ -130,6 +156,23 @@ describe("dialog-form mounted nested forms", () => {
     expect(getForms(dialog)[0].hidden).toBe(false);
   });
 
+  it("moves focus to the first nested form control when a level is pushed", async () => {
+    const dialog = await openDialog();
+    const parent = getForms(dialog)[0];
+    const opener = document.createElement("button");
+    parent.append(opener);
+    opener.focus();
+
+    expect(deepActiveElement()).toBe(opener);
+
+    await showNestedDialog(dialog, parent, nestedParams());
+
+    await vi.waitUntil(
+      () => deepActiveElement() === formControl(getForms(dialog)[1])
+    );
+    expect(getForms(dialog)[0].hidden).toBe(true);
+  });
+
   it.each(["submit", "cancel"] as const)(
     "restores focus to the opener after nested %s",
     async (action) => {
@@ -140,6 +183,9 @@ describe("dialog-form mounted nested forms", () => {
       opener.focus();
 
       await showNestedDialog(dialog, parent, nestedParams());
+      await vi.waitUntil(
+        () => deepActiveElement() === formControl(getForms(dialog)[1])
+      );
 
       const child = getForms(dialog)[1];
       const childFocusTarget = document.createElement("button");
@@ -157,6 +203,71 @@ describe("dialog-form mounted nested forms", () => {
       await vi.waitUntil(() => deepActiveElement() === opener);
     }
   );
+
+  it("focuses the first parent form control when the opener is gone after nested submit", async () => {
+    const dialog = await openDialog();
+    const parent = getForms(dialog)[0];
+    const opener = document.createElement("button");
+    parent.append(opener);
+    opener.focus();
+
+    await showNestedDialog(dialog, parent, nestedParams());
+    await vi.waitUntil(
+      () => deepActiveElement() === formControl(getForms(dialog)[1])
+    );
+    opener.remove();
+    submit(dialog);
+
+    await vi.waitUntil(
+      () => deepActiveElement() === formControl(getForms(dialog)[0])
+    );
+  });
+
+  it("focuses a nested control after its selector custom element upgrades", async () => {
+    const tag = `ha-test-delayed-selector-${crypto.randomUUID()}`;
+    const dialog = await openDialog();
+    const parent = getForms(dialog)[0];
+    const opener = document.createElement("button");
+    parent.append(opener);
+    opener.focus();
+
+    mockForm.delayedTag = tag;
+    await showNestedDialog(dialog, parent, nestedParams());
+
+    customElements.define(
+      tag,
+      class extends HTMLElement {
+        public connectedCallback(): void {
+          if (this.shadowRoot) {
+            return;
+          }
+          this.attachShadow({ mode: "open" });
+          this.shadowRoot.append(document.createElement("input"));
+        }
+      }
+    );
+
+    await vi.waitUntil(
+      () => deepActiveElement() === formControl(getForms(dialog)[1])
+    );
+  });
+
+  it("does not steal focus after a nested level is immediately cancelled", async () => {
+    const dialog = await openDialog();
+    const parent = getForms(dialog)[0];
+    const opener = document.createElement("button");
+    parent.append(opener);
+    opener.focus();
+
+    await showNestedDialog(dialog, parent, nestedParams());
+    cancel(dialog);
+
+    await vi.waitUntil(() => deepActiveElement() === opener);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(deepActiveElement()).toBe(opener);
+  });
 
   it("keeps the parent open after a custom object selector nested save", async () => {
     const dialog = await openDialog();


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Follow-up to #53709. After a nested `dialog-form` level is pushed, keyboard focus now moves to the first real control (`input` / `textarea` / `button`) inside the active `ha-form`.

Calling `.focus()` on the `ha-form` host is not enough: `delegatesFocus` does not pierce nested selector shadows, so focus previously stayed on the opener. Restore-focus still returns to the opener when it is connected, and falls back to that same nested control search when the opener has been disconnected.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53709
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr