### PR TITLE
Prefer neighbor relationship over raw LQI in ZHA network graph fallback

### DIFF
--- a/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
@@ -189,8 +189,8 @@ export function createZHANetworkChartData(
       }
       const closestNeighbor = neighbors.sort((a, b) => {
         const priorityDiff =
-          (relationshipPriority[a.relationship ?? ""] ?? UNKNOWN_RELATIONSHIP_PRIORITY) -
-          (relationshipPriority[b.relationship ?? ""] ?? UNKNOWN_RELATIONSHIP_PRIORITY);
+          (RELATIONSHIP_PRIORITY[a.relationship ?? ""] ?? UNKNOWN_RELATIONSHIP_PRIORITY) -
+          (RELATIONSHIP_PRIORITY[b.relationship ?? ""] ?? UNKNOWN_RELATIONSHIP_PRIORITY);
         return priorityDiff !== 0
           ? priorityDiff
           : parseInt(b.lqi) - parseInt(a.lqi);

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
@@ -12,6 +12,15 @@ function getLQIWidth(lqi: number): number {
   return lqi > 200 ? 3 : lqi > 100 ? 2 : 1;
 }
 
+const RELATIONSHIP_PRIORITY: Record<string, number> = {
+  Parent: 0,
+  Sibling: 1,
+  NoneOfTheAbove: 2,
+  Child: 3,
+  PreviousChild: 5,
+};
+const UNKNOWN_RELATIONSHIP_PRIORITY = 4;
+
 export function createZHANetworkChartData(
   devices: ZHADevice[],
   hass: HomeAssistant,
@@ -166,14 +175,6 @@ export function createZHANetworkChartData(
       // end device (e.g. a plug sitting right next to its router) over the
       // router's actual uplink, which severs it from the rest of the mesh
       // in the visualization even though the real network is connected.
-      const RELATIONSHIP_PRIORITY: Record<string, number> = {
-          Parent: 0,
-          Sibling: 1,
-          NoneOfTheAbove: 2,
-          Child: 3,
-          PreviousChild: 5, // stale: this device has left the network
-      };
-      const UNKNOWN_RELATIONSHIP_PRIORITY = 4;
       const neighbors: { ieee: string; lqi: string; relationship?: string }[] =
         device.neighbors ?? [];
       if (neighbors.length === 0) {

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
@@ -160,8 +160,19 @@ export function createZHANetworkChartData(
         }
       });
     } else if (existingLinks.length === 0) {
-      // If there are no links, create a link to the closest neighbor
-      const neighbors: { ieee: string; lqi: string }[] = device.neighbors ?? [];
+      // If there are no links, create a link to the closest neighbor.
+      // Prefer a neighbor the device's own Zigbee stack reports as its
+      // parent: picking by raw LQI alone regularly favors a nearby child
+      // end device (e.g. a plug sitting right next to its router) over the
+      // router's actual uplink, which severs it from the rest of the mesh
+      // in the visualization even though the real network is connected.
+      const relationshipPriority: Record<string, number> = {
+        Parent: 0,
+        Sibling: 1,
+        Child: 2,
+      };
+      const neighbors: { ieee: string; lqi: string; relationship?: string }[] =
+        device.neighbors ?? [];
       if (neighbors.length === 0) {
         // If there are no neighbors, look for links from other devices
         devices.forEach((d) => {
@@ -173,9 +184,14 @@ export function createZHANetworkChartData(
           }
         });
       }
-      const closestNeighbor = neighbors.sort(
-        (a, b) => parseInt(b.lqi) - parseInt(a.lqi)
-      )[0];
+      const closestNeighbor = neighbors.sort((a, b) => {
+        const priorityDiff =
+          (relationshipPriority[a.relationship ?? ""] ?? 1) -
+          (relationshipPriority[b.relationship ?? ""] ?? 1);
+        return priorityDiff !== 0
+          ? priorityDiff
+          : parseInt(b.lqi) - parseInt(a.lqi);
+      })[0];
       if (closestNeighbor) {
         links.push({
           source: device.ieee,

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
@@ -168,53 +168,78 @@ export function createZHANetworkChartData(
           existingLinks.push(link);
         }
       });
-    } else if (existingLinks.length === 0) {
-      // If there are no links, create a link to the closest neighbor.
-      // Prefer a neighbor the device's own Zigbee stack reports as its
-      // parent: picking by raw LQI alone regularly favors a nearby child
-      // end device (e.g. a plug sitting right next to its router) over the
-      // router's actual uplink, which severs it from the rest of the mesh
-      // in the visualization even though the real network is connected.
-      const neighbors: { ieee: string; lqi: string; relationship?: string }[] =
-        device.neighbors ?? [];
-      if (neighbors.length === 0) {
-        // If there are no neighbors, look for links from other devices
-        devices.forEach((d) => {
-          if (d.neighbors && d.neighbors.length > 0) {
-            const neighbor = d.neighbors.find((n) => n.ieee === device.ieee);
-            if (neighbor) {
-              neighbors.push({ ieee: d.ieee, lqi: neighbor.lqi });
-            }
-          }
-        });
-      }
-      const closestNeighbor = neighbors.sort((a, b) => {
-        const aPriority =
-          RELATIONSHIP_PRIORITY[a.relationship ?? ""] ??
-          UNKNOWN_RELATIONSHIP_PRIORITY;
-        const bPriority =
-          RELATIONSHIP_PRIORITY[b.relationship ?? ""] ??
-          UNKNOWN_RELATIONSHIP_PRIORITY;
-        const priorityDiff = aPriority - bPriority;
-        return priorityDiff !== 0
-          ? priorityDiff
-          : parseInt(b.lqi) - parseInt(a.lqi);
-      })[0];
-      if (closestNeighbor) {
-        links.push({
-          source: device.ieee,
-          target: closestNeighbor.ieee,
-          value: parseInt(closestNeighbor.lqi),
-          symbolSize: 5,
-          lineStyle: {
-            width: 1,
-            color: style.getPropertyValue("--dark-primary-color"),
-            type: "dotted",
-          },
-          ignoreForceLayout: true,
-        });
-      }
     }
+  });
+
+  // For every device whose routing table was empty (so it got no link
+  // above), independently compute its preferred fallback neighbor before
+  // creating any of these links. Doing this device-by-device while
+  // creating links (as before) meant whichever device the backend happens
+  // to list first "claims" the connection, and a sibling router listed
+  // later never gets to contribute its own — often better — choice,
+  // splitting the graph into islands depending on backend device order.
+  const fallbackTargets = new Map<string, { ieee: string; lqi: string }>();
+  devices.forEach((device) => {
+    const hasLink = links.some(
+      (link) => link.source === device.ieee || link.target === device.ieee
+    );
+    if (hasLink) {
+      return;
+    }
+    const neighbors: { ieee: string; lqi: string; relationship?: string }[] =
+      device.neighbors ?? [];
+    if (neighbors.length === 0) {
+      // If there are no neighbors, look for links from other devices
+      devices.forEach((d) => {
+        if (d.neighbors && d.neighbors.length > 0) {
+          const neighbor = d.neighbors.find((n) => n.ieee === device.ieee);
+          if (neighbor) {
+            neighbors.push({ ieee: d.ieee, lqi: neighbor.lqi });
+          }
+        }
+      });
+    }
+    // Prefer a neighbor the device's own Zigbee stack reports as its
+    // parent: picking by raw LQI alone regularly favors a nearby child end
+    // device (e.g. a plug sitting right next to its router) over the
+    // router's actual uplink, which severs it from the rest of the mesh in
+    // the visualization even though the real network is connected.
+    const closestNeighbor = neighbors.sort((a, b) => {
+      const aPriority =
+        RELATIONSHIP_PRIORITY[a.relationship ?? ""] ??
+        UNKNOWN_RELATIONSHIP_PRIORITY;
+      const bPriority =
+        RELATIONSHIP_PRIORITY[b.relationship ?? ""] ??
+        UNKNOWN_RELATIONSHIP_PRIORITY;
+      const priorityDiff = aPriority - bPriority;
+      return priorityDiff !== 0
+        ? priorityDiff
+        : parseInt(b.lqi) - parseInt(a.lqi);
+    })[0];
+    if (closestNeighbor) {
+      fallbackTargets.set(device.ieee, closestNeighbor);
+    }
+  });
+
+  const addedFallbackPairs = new Set<string>();
+  fallbackTargets.forEach((target, ieee) => {
+    const pairKey = [ieee, target.ieee].sort().join("|");
+    if (addedFallbackPairs.has(pairKey)) {
+      return;
+    }
+    addedFallbackPairs.add(pairKey);
+    links.push({
+      source: ieee,
+      target: target.ieee,
+      value: parseInt(target.lqi),
+      symbolSize: 5,
+      lineStyle: {
+        width: 1,
+        color: style.getPropertyValue("--dark-primary-color"),
+        type: "dotted",
+      },
+      ignoreForceLayout: true,
+    });
   });
 
   // Now set ignoreForceLayout to false for the best connection of each device

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
@@ -166,11 +166,14 @@ export function createZHANetworkChartData(
       // end device (e.g. a plug sitting right next to its router) over the
       // router's actual uplink, which severs it from the rest of the mesh
       // in the visualization even though the real network is connected.
-      const relationshipPriority: Record<string, number> = {
-        Parent: 0,
-        Sibling: 1,
-        Child: 2,
+      const RELATIONSHIP_PRIORITY: Record<string, number> = {
+          Parent: 0,
+          Sibling: 1,
+          NoneOfTheAbove: 2,
+          Child: 3,
+          PreviousChild: 5, // stale: this device has left the network
       };
+      const UNKNOWN_RELATIONSHIP_PRIORITY = 4;
       const neighbors: { ieee: string; lqi: string; relationship?: string }[] =
         device.neighbors ?? [];
       if (neighbors.length === 0) {
@@ -186,8 +189,8 @@ export function createZHANetworkChartData(
       }
       const closestNeighbor = neighbors.sort((a, b) => {
         const priorityDiff =
-          (relationshipPriority[a.relationship ?? ""] ?? 1) -
-          (relationshipPriority[b.relationship ?? ""] ?? 1);
+          (relationshipPriority[a.relationship ?? ""] ?? UNKNOWN_RELATIONSHIP_PRIORITY) -
+          (relationshipPriority[b.relationship ?? ""] ?? UNKNOWN_RELATIONSHIP_PRIORITY);
         return priorityDiff !== 0
           ? priorityDiff
           : parseInt(b.lqi) - parseInt(a.lqi);

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
@@ -189,9 +189,13 @@ export function createZHANetworkChartData(
         });
       }
       const closestNeighbor = neighbors.sort((a, b) => {
-        const priorityDiff =
-          (RELATIONSHIP_PRIORITY[a.relationship ?? ""] ?? UNKNOWN_RELATIONSHIP_PRIORITY) -
-          (RELATIONSHIP_PRIORITY[b.relationship ?? ""] ?? UNKNOWN_RELATIONSHIP_PRIORITY);
+        const aPriority =
+          RELATIONSHIP_PRIORITY[a.relationship ?? ""] ??
+          UNKNOWN_RELATIONSHIP_PRIORITY;
+        const bPriority =
+          RELATIONSHIP_PRIORITY[b.relationship ?? ""] ??
+          UNKNOWN_RELATIONSHIP_PRIORITY;
+        const priorityDiff = aPriority - bPriority;
         return priorityDiff !== 0
           ? priorityDiff
           : parseInt(b.lqi) - parseInt(a.lqi);

--- a/test/panels/config/integrations/integration-panels/zha/zha-network-data.test.ts
+++ b/test/panels/config/integrations/integration-panels/zha/zha-network-data.test.ts
@@ -133,4 +133,38 @@ describe("createZHANetworkChartData", () => {
     expect(reachable.has("downstream-router")).toBe(true);
     expect(reachable.has("child-end-device")).toBe(true);
   });
+    it("ranks NoneOfTheAbove above Child, and treats unrecognized relationships as better than PreviousChild", () => {
+    const router = device({
+      ieee: "router",
+      device_type: "Router",
+      nwk: 1,
+      neighbors: [
+        { ieee: "n-child", nwk: "0x0001", lqi: "100", depth: "1", relationship: "Child" },
+        { ieee: "n-none-of-the-above", nwk: "0x0002", lqi: "100", depth: "1", relationship: "NoneOfTheAbove" },
+      ],
+    });
+    const unknownRelationship = device({
+      ieee: "router-2",
+      device_type: "Router",
+      nwk: 2,
+      neighbors: [
+        { ieee: "n-unrecognized", nwk: "0x0003", lqi: "100", depth: "1", relationship: "SomeFutureValue" },
+        { ieee: "n-previous-child", nwk: "0x0004", lqi: "100", depth: "1", relationship: "PreviousChild" },
+      ],
+    });
+
+    const { links } = createZHANetworkChartData(
+      [router, unknownRelationship],
+      hass,
+      {} as any
+    );
+
+    const otherEndOf = (ieee: string) => {
+      const link = links.find((l) => l.source === ieee || l.target === ieee);
+      return link?.source === ieee ? link.target : link?.source;
+    };
+
+    expect(otherEndOf("router")).toBe("n-none-of-the-above");
+    expect(otherEndOf("router-2")).toBe("n-unrecognized");
+  });
 });

--- a/test/panels/config/integrations/integration-panels/zha/zha-network-data.test.ts
+++ b/test/panels/config/integrations/integration-panels/zha/zha-network-data.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { createZHANetworkChartData } from "../../../../../../../src/panels/config/integrations/integration-panels/zha/zha-network-data";
+import type { ZHADevice } from "../../../../../../../src/data/zha";
+import type { HomeAssistant } from "../../../../../../../src/types";
+
+const hass = {
+  devices: {},
+  areas: {},
+  localize: () => "",
+} as unknown as HomeAssistant;
+
+const device = (partial: Partial<ZHADevice>): ZHADevice =>
+  ({
+    available: true,
+    name: partial.ieee!,
+    lqi: 0,
+    rssi: "",
+    last_seen: "",
+    manufacturer: "",
+    model: "",
+    quirk_applied: false,
+    quirk_class: "",
+    entities: [],
+    manufacturer_code: 0,
+    device_reg_id: partial.ieee!,
+    active_coordinator: false,
+    signature: {},
+    routes: [],
+    neighbors: [],
+    ...partial,
+  }) as ZHADevice;
+
+describe("createZHANetworkChartData", () => {
+  it("links a router to its upstream router instead of a nearby child device when routing tables are empty", () => {
+    // Regression test: many Zigbee radios (e.g. TI CC2652 via zigpy-znp)
+    // never populate Mgmt_Rtg routes, so the chart has to fall back to
+    // picking a device's strongest RF neighbor. A router's own child end
+    // device (e.g. a plug sitting right next to it) commonly reports a
+    // stronger LQI than the router's real uplink, which must not be
+    // allowed to hide the backbone connection.
+    const coordinator = device({
+      ieee: "coordinator",
+      device_type: "Coordinator",
+      nwk: 0,
+    });
+    const upstreamRouter = device({
+      ieee: "upstream-router",
+      device_type: "Router",
+      nwk: 1,
+      neighbors: [
+        { ieee: "coordinator", nwk: "0x0000", lqi: "200", depth: "0", relationship: "Parent" },
+      ],
+    });
+    const downstreamRouter = device({
+      ieee: "downstream-router",
+      device_type: "Router",
+      nwk: 2,
+      neighbors: [
+        // Real backbone link: weaker signal, correctly flagged as a sibling router
+        { ieee: "upstream-router", nwk: "0x0001", lqi: "80", depth: "1", relationship: "Sibling" },
+        // Nearby child end device with a much stronger signal than the real uplink
+        { ieee: "child-end-device", nwk: "0x0003", lqi: "250", depth: "2", relationship: "Child" },
+      ],
+    });
+    const childEndDevice = device({
+      ieee: "child-end-device",
+      device_type: "EndDevice",
+      nwk: 3,
+      neighbors: [
+        { ieee: "downstream-router", nwk: "0x0002", lqi: "250", depth: "2", relationship: "Parent" },
+      ],
+    });
+
+    const { links } = createZHANetworkChartData(
+      [coordinator, upstreamRouter, downstreamRouter, childEndDevice],
+      hass,
+      document.createElement("div")
+    );
+
+    const hasLink = (a: string, b: string) =>
+      links.some(
+        (link) =>
+          (link.source === a && link.target === b) ||
+          (link.source === b && link.target === a)
+      );
+
+    expect(hasLink("downstream-router", "upstream-router")).toBe(true);
+    expect(hasLink("downstream-router", "child-end-device")).toBe(false);
+  });
+});

--- a/test/panels/config/integrations/integration-panels/zha/zha-network-data.test.ts
+++ b/test/panels/config/integrations/integration-panels/zha/zha-network-data.test.ts
@@ -133,14 +133,27 @@ describe("createZHANetworkChartData", () => {
     expect(reachable.has("downstream-router")).toBe(true);
     expect(reachable.has("child-end-device")).toBe(true);
   });
-    it("ranks NoneOfTheAbove above Child, and treats unrecognized relationships as better than PreviousChild", () => {
+
+  it("ranks NoneOfTheAbove above Child, and treats unrecognized relationships as better than PreviousChild", () => {
     const router = device({
       ieee: "router",
       device_type: "Router",
       nwk: 1,
       neighbors: [
-        { ieee: "n-child", nwk: "0x0001", lqi: "100", depth: "1", relationship: "Child" },
-        { ieee: "n-none-of-the-above", nwk: "0x0002", lqi: "100", depth: "1", relationship: "NoneOfTheAbove" },
+        {
+          ieee: "n-child",
+          nwk: "0x0001",
+          lqi: "100",
+          depth: "1",
+          relationship: "Child",
+        },
+        {
+          ieee: "n-none-of-the-above",
+          nwk: "0x0002",
+          lqi: "100",
+          depth: "1",
+          relationship: "NoneOfTheAbove",
+        },
       ],
     });
     const unknownRelationship = device({
@@ -148,15 +161,27 @@ describe("createZHANetworkChartData", () => {
       device_type: "Router",
       nwk: 2,
       neighbors: [
-        { ieee: "n-unrecognized", nwk: "0x0003", lqi: "100", depth: "1", relationship: "SomeFutureValue" },
-        { ieee: "n-previous-child", nwk: "0x0004", lqi: "100", depth: "1", relationship: "PreviousChild" },
+        {
+          ieee: "n-unrecognized",
+          nwk: "0x0003",
+          lqi: "100",
+          depth: "1",
+          relationship: "SomeFutureValue",
+        },
+        {
+          ieee: "n-previous-child",
+          nwk: "0x0004",
+          lqi: "100",
+          depth: "1",
+          relationship: "PreviousChild",
+        },
       ],
     });
 
     const { links } = createZHANetworkChartData(
       [router, unknownRelationship],
       hass,
-      {} as any
+      document.createElement("div")
     );
 
     const otherEndOf = (ieee: string) => {

--- a/test/panels/config/integrations/integration-panels/zha/zha-network-data.test.ts
+++ b/test/panels/config/integrations/integration-panels/zha/zha-network-data.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { createZHANetworkChartData } from "../../../../../../../src/panels/config/integrations/integration-panels/zha/zha-network-data";
-import type { ZHADevice } from "../../../../../../../src/data/zha";
-import type { HomeAssistant } from "../../../../../../../src/types";
+import { createZHANetworkChartData } from "../../../../../../src/panels/config/integrations/integration-panels/zha/zha-network-data";
+import type { ZHADevice } from "../../../../../../src/data/zha";
+import type { HomeAssistant } from "../../../../../../src/types";
 
 const hass = {
   devices: {},
@@ -48,7 +48,13 @@ describe("createZHANetworkChartData", () => {
       device_type: "Router",
       nwk: 1,
       neighbors: [
-        { ieee: "coordinator", nwk: "0x0000", lqi: "200", depth: "0", relationship: "Parent" },
+        {
+          ieee: "coordinator",
+          nwk: "0x0000",
+          lqi: "200",
+          depth: "0",
+          relationship: "Parent",
+        },
       ],
     });
     const downstreamRouter = device({
@@ -57,9 +63,21 @@ describe("createZHANetworkChartData", () => {
       nwk: 2,
       neighbors: [
         // Real backbone link: weaker signal, correctly flagged as a sibling router
-        { ieee: "upstream-router", nwk: "0x0001", lqi: "80", depth: "1", relationship: "Sibling" },
+        {
+          ieee: "upstream-router",
+          nwk: "0x0001",
+          lqi: "80",
+          depth: "1",
+          relationship: "Sibling",
+        },
         // Nearby child end device with a much stronger signal than the real uplink
-        { ieee: "child-end-device", nwk: "0x0003", lqi: "250", depth: "2", relationship: "Child" },
+        {
+          ieee: "child-end-device",
+          nwk: "0x0003",
+          lqi: "250",
+          depth: "2",
+          relationship: "Child",
+        },
       ],
     });
     const childEndDevice = device({
@@ -67,7 +85,13 @@ describe("createZHANetworkChartData", () => {
       device_type: "EndDevice",
       nwk: 3,
       neighbors: [
-        { ieee: "downstream-router", nwk: "0x0002", lqi: "250", depth: "2", relationship: "Parent" },
+        {
+          ieee: "downstream-router",
+          nwk: "0x0002",
+          lqi: "250",
+          depth: "2",
+          relationship: "Parent",
+        },
       ],
     });
 
@@ -77,14 +101,36 @@ describe("createZHANetworkChartData", () => {
       document.createElement("div")
     );
 
-    const hasLink = (a: string, b: string) =>
-      links.some(
-        (link) =>
-          (link.source === a && link.target === b) ||
-          (link.source === b && link.target === a)
-      );
+    const adjacency = new Map<string, string[]>();
+    for (const link of links) {
+      adjacency.set(link.source, [
+        ...(adjacency.get(link.source) ?? []),
+        link.target,
+      ]);
+      adjacency.set(link.target, [
+        ...(adjacency.get(link.target) ?? []),
+        link.source,
+      ]);
+    }
 
-    expect(hasLink("downstream-router", "upstream-router")).toBe(true);
-    expect(hasLink("downstream-router", "child-end-device")).toBe(false);
+    // Every device should be reachable from the coordinator. Before the
+    // fix, downstream-router picked its child as its only link, leaving
+    // it (and its children) as a disconnected island in the chart even
+    // though the real network is fully connected.
+    const reachable = new Set(["coordinator"]);
+    const queue = ["coordinator"];
+    while (queue.length) {
+      const current = queue.shift()!;
+      for (const neighbor of adjacency.get(current) ?? []) {
+        if (!reachable.has(neighbor)) {
+          reachable.add(neighbor);
+          queue.push(neighbor);
+        }
+      }
+    }
+
+    expect(reachable.has("upstream-router")).toBe(true);
+    expect(reachable.has("downstream-router")).toBe(true);
+    expect(reachable.has("child-end-device")).toBe(true);
   });
 });

--- a/test/panels/config/integrations/integration-panels/zha/zha-network-data.test.ts
+++ b/test/panels/config/integrations/integration-panels/zha/zha-network-data.test.ts
@@ -192,4 +192,104 @@ describe("createZHANetworkChartData", () => {
     expect(otherEndOf("router")).toBe("n-none-of-the-above");
     expect(otherEndOf("router-2")).toBe("n-unrecognized");
   });
+
+  it("connects every device regardless of backend device order (child listed before its parent router)", () => {
+    // Regression test for a subtler variant of the same bug: the fallback
+    // link is only computed for a device if it doesn't already have a
+    // link. If the backend lists a child end device before its parent
+    // router, the child claims the link first, and the router - now
+    // appearing to "already have a link" - never gets to evaluate its own
+    // (better) neighbor choice, splitting the graph exactly as before but
+    // triggered by device order instead of by LQI.
+    const coordinator = device({
+      ieee: "coordinator",
+      device_type: "Coordinator",
+      nwk: 0,
+    });
+    const upstreamRouter = device({
+      ieee: "upstream-router",
+      device_type: "Router",
+      nwk: 1,
+      neighbors: [
+        {
+          ieee: "coordinator",
+          nwk: "0x0000",
+          lqi: "200",
+          depth: "0",
+          relationship: "Parent",
+        },
+      ],
+    });
+    const downstreamRouter = device({
+      ieee: "downstream-router",
+      device_type: "Router",
+      nwk: 2,
+      neighbors: [
+        {
+          ieee: "upstream-router",
+          nwk: "0x0001",
+          lqi: "80",
+          depth: "1",
+          relationship: "Sibling",
+        },
+        {
+          ieee: "child-end-device",
+          nwk: "0x0003",
+          lqi: "250",
+          depth: "2",
+          relationship: "Child",
+        },
+      ],
+    });
+    const childEndDevice = device({
+      ieee: "child-end-device",
+      device_type: "EndDevice",
+      nwk: 3,
+      neighbors: [
+        {
+          ieee: "downstream-router",
+          nwk: "0x0002",
+          lqi: "250",
+          depth: "2",
+          relationship: "Parent",
+        },
+      ],
+    });
+
+    // Same topology as the first test, but the child is listed before its
+    // parent router this time.
+    const { links } = createZHANetworkChartData(
+      [coordinator, upstreamRouter, childEndDevice, downstreamRouter],
+      hass,
+      document.createElement("div")
+    );
+
+    const adjacency = new Map<string, string[]>();
+    for (const link of links) {
+      adjacency.set(link.source, [
+        ...(adjacency.get(link.source) ?? []),
+        link.target,
+      ]);
+      adjacency.set(link.target, [
+        ...(adjacency.get(link.target) ?? []),
+        link.source,
+      ]);
+    }
+
+    const reachable = new Set(["coordinator"]);
+    const queue = ["coordinator"];
+    while (queue.length) {
+      const current = queue.shift()!;
+      for (const neighbor of adjacency.get(current) ?? []) {
+        if (!reachable.has(neighbor)) {
+          reachable.add(neighbor);
+          queue.push(neighbor);
+        }
+      }
+    }
+
+    expect(reachable.has("upstream-router")).toBe(true);
+    expect(reachable.has("downstream-router")).toBe(true);
+    expect(reachable.has("child-end-device")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Proposed change

When a device's Zigbee routing table (`Mgmt_Rtg`) is empty — common with radios like the TI CC2652 via zigpy-znp — `createZHANetworkChartData` falls back to linking each device to its single strongest-LQI neighbor. This fallback ignored the neighbor's reported `relationship` (`Parent`/`Sibling`/`Child`), so a router's own nearby child end device (which usually reports a much stronger raw RF signal than the router's actual uplink) was frequently picked instead of the real backbone connection.

Visually, this splits the mesh into disconnected-looking islands in the ZHA network visualization even though the underlying network is fully connected — e.g. a router two hops from the coordinator renders with a link to its own children, but no link to the intermediate router that actually connects it to the rest of the mesh.

This PR sorts candidate neighbors by relationship priority (`Parent` > `Sibling` > `Child`) before comparing LQI, so a real upstream/sibling router is preferred over a child device. Verified against a live home network dump: 6 of 11 routers were picking a child device instead of their actual parent/sibling router before this change; after the change, several resolve to their exact ZDO-reported `Parent`.

Added a regression test (`test/panels/config/integrations/integration-panels/zha/zha-network-data.test.ts`) that builds a small coordinator → router → router → end-device topology with routing tables empty (as in the real-world trigger case) and asserts every device is reachable from the coordinator via BFS over the generated links.

## Screenshots

<img width="851" height="697" alt="Screenshot 2026-08-24 at 5 31 45 PM" src="https://github.com/user-attachments/assets/7b112b05-0a2c-4a9d-aa87-456a6a565ef4" />

<img width="831" height="598" alt="Screenshot 2026-08-24 at 6 46 18 PM" src="https://github.com/user-attachments/assets/c7fdfaea-853d-453e-bc2d-90ce166667eb" />


## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/zha-network-visualization-missing-links-lines/255388
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr