### PR TITLE
Fix timeCachePromiseFunc cache handling

### DIFF
--- a/src/common/util/time-cache-function-promise.ts
+++ b/src/common/util/time-cache-function-promise.ts
@@ -55,17 +55,20 @@ export const timeCachePromiseFunc = async <T, H = HomeAssistant>(
   }
 
   const resultPromise = func(hass, ...args);
-  anyHass[cacheKey] = resultPromise;
+  const cachePromise = resultPromise.then((result) => ({
+    result,
+    cacheKey: generateCacheKey?.(hass, result),
+  }));
+  anyHass[cacheKey] = cachePromise;
 
-  resultPromise.then(
+  cachePromise.then(
     // When successful, set timer to clear cache
     (result) => {
-      anyHass[cacheKey] = {
-        result,
-        cacheKey: generateCacheKey?.(hass, result),
-      };
+      anyHass[cacheKey] = result;
       setTimeout(() => {
-        anyHass[cacheKey] = undefined;
+        if (anyHass[cacheKey] === result) {
+          anyHass[cacheKey] = undefined;
+        }
       }, cacheTime);
     },
     // On failure, clear cache right away

--- a/test/common/util/time-cache-function-promise.test.ts
+++ b/test/common/util/time-cache-function-promise.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { timeCachePromiseFunc } from "../../../src/common/util/time-cache-function-promise";
+
+describe("timeCachePromiseFunc", () => {
+  it("reuses an in-flight request when the cache key is unchanged", async () => {
+    let resolveRequest!: (value: string) => void;
+
+    const request = new Promise<string>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const fetchData = vi.fn(() => request);
+    const hass = { version: 1 };
+
+    const calls = Array.from({ length: 20 }, () =>
+      timeCachePromiseFunc(
+        "_testCache",
+        30_000,
+        fetchData,
+        (currentHass: typeof hass) => currentHass.version,
+        hass
+      )
+    );
+
+    expect(fetchData).toHaveBeenCalledTimes(1);
+
+    resolveRequest("result");
+
+    await expect(Promise.all(calls)).resolves.toEqual(Array(20).fill("result"));
+
+    expect(fetchData).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses a resolved cached result while the cache key is unchanged", async () => {
+    const fetchData = vi.fn().mockResolvedValue("result");
+    const hass = { version: 1 };
+
+    const first = await timeCachePromiseFunc(
+      "_testCache",
+      30_000,
+      fetchData,
+      (currentHass: typeof hass) => currentHass.version,
+      hass
+    );
+
+    const second = await timeCachePromiseFunc(
+      "_testCache",
+      30_000,
+      fetchData,
+      (currentHass: typeof hass) => currentHass.version,
+      hass
+    );
+
+    expect(first).toBe("result");
+    expect(second).toBe("result");
+    expect(fetchData).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches a resolved cached result when the cache key changes", async () => {
+    const fetchData = vi
+      .fn()
+      .mockResolvedValueOnce("first")
+      .mockResolvedValueOnce("second");
+
+    const hass = { version: 1 };
+
+    const first = await timeCachePromiseFunc(
+      "_testCache",
+      30_000,
+      fetchData,
+      (currentHass: typeof hass) => currentHass.version,
+      hass
+    );
+
+    hass.version = 2;
+
+    const second = await timeCachePromiseFunc(
+      "_testCache",
+      30_000,
+      fetchData,
+      (currentHass: typeof hass) => currentHass.version,
+      hass
+    );
+
+    expect(first).toBe("first");
+    expect(second).toBe("second");
+    expect(fetchData).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses an in-flight request without a cache key validator", async () => {
+    let resolveRequest!: (value: string) => void;
+
+    const request = new Promise<string>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const fetchData = vi.fn(() => request);
+    const hass = {};
+
+    const first = timeCachePromiseFunc(
+      "_testCacheNoValidator",
+      30_000,
+      fetchData,
+      undefined,
+      hass
+    );
+
+    const second = timeCachePromiseFunc(
+      "_testCacheNoValidator",
+      30_000,
+      fetchData,
+      undefined,
+      hass
+    );
+
+    expect(fetchData).toHaveBeenCalledTimes(1);
+
+    resolveRequest("result");
+
+    await expect(first).resolves.toBe("result");
+    await expect(second).resolves.toBe("result");
+    expect(fetchData).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("timeCachePromiseFunc cache ownership", () => {
+  it("does not let an older cache timer clear a newer cached result", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchData = vi
+        .fn()
+        .mockResolvedValueOnce("first")
+        .mockResolvedValueOnce("second")
+        .mockResolvedValueOnce("third");
+
+      const hass = { version: 1 };
+
+      await timeCachePromiseFunc(
+        "_testTimerOwnership",
+        1000,
+        fetchData,
+        (currentHass: typeof hass) => currentHass.version,
+        hass
+      );
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      hass.version = 2;
+
+      await timeCachePromiseFunc(
+        "_testTimerOwnership",
+        1000,
+        fetchData,
+        (currentHass: typeof hass) => currentHass.version,
+        hass
+      );
+
+      expect(fetchData).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      const result = await timeCachePromiseFunc(
+        "_testTimerOwnership",
+        1000,
+        fetchData,
+        (currentHass: typeof hass) => currentHass.version,
+        hass
+      );
+
+      expect(result).toBe("second");
+      expect(fetchData).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The cache expects an in-flight entry to resolve to `CacheResult<T>`, but the function previously stored the raw `Promise<T>`. As a result, concurrent callers could pass the wrong value shape through cache validation and invalidate the cached request.

The pending cache now stores a promise that resolves to `CacheResult<T>`, while callers continue to receive the original `Promise<T>`.

Cache expiry now verifies that the cached result still belongs to that timer before clearing it, preventing an older timer from clearing a newer cached result.

Regression tests cover in-flight request reuse, resolved cache reuse and invalidation, operation without a cache key validator, and cache timer ownership.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr