### PR TITLE
Remove pulse from security dashboard alerts

### DIFF
--- a/src/panels/security/strategies/security-alerts.ts
+++ b/src/panels/security/strategies/security-alerts.ts
@@ -84,7 +84,6 @@ export const computeSecurityAlertCardConfig = (
     type: "alert",
     entity: alertEntity.entity,
     color: severity === "alert" ? "red" : "amber",
-    pulse: severity === "alert",
     visibility: computeDefaultSecurityAlertVisibility(alertEntity.entity),
   };
 };

--- a/test/panels/security/strategies/security-alerts.test.ts
+++ b/test/panels/security/strategies/security-alerts.test.ts
@@ -38,7 +38,6 @@ describe("computeSecurityAlertCardConfig", () => {
       type: "alert",
       entity: "binary_sensor.smoke",
       color: "red",
-      pulse: true,
       visibility: [
         {
           condition: "state",

--- a/test/panels/security/strategies/security-view-strategy.test.ts
+++ b/test/panels/security/strategies/security-view-strategy.test.ts
@@ -44,7 +44,6 @@ describe("security-view-strategy", () => {
         type: "alert",
         entity: "binary_sensor.window",
         color: "amber",
-        pulse: false,
         visibility: [
           {
             condition: "state",


### PR DESCRIPTION
## Proposed change

The security dashboard generated alert cards with `pulse` enabled for the alert severity. After discussing with product, a permanently pulsing card is too much for a built-in dashboard, so the strategy no longer sets `pulse` at all. Severity keeps driving the color: red for alerts, amber for warnings.

The option stays on the `alert` card itself, so manual dashboards can still enable pulsing.

## Screenshots

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: follow-up of #53031
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
