### PR TITLE
Share favorites editor and security entity filter

### DIFF
--- a/src/components/entity/ha-favorite-entity-list-item.ts
+++ b/src/components/entity/ha-favorite-entity-list-item.ts
@@ -3,28 +3,28 @@ import { mdiDelete } from "@mdi/js";
 import type { HassEntity } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { consumeEntityState } from "../../../common/decorators/consume-context-entry";
-import { computeEntityPickerDisplay } from "../../../common/entity/compute_entity_name_display";
-import { fireEvent } from "../../../common/dom/fire_event";
-import "../../../components/entity/state-badge";
-import "../../../components/ha-icon-button";
-import "../../../components/ha-settings-row";
+import { consumeEntityState } from "../../common/decorators/consume-context-entry";
+import { computeEntityPickerDisplay } from "../../common/entity/compute_entity_name_display";
+import { fireEvent } from "../../common/dom/fire_event";
+import "./state-badge";
+import "../ha-icon-button";
+import "../ha-settings-row";
 import {
   internationalizationContext,
   registriesContext,
-} from "../../../data/context";
+} from "../../data/context";
 
 declare global {
   interface HASSDomEvents {
     "delete-favorite-entity": { index: number };
   }
   interface HTMLElementTagNameMap {
-    "home-favorite-entity-list-item": HomeFavoriteEntityListItem;
+    "ha-favorite-entity-list-item": HaFavoriteEntityListItem;
   }
 }
 
-@customElement("home-favorite-entity-list-item")
-export class HomeFavoriteEntityListItem extends LitElement {
+@customElement("ha-favorite-entity-list-item")
+export class HaFavoriteEntityListItem extends LitElement {
   @property({ attribute: "entity-id" }) public entityId!: string;
 
   @property({ type: Number }) public index = 0;

--- a/src/components/entity/ha-favorites-editor.ts
+++ b/src/components/entity/ha-favorites-editor.ts
@@ -1,20 +1,18 @@
 import { mdiDragHorizontalVariant } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
-import { consumeLocalize } from "../../../common/decorators/consume-context-entry";
-import { fireEvent, type HASSDomEvent } from "../../../common/dom/fire_event";
-import type { LocalizeFunc } from "../../../common/translations/localize";
-import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker";
-import "../../../components/entity/ha-entity-picker";
-import "../../../components/ha-sortable";
-import "../../../components/ha-svg-icon";
-import type { HaEntityPickerEntityFilterFunc } from "../../../data/entity/entity";
-import type { ValueChangedEvent } from "../../../types";
-import "./home-favorite-entity-list-item";
+import { fireEvent, type HASSDomEvent } from "../../common/dom/fire_event";
+import type { HaEntityPicker } from "./ha-entity-picker";
+import "./ha-entity-picker";
+import "../ha-sortable";
+import "../ha-svg-icon";
+import type { HaEntityPickerEntityFilterFunc } from "../../data/entity/entity";
+import type { ValueChangedEvent } from "../../types";
+import "./ha-favorite-entity-list-item";
 
-@customElement("home-favorites-editor")
-export class HomeFavoritesEditor extends LitElement {
+@customElement("ha-favorites-editor")
+export class HaFavoritesEditor extends LitElement {
   @property({ attribute: false }) public favorites: string[] = [];
 
   @property() public label?: string;
@@ -26,10 +24,6 @@ export class HomeFavoritesEditor extends LitElement {
 
   @property({ attribute: "add-button-label" }) public addButtonLabel?: string;
 
-  @state()
-  @consumeLocalize()
-  private _localize!: LocalizeFunc;
-
   protected render() {
     return html`
       ${this.label ? html`<p class="field-label">${this.label}</p>` : nothing}
@@ -37,21 +31,21 @@ export class HomeFavoritesEditor extends LitElement {
         this.helper ? html`<p class="field-helper">${this.helper}</p>` : nothing
       }
       <ha-sortable handle-selector=".handle" @item-moved=${this._moved}>
-        <div class="home-list">
+        <div class="favorites-list">
           ${repeat(
             this.favorites,
             (entityId) => entityId,
             (entityId, index) => html`
-              <div class="home-list-item favorite-row">
+              <div class="favorite-row">
                 <div class="handle">
                   <ha-svg-icon .path=${mdiDragHorizontalVariant}></ha-svg-icon>
                 </div>
-                <home-favorite-entity-list-item
+                <ha-favorite-entity-list-item
                   class="favorite-content"
                   .entityId=${entityId}
                   .index=${index}
                   @delete-favorite-entity=${this._remove}
-                ></home-favorite-entity-list-item>
+                ></ha-favorite-entity-list-item>
               </div>
             `
           )}
@@ -59,12 +53,7 @@ export class HomeFavoritesEditor extends LitElement {
       </ha-sortable>
       <ha-entity-picker
         add-button
-        .addButtonLabel=${
-          this.addButtonLabel ??
-          this._localize(
-            "ui.panel.lovelace.editor.strategy.home.add_favorite_entity"
-          )
-        }
+        .addButtonLabel=${this.addButtonLabel}
         .excludeEntities=${this.favorites}
         .entityFilter=${this.entityFilter}
         @value-changed=${this._add}
@@ -115,7 +104,7 @@ export class HomeFavoritesEditor extends LitElement {
       color: var(--secondary-text-color);
       font-size: 12px;
     }
-    .home-list {
+    .favorites-list {
       display: flex;
       flex-direction: column;
     }
@@ -144,6 +133,6 @@ export class HomeFavoritesEditor extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "home-favorites-editor": HomeFavoritesEditor;
+    "ha-favorites-editor": HaFavoritesEditor;
   }
 }

--- a/src/panels/home/dialogs/dialog-edit-home.ts
+++ b/src/panels/home/dialogs/dialog-edit-home.ts
@@ -16,7 +16,7 @@ import type { HassDialog } from "../../../dialogs/make-dialog-manager";
 import { DirtyStateProviderMixin } from "../../../mixins/dirty-state-provider-mixin";
 import { haStyleDialog } from "../../../resources/styles";
 import type { HomeAssistant, ValueChangedEvent } from "../../../types";
-import "../components/home-favorites-editor";
+import "../../../components/entity/ha-favorites-editor";
 import "../components/home-shortcuts-editor";
 import type { EditHomeDialogParams } from "./show-dialog-edit-home";
 
@@ -123,13 +123,16 @@ export class DialogEditHome
               @value-changed=${this._welcomeChanged}
             ></ha-form>
 
-            <home-favorites-editor
+            <ha-favorites-editor
               .favorites=${this._state.favorite_entities}
               .label=${this.hass.localize(
                 "ui.panel.lovelace.editor.strategy.home.favorite_entities"
               )}
+              .addButtonLabel=${this.hass.localize(
+                "ui.panel.lovelace.editor.strategy.home.add_favorite_entity"
+              )}
               @value-changed=${this._favoriteEntitiesChanged}
-            ></home-favorites-editor>
+            ></ha-favorites-editor>
 
             <ha-form
               .hass=${this.hass}
@@ -308,7 +311,7 @@ export class DialogEditHome
         display: block;
       }
 
-      home-favorites-editor {
+      ha-favorites-editor {
         display: block;
         margin-top: var(--ha-space-2);
         margin-bottom: var(--ha-space-4);

--- a/src/panels/security/components/security-alerts-editor.ts
+++ b/src/panels/security/components/security-alerts-editor.ts
@@ -1,6 +1,5 @@
 import { consume, type ContextType } from "@lit/context";
 import { mdiDelete, mdiDragHorizontalVariant } from "@mdi/js";
-import type { HassEntity } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
@@ -29,11 +28,13 @@ import "../../../components/ha-settings-row";
 import "../../../components/ha-sortable";
 import "../../../components/ha-svg-icon";
 import { computeDefaultSecurityAlertSeverity } from "../strategies/security-alerts";
-import { isSecurityPanelEntity } from "../strategies/security-view-strategy";
+import {
+  createSecurityEntityFilter,
+  type SecurityEntityContext,
+} from "../security-entity-filter";
 import type { ValueChangedEvent } from "../../../types";
 
-type SecurityEditorContext = ContextType<typeof registriesContext> & {
-  states: ContextType<typeof statesContext>;
+type SecurityEditorContext = SecurityEntityContext & {
   language: ContextType<typeof internationalizationContext>["language"];
   translationMetadata: ContextType<
     typeof internationalizationContext
@@ -92,7 +93,7 @@ export class SecurityAlertsEditor extends LitElement {
           "ui.panel.security.editor.add_alert_entity"
         )}
         .excludeEntities=${this.alertEntities.map(({ entity }) => entity)}
-        .entityFilter=${this._alertEntityFilter}
+        .entityFilter=${this._entityFilter}
         @value-changed=${this._add}
       ></ha-entity-picker>
     `;
@@ -154,10 +155,7 @@ export class SecurityAlertsEditor extends LitElement {
     fireEvent(this, "value-changed", { value: next });
   }
 
-  private _alertEntityFilter = (entity: HassEntity) =>
-    this._entityContext
-      ? isSecurityPanelEntity(this._entityContext, entity)
-      : false;
+  private _entityFilter = createSecurityEntityFilter(() => this._entityContext);
 
   private _getIndex(
     ev: HASSDomCurrentTargetEvent<HTMLElement>

--- a/src/panels/security/dialogs/dialog-edit-security.ts
+++ b/src/panels/security/dialogs/dialog-edit-security.ts
@@ -1,5 +1,4 @@
 import { consume, type ContextType } from "@lit/context";
-import type { HassEntity } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, state } from "lit/decorators";
 import "../../../components/ha-button";
@@ -17,14 +16,13 @@ import { DialogMixin } from "../../../dialogs/dialog-mixin";
 import { DirtyStateProviderMixin } from "../../../mixins/dirty-state-provider-mixin";
 import { haStyleDialog } from "../../../resources/styles";
 import type { ValueChangedEvent } from "../../../types";
-import "../../home/components/home-favorites-editor";
+import "../../../components/entity/ha-favorites-editor";
 import "../components/security-alerts-editor";
-import { isSecurityPanelEntity } from "../strategies/security-view-strategy";
+import {
+  createSecurityEntityFilter,
+  type SecurityEntityContext,
+} from "../security-entity-filter";
 import type { EditSecurityDialogParams } from "./show-dialog-edit-security";
-
-type SecurityDialogContext = ContextType<typeof registriesContext> & {
-  states: ContextType<typeof statesContext>;
-};
 
 @customElement("dialog-edit-security")
 export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontendSystemData>()(
@@ -46,7 +44,7 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
   @consume({ context: registriesContext, subscribe: true })
   private _registries!: ContextType<typeof registriesContext>;
 
-  private _entityContext?: SecurityDialogContext;
+  private _entityContext?: SecurityEntityContext;
 
   protected willUpdate(changedProps: PropertyValues): void {
     super.willUpdate(changedProps);
@@ -128,14 +126,14 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
       >
         <ha-icon slot="leading-icon" icon="mdi:star-outline"></ha-icon>
         <div class="expansion-content">
-          <home-favorites-editor
+          <ha-favorites-editor
             .favorites=${this._state?.favorite_entities ?? []}
-            .entityFilter=${this._alertEntityFilter}
+            .entityFilter=${this._entityFilter}
             .addButtonLabel=${this._i18n.localize(
               "ui.panel.security.editor.add_favorite_entity"
             )}
             @value-changed=${this._favoriteEntitiesChanged}
-          ></home-favorites-editor>
+          ></ha-favorites-editor>
         </div>
       </ha-expansion-panel>
       <ha-expansion-panel
@@ -180,10 +178,7 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
     this._updateDirtyState(this._state);
   }
 
-  private _alertEntityFilter = (entity: HassEntity) =>
-    this._entityContext
-      ? isSecurityPanelEntity(this._entityContext, entity)
-      : false;
+  private _entityFilter = createSecurityEntityFilter(() => this._entityContext);
 
   private async _save(): Promise<void> {
     if (!this.params || !this._state) return;

--- a/src/panels/security/security-entity-filter.ts
+++ b/src/panels/security/security-entity-filter.ts
@@ -1,0 +1,15 @@
+import type { ContextType } from "@lit/context";
+import type { HassEntity } from "home-assistant-js-websocket";
+import type { registriesContext, statesContext } from "../../data/context";
+import { isSecurityPanelEntity } from "./strategies/security-view-strategy";
+
+export type SecurityEntityContext = ContextType<typeof registriesContext> & {
+  states: ContextType<typeof statesContext>;
+};
+
+export const createSecurityEntityFilter =
+  (getContext: () => SecurityEntityContext | undefined) =>
+  (entity: HassEntity): boolean => {
+    const context = getContext();
+    return context ? isSecurityPanelEntity(context, entity) : false;
+  };


### PR DESCRIPTION
## Proposed change

Follow-up cleanup of #53512, which reused the home favorites editor from the security dialog. That was the first panel to panel import in the repo, so the two components move to `src/components/entity/` and get the `ha-` prefix: `home-favorites-editor` becomes `ha-favorites-editor`, `home-favorite-entity-list-item` becomes `ha-favorite-entity-list-item`. Their API does not change. `addButtonLabel` no longer falls back to the home translation key, `dialog-edit-home` passes it like the security dialog already did.

The second half is the entity filter. `security-alerts-editor` and `dialog-edit-security` both carried the same context building plus filter code. The filter now lives in `security-entity-filter.ts` as `createSecurityEntityFilter`, with the shared `SecurityEntityContext` type. Both components keep their own context consumption, and `_alertEntityFilter` is renamed to `_entityFilter` since it filters security entities in both places, not alert entities.

No behavior change.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: follow-up of #53512
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
