### PR TITLE
Fix ha-control-select losing its value when activated by a screen reader

### DIFF
--- a/src/components/ha-control-select.ts
+++ b/src/components/ha-control-select.ts
@@ -101,7 +101,7 @@ export class HaControlSelect extends LitElement {
 
   private _handleOptionClick(ev: MouseEvent) {
     if (this.disabled) return;
-    const value = (ev.target as any).value;
+    const value = (ev.currentTarget as any).value;
     this.value = value;
     fireEvent(this, "value-changed", { value });
   }
@@ -109,7 +109,7 @@ export class HaControlSelect extends LitElement {
   private _handleOptionMouseDown(ev: MouseEvent) {
     if (this.disabled) return;
     ev.preventDefault();
-    const value = (ev.target as any).value;
+    const value = (ev.currentTarget as any).value;
     this._activeIndex = this.options?.findIndex(
       (option) => option.value === value
     );
@@ -121,7 +121,7 @@ export class HaControlSelect extends LitElement {
 
   private _handleOptionFocus(ev: FocusEvent) {
     if (this.disabled) return;
-    const value = (ev.target as any).value;
+    const value = (ev.currentTarget as any).value;
     this._activeIndex = this.options?.findIndex(
       (option) => option.value === value
     );


### PR DESCRIPTION
## Proposed change

`ha-control-select` reads the selected value from `ev.target`, which is whichever element the
click landed on. Real pointer events are retargeted to the outer `role="radio"` element by
`.option .content { pointer-events: none }`, but a screen reader's synthetic activation click is
not hit-tested, so it lands on the inner content element - which has no `value`.

The result is `value === undefined`: every option gets `aria-checked="false"`, nothing is
announced as selected, and consumers that guard on the value (for example
`HuiModeSelectCardFeatureBase._valueChanged`) silently do nothing. On iOS with VoiceOver the
climate HVAC mode buttons are simply not operable.

`ev.currentTarget` is always the element the listener is bound to, so it always carries the value.
The same change is applied to `_handleOptionMouseDown` and `_handleOptionFocus`.
`_handleFocus` is left untouched: its `ev.target === ev.currentTarget` comparison is intentional.

Verified on an iPhone with VoiceOver against Home Assistant 2026.8.3: two successful HVAC mode
changes with this change applied, zero without it, on the same page in the same session.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #53776
- This PR is related to issue or discussion: #16345, #26107, #53633, #27946
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
