### PR TITLE
Deduplicate in-flight requests

### DIFF
--- a/src/common/util/share-in-flight-request.ts
+++ b/src/common/util/share-in-flight-request.ts
@@ -1,6 +1,25 @@
-import deepFreeze from "deep-freeze";
-
 const inFlightRequests = new WeakMap<object, Map<string, Promise<unknown>>>();
+
+const deepFreeze = <T>(value: T): T => {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  Object.freeze(value);
+
+  for (const key of Object.getOwnPropertyNames(value)) {
+    const property = (value as Record<string, unknown>)[key];
+    if (
+      property !== null &&
+      typeof property === "object" &&
+      !Object.isFrozen(property)
+    ) {
+      deepFreeze(property);
+    }
+  }
+
+  return value;
+};
 
 export const shareInFlightRequest = <T>(
   owner: object,
@@ -20,7 +39,7 @@ export const shareInFlightRequest = <T>(
   }
 
   const request = fetcher()
-    .then((result) => deepFreeze(result) as T)
+    .then((result) => deepFreeze(result))
     .finally(() => {
       if (ownerRequests.get(key) !== request) {
         return;

--- a/src/common/util/share-in-flight-request.ts
+++ b/src/common/util/share-in-flight-request.ts
@@ -1,3 +1,5 @@
+import deepFreeze from "deep-freeze";
+
 const inFlightRequests = new WeakMap<object, Map<string, Promise<unknown>>>();
 
 export const shareInFlightRequest = <T>(
@@ -17,16 +19,18 @@ export const shareInFlightRequest = <T>(
     return existing as Promise<T>;
   }
 
-  const request = fetcher().finally(() => {
-    if (ownerRequests.get(key) !== request) {
-      return;
-    }
+  const request = fetcher()
+    .then((result) => deepFreeze(result) as T)
+    .finally(() => {
+      if (ownerRequests.get(key) !== request) {
+        return;
+      }
 
-    ownerRequests.delete(key);
-    if (ownerRequests.size === 0) {
-      inFlightRequests.delete(owner);
-    }
-  });
+      ownerRequests.delete(key);
+      if (ownerRequests.size === 0) {
+        inFlightRequests.delete(owner);
+      }
+    });
 
   ownerRequests.set(key, request);
   return request;

--- a/src/common/util/share-in-flight-request.ts
+++ b/src/common/util/share-in-flight-request.ts
@@ -1,0 +1,33 @@
+const inFlightRequests = new WeakMap<object, Map<string, Promise<unknown>>>();
+
+export const shareInFlightRequest = <T>(
+  owner: object,
+  key: string,
+  fetcher: () => Promise<T>
+): Promise<T> => {
+  let requests = inFlightRequests.get(owner);
+  if (!requests) {
+    requests = new Map();
+    inFlightRequests.set(owner, requests);
+  }
+
+  const ownerRequests = requests;
+  const existing = ownerRequests.get(key);
+  if (existing) {
+    return existing as Promise<T>;
+  }
+
+  const request = fetcher().finally(() => {
+    if (ownerRequests.get(key) !== request) {
+      return;
+    }
+
+    ownerRequests.delete(key);
+    if (ownerRequests.size === 0) {
+      inFlightRequests.delete(owner);
+    }
+  });
+
+  ownerRequests.set(key, request);
+  return request;
+};

--- a/src/common/util/share-in-flight-request.ts
+++ b/src/common/util/share-in-flight-request.ts
@@ -1,25 +1,6 @@
+import deepFreeze from "deep-freeze";
+
 const inFlightRequests = new WeakMap<object, Map<string, Promise<unknown>>>();
-
-const deepFreeze = <T>(value: T): T => {
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-
-  Object.freeze(value);
-
-  for (const key of Object.getOwnPropertyNames(value)) {
-    const property = (value as Record<string, unknown>)[key];
-    if (
-      property !== null &&
-      typeof property === "object" &&
-      !Object.isFrozen(property)
-    ) {
-      deepFreeze(property);
-    }
-  }
-
-  return value;
-};
 
 export const shareInFlightRequest = <T>(
   owner: object,
@@ -39,7 +20,7 @@ export const shareInFlightRequest = <T>(
   }
 
   const request = fetcher()
-    .then((result) => deepFreeze(result))
+    .then((result) => deepFreeze(result) as T)
     .finally(() => {
       if (ownerRequests.get(key) !== request) {
         return;

--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -98,7 +98,7 @@ export class HaStatisticPicker extends LitElement {
   public allowCustomEntity;
 
   @property({ attribute: false })
-  public statisticIds?: StatisticsMetaData[];
+  public statisticIds?: readonly Readonly<StatisticsMetaData>[];
 
   @property({ attribute: false }) public helpMissingEntityUrl =
     "/more-info/statistics/";
@@ -191,7 +191,7 @@ export class HaStatisticPicker extends LitElement {
   private _getStatisticsItems = memoizeOne(
     (
       hass: HomeAssistant,
-      statisticIds?: StatisticsMetaData[],
+      statisticIds?: readonly Readonly<StatisticsMetaData>[],
       includeStatisticsUnitOfMeasurement?: string | string[],
       includeUnitClass?: string | string[],
       includeDeviceClass?: string | string[],
@@ -329,7 +329,10 @@ export class HaStatisticPicker extends LitElement {
   );
 
   private _statisticMetaData = memoizeOne(
-    (statisticId: string, statisticIds: StatisticsMetaData[]) => {
+    (
+      statisticId: string,
+      statisticIds: readonly Readonly<StatisticsMetaData>[]
+    ) => {
       if (!statisticIds) {
         return undefined;
       }

--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -98,7 +98,7 @@ export class HaStatisticPicker extends LitElement {
   public allowCustomEntity;
 
   @property({ attribute: false })
-  public statisticIds?: readonly Readonly<StatisticsMetaData>[];
+  public statisticIds?: StatisticsMetaData[];
 
   @property({ attribute: false }) public helpMissingEntityUrl =
     "/more-info/statistics/";
@@ -191,7 +191,7 @@ export class HaStatisticPicker extends LitElement {
   private _getStatisticsItems = memoizeOne(
     (
       hass: HomeAssistant,
-      statisticIds?: readonly Readonly<StatisticsMetaData>[],
+      statisticIds?: StatisticsMetaData[],
       includeStatisticsUnitOfMeasurement?: string | string[],
       includeUnitClass?: string | string[],
       includeDeviceClass?: string | string[],
@@ -329,10 +329,7 @@ export class HaStatisticPicker extends LitElement {
   );
 
   private _statisticMetaData = memoizeOne(
-    (
-      statisticId: string,
-      statisticIds: readonly Readonly<StatisticsMetaData>[]
-    ) => {
+    (statisticId: string, statisticIds: StatisticsMetaData[]) => {
       if (!statisticIds) {
         return undefined;
       }

--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -16,10 +16,10 @@ import { computeStateName } from "../../common/entity/compute_state_name";
 import { computeRTL } from "../../common/util/compute_rtl";
 import { domainToName } from "../../data/integration";
 import {
-  getStatisticIds,
   getStatisticLabel,
   type StatisticsMetaData,
 } from "../../data/recorder";
+import { getStatisticIds } from "../../data/recorder_statistic_ids";
 import type { HomeAssistant, ValueChangedEvent } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
 import "../ha-combo-box-item";

--- a/src/components/target-picker/ha-target-picker-item-row.ts
+++ b/src/components/target-picker/ha-target-picker-item-row.ts
@@ -548,75 +548,73 @@ export class HaTargetPickerItemRow extends LitElement {
         this.primaryEntitiesOnly
       );
 
+      let referencedAreas = entries.referenced_areas;
       const hiddenAreaIds: string[] = [];
       if (this.type === "floor" || this.type === "label") {
-        entries.referenced_areas = entries.referenced_areas.filter(
-          (area_id) => {
-            const area = this.hass.areas[area_id];
-            // Absent from the registry is not a filter decision: drop the id
-            // without marking it hidden, so entities targeted through their
-            // own area or label are not dropped along with it.
-            if (!area) {
-              return false;
-            }
-            if (
-              (this.type === "floor" || area.labels.includes(this.itemId)) &&
-              areaMeetsFilter(
-                area,
-                this.hass.devices,
-                this.hass.entities,
-                this.deviceFilter,
-                this.includeDomains,
-                this.includeDeviceClasses,
-                this.hass.states,
-                this.entityFilter,
-                !this.primaryEntitiesOnly
-              )
-            ) {
-              return true;
-            }
-
-            hiddenAreaIds.push(area_id);
+        referencedAreas = referencedAreas.filter((area_id) => {
+          const area = this.hass.areas[area_id];
+          // Absent from the registry is not a filter decision: drop the id
+          // without marking it hidden, so entities targeted through their
+          // own area or label are not dropped along with it.
+          if (!area) {
             return false;
           }
-        );
+          if (
+            (this.type === "floor" || area.labels.includes(this.itemId)) &&
+            areaMeetsFilter(
+              area,
+              this.hass.devices,
+              this.hass.entities,
+              this.deviceFilter,
+              this.includeDomains,
+              this.includeDeviceClasses,
+              this.hass.states,
+              this.entityFilter,
+              !this.primaryEntitiesOnly
+            )
+          ) {
+            return true;
+          }
+
+          hiddenAreaIds.push(area_id);
+          return false;
+        });
       }
 
+      let referencedDevices = entries.referenced_devices;
       const hiddenDeviceIds: string[] = [];
       if (
         this.type === "floor" ||
         this.type === "area" ||
         this.type === "label"
       ) {
-        entries.referenced_devices = entries.referenced_devices.filter(
-          (device_id) => {
-            const device = this.hass.devices[device_id];
-            if (!device) {
-              return false;
-            }
-            if (
-              !hiddenAreaIds.includes(device.area_id || "") &&
-              deviceMeetsFilter(
-                device,
-                this.hass.entities,
-                this.deviceFilter,
-                this.includeDomains,
-                this.includeDeviceClasses,
-                this.hass.states,
-                this.entityFilter,
-                !this.primaryEntitiesOnly
-              )
-            ) {
-              return true;
-            }
-
-            hiddenDeviceIds.push(device_id);
+        referencedDevices = referencedDevices.filter((device_id) => {
+          const device = this.hass.devices[device_id];
+          if (!device) {
             return false;
           }
-        );
+          if (
+            !hiddenAreaIds.includes(device.area_id || "") &&
+            deviceMeetsFilter(
+              device,
+              this.hass.entities,
+              this.deviceFilter,
+              this.includeDomains,
+              this.includeDeviceClasses,
+              this.hass.states,
+              this.entityFilter,
+              !this.primaryEntitiesOnly
+            )
+          ) {
+            return true;
+          }
+
+          hiddenDeviceIds.push(device_id);
+          return false;
+        });
       }
 
-      entries.referenced_entities = entries.referenced_entities.filter(
+      const referencedEntities = entries.referenced_entities.filter(
         (entity_id) => {
           const entity = this.hass.entities[entity_id];
           // Core can reference entities that are absent from the display
@@ -631,9 +629,9 @@ export class HaTargetPickerItemRow extends LitElement {
             (this.type === "area" && entity.area_id === this.itemId) ||
             (this.type === "floor" &&
               entity.area_id &&
-              entries.referenced_areas.includes(entity.area_id)) ||
+              referencedAreas.includes(entity.area_id)) ||
             (this.type === "label" && entity.labels.includes(this.itemId)) ||
-            entries.referenced_devices.includes(entity.device_id || "")
+            referencedDevices.includes(entity.device_id || "")
           ) {
             return entityRegMeetsFilter(
               entity,
@@ -648,7 +646,12 @@ export class HaTargetPickerItemRow extends LitElement {
         }
       );
 
-      this._entries = entries;
+      this._entries = {
+        ...entries,
+        referenced_areas: referencedAreas,
+        referenced_devices: referencedDevices,
+        referenced_entities: referencedEntities,
+      };
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error("Failed to extract target", e);

--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -168,7 +168,7 @@ type StatisticIdsApi = Pick<HomeAssistant, "callWS">;
 export const getStatisticIds = (
   hass: StatisticIdsApi,
   statistic_type?: StatisticIdsType
-): Promise<StatisticsMetaData[]> =>
+): Promise<readonly Readonly<StatisticsMetaData>[]> =>
   shareInFlightRequest(
     hass.callWS,
     `recorder/list_statistic_ids:${statistic_type ?? "all"}`,

--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -3,6 +3,7 @@ import { computeStateName } from "../common/entity/compute_state_name";
 import type { HaDurationData } from "../components/ha-duration-input";
 import type { HomeAssistant } from "../types";
 import { firstWeekday } from "../common/datetime/first_weekday";
+import { shareInFlightRequest } from "../common/util/share-in-flight-request";
 
 export interface RecorderInfo {
   backlog: number | null;
@@ -160,14 +161,24 @@ export const getRecorderEntityOptions = (
     entity_id,
   });
 
+type StatisticIdsType = "mean" | "sum";
+
+type StatisticIdsApi = Pick<HomeAssistant, "callWS"> &
+  Partial<Pick<HomeAssistant, "connection">>;
+
 export const getStatisticIds = (
-  hass: Pick<HomeAssistant, "callWS">,
-  statistic_type?: "mean" | "sum"
-) =>
-  hass.callWS<StatisticsMetaData[]>({
-    type: "recorder/list_statistic_ids",
-    statistic_type,
-  });
+  hass: StatisticIdsApi,
+  statistic_type?: StatisticIdsType
+): Promise<StatisticsMetaData[]> =>
+  shareInFlightRequest(
+    hass.connection ?? hass,
+    `recorder/list_statistic_ids:${statistic_type ?? "all"}`,
+    () =>
+      hass.callWS<StatisticsMetaData[]>({
+        type: "recorder/list_statistic_ids",
+        statistic_type,
+      })
+  );
 
 export const getStatisticMetadata = (
   hass: HomeAssistant,

--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -3,7 +3,6 @@ import { computeStateName } from "../common/entity/compute_state_name";
 import type { HaDurationData } from "../components/ha-duration-input";
 import type { HomeAssistant } from "../types";
 import { firstWeekday } from "../common/datetime/first_weekday";
-import { shareInFlightRequest } from "../common/util/share-in-flight-request";
 
 export interface RecorderInfo {
   backlog: number | null;
@@ -160,24 +159,6 @@ export const getRecorderEntityOptions = (
     type: "recorder/entity_options/get",
     entity_id,
   });
-
-type StatisticIdsType = "mean" | "sum";
-
-type StatisticIdsApi = Pick<HomeAssistant, "callWS">;
-
-export const getStatisticIds = (
-  hass: StatisticIdsApi,
-  statistic_type?: StatisticIdsType
-) =>
-  shareInFlightRequest(
-    hass.callWS,
-    `recorder/list_statistic_ids:${statistic_type ?? "all"}`,
-    () =>
-      hass.callWS<StatisticsMetaData[]>({
-        type: "recorder/list_statistic_ids",
-        statistic_type,
-      })
-  );
 
 export const getStatisticMetadata = (
   hass: HomeAssistant,

--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -163,15 +163,14 @@ export const getRecorderEntityOptions = (
 
 type StatisticIdsType = "mean" | "sum";
 
-type StatisticIdsApi = Pick<HomeAssistant, "callWS"> &
-  Partial<Pick<HomeAssistant, "connection">>;
+type StatisticIdsApi = Pick<HomeAssistant, "callWS">;
 
 export const getStatisticIds = (
   hass: StatisticIdsApi,
   statistic_type?: StatisticIdsType
 ): Promise<StatisticsMetaData[]> =>
   shareInFlightRequest(
-    hass.connection ?? hass,
+    hass.callWS,
     `recorder/list_statistic_ids:${statistic_type ?? "all"}`,
     () =>
       hass.callWS<StatisticsMetaData[]>({

--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -168,7 +168,7 @@ type StatisticIdsApi = Pick<HomeAssistant, "callWS">;
 export const getStatisticIds = (
   hass: StatisticIdsApi,
   statistic_type?: StatisticIdsType
-): Promise<readonly Readonly<StatisticsMetaData>[]> =>
+) =>
   shareInFlightRequest(
     hass.callWS,
     `recorder/list_statistic_ids:${statistic_type ?? "all"}`,

--- a/src/data/recorder_statistic_ids.ts
+++ b/src/data/recorder_statistic_ids.ts
@@ -1,0 +1,21 @@
+import { shareInFlightRequest } from "../common/util/share-in-flight-request";
+import type { HomeAssistant } from "../types";
+import type { StatisticsMetaData } from "./recorder";
+
+type StatisticIdsType = "mean" | "sum";
+
+type StatisticIdsApi = Pick<HomeAssistant, "callWS">;
+
+export const getStatisticIds = (
+  hass: StatisticIdsApi,
+  statistic_type?: StatisticIdsType
+) =>
+  shareInFlightRequest(
+    hass.callWS,
+    `recorder/list_statistic_ids:${statistic_type ?? "all"}`,
+    () =>
+      hass.callWS<StatisticsMetaData[]>({
+        type: "recorder/list_statistic_ids",
+        statistic_type,
+      })
+  );

--- a/src/data/target.ts
+++ b/src/data/target.ts
@@ -35,19 +35,19 @@ export interface SingleHassServiceTarget {
 }
 
 export interface ExtractFromTargetResult {
-  missing_areas: string[];
-  missing_devices: string[];
-  missing_floors: string[];
-  missing_labels: string[];
-  referenced_areas: string[];
-  referenced_devices: string[];
-  referenced_entities: string[];
+  readonly missing_areas: readonly string[];
+  readonly missing_devices: readonly string[];
+  readonly missing_floors: readonly string[];
+  readonly missing_labels: readonly string[];
+  readonly referenced_areas: readonly string[];
+  readonly referenced_devices: readonly string[];
+  readonly referenced_entities: readonly string[];
 }
 
 export interface ExtractFromTargetResultReferenced {
-  referenced_areas: string[];
-  referenced_devices: string[];
-  referenced_entities: string[];
+  readonly referenced_areas: readonly string[];
+  readonly referenced_devices: readonly string[];
+  readonly referenced_entities: readonly string[];
 }
 
 export const extractFromTarget = async (

--- a/src/data/target.ts
+++ b/src/data/target.ts
@@ -14,6 +14,7 @@ import {
 import type { HaEntityPickerEntityFilterFunc } from "./entity/entity";
 import type { EntityComboBoxItem } from "./entity/entity_picker";
 import type { EntityRegistryDisplayEntry } from "./entity/entity_registry";
+import { shareInFlightRequest } from "../common/util/share-in-flight-request";
 
 export const TARGET_SEPARATOR = "________";
 
@@ -54,13 +55,18 @@ export const extractFromTarget = async (
   target: HassServiceTarget,
   expandGroup = false,
   primaryEntitiesOnly = true
-) =>
-  callWS<ExtractFromTargetResult>({
-    type: "extract_from_target",
+) => {
+  const request = {
+    type: "extract_from_target" as const,
     target,
     expand_group: expandGroup,
     primary_entities_only: primaryEntitiesOnly,
-  });
+  };
+
+  return shareInFlightRequest(callWS, JSON.stringify(request), () =>
+    callWS<ExtractFromTargetResult>(request)
+  );
+};
 
 export const getTargetEntityCount = (target?: HassServiceTarget): number => {
   const tempTarget = {

--- a/src/data/target.ts
+++ b/src/data/target.ts
@@ -35,19 +35,19 @@ export interface SingleHassServiceTarget {
 }
 
 export interface ExtractFromTargetResult {
-  readonly missing_areas: readonly string[];
-  readonly missing_devices: readonly string[];
-  readonly missing_floors: readonly string[];
-  readonly missing_labels: readonly string[];
-  readonly referenced_areas: readonly string[];
-  readonly referenced_devices: readonly string[];
-  readonly referenced_entities: readonly string[];
+  missing_areas: string[];
+  missing_devices: string[];
+  missing_floors: string[];
+  missing_labels: string[];
+  referenced_areas: string[];
+  referenced_devices: string[];
+  referenced_entities: string[];
 }
 
 export interface ExtractFromTargetResultReferenced {
-  readonly referenced_areas: readonly string[];
-  readonly referenced_devices: readonly string[];
-  readonly referenced_entities: readonly string[];
+  referenced_areas: string[];
+  referenced_devices: string[];
+  referenced_entities: string[];
 }
 
 export const extractFromTarget = async (

--- a/src/panels/config/automation/target/ha-automation-row-targets.ts
+++ b/src/panels/config/automation/target/ha-automation-row-targets.ts
@@ -167,9 +167,7 @@ export class HaAutomationRowTargets extends LitElement {
     this._rerenderCount = false;
   }
 
-  private _countMatchingEntities(
-    referencedEntities: readonly string[]
-  ): number {
+  private _countMatchingEntities(referencedEntities: string[]): number {
     const targetSelector = this.selector;
     const hasEntityFilter = !!targetSelector?.target?.entity;
     const hasDeviceFilter = !!targetSelector?.target?.device;

--- a/src/panels/config/automation/target/ha-automation-row-targets.ts
+++ b/src/panels/config/automation/target/ha-automation-row-targets.ts
@@ -167,7 +167,9 @@ export class HaAutomationRowTargets extends LitElement {
     this._rerenderCount = false;
   }
 
-  private _countMatchingEntities(referencedEntities: string[]): number {
+  private _countMatchingEntities(
+    referencedEntities: readonly string[]
+  ): number {
     const targetSelector = this.selector;
     const hasEntityFilter = !!targetSelector?.target?.entity;
     const hasDeviceFilter = !!targetSelector?.target?.device;

--- a/src/panels/config/tools/statistics/tools-statistics.ts
+++ b/src/panels/config/tools/statistics/tools-statistics.ts
@@ -52,11 +52,11 @@ import type {
 } from "../../../../data/recorder";
 import {
   clearStatistics,
-  getStatisticIds,
   StatisticMeanType,
   updateStatisticsIssues,
   validateStatistics,
 } from "../../../../data/recorder";
+import { getStatisticIds } from "../../../../data/recorder_statistic_ids";
 import {
   apiContext,
   internationalizationContext,

--- a/test/common/util/share-in-flight-request.test.ts
+++ b/test/common/util/share-in-flight-request.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { shareInFlightRequest } from "../../../src/common/util/share-in-flight-request";
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+};
+
+describe("shareInFlightRequest", () => {
+  it("shares an in-flight request for the same owner and key", async () => {
+    const owner = {};
+    const request = deferred<number>();
+    const fetcher = vi.fn(() => request.promise);
+
+    const first = shareInFlightRequest(owner, "resource:a", fetcher);
+    const second = shareInFlightRequest(owner, "resource:a", fetcher);
+
+    expect(first).toBe(second);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    request.resolve(42);
+
+    await expect(first).resolves.toBe(42);
+    await expect(second).resolves.toBe(42);
+  });
+
+  it("does not share requests with different keys", async () => {
+    const owner = {};
+    const fetcherA = vi.fn(async () => "a");
+    const fetcherB = vi.fn(async () => "b");
+
+    await Promise.all([
+      shareInFlightRequest(owner, "resource:a", fetcherA),
+      shareInFlightRequest(owner, "resource:b", fetcherB),
+    ]);
+
+    expect(fetcherA).toHaveBeenCalledTimes(1);
+    expect(fetcherB).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not share requests between different owners", async () => {
+    const firstOwner = {};
+    const secondOwner = {};
+    const firstFetcher = vi.fn(async () => "first");
+    const secondFetcher = vi.fn(async () => "second");
+
+    await Promise.all([
+      shareInFlightRequest(firstOwner, "resource:a", firstFetcher),
+      shareInFlightRequest(secondOwner, "resource:a", secondFetcher),
+    ]);
+
+    expect(firstFetcher).toHaveBeenCalledTimes(1);
+    expect(secondFetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("forgets a request after it resolves", async () => {
+    const owner = {};
+    const fetcher = vi.fn(async () => 42);
+
+    await shareInFlightRequest(owner, "resource:a", fetcher);
+    await shareInFlightRequest(owner, "resource:a", fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("forgets a request after it rejects", async () => {
+    const owner = {};
+    const fetcher = vi
+      .fn<() => Promise<number>>()
+      .mockRejectedValueOnce(new Error("failed"))
+      .mockResolvedValueOnce(42);
+
+    await expect(
+      shareInFlightRequest(owner, "resource:a", fetcher)
+    ).rejects.toThrow("failed");
+
+    await expect(
+      shareInFlightRequest(owner, "resource:a", fetcher)
+    ).resolves.toBe(42);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/common/util/share-in-flight-request.test.ts
+++ b/test/common/util/share-in-flight-request.test.ts
@@ -88,4 +88,19 @@ describe("shareInFlightRequest", () => {
 
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
+
+  it("deep-freezes resolved results", async () => {
+    const owner = {};
+    const result = { items: ["a"] };
+    const fetcher = vi.fn(async () => result);
+
+    const shared = await shareInFlightRequest(owner, "resource:a", fetcher);
+
+    expect(shared).toBe(result);
+    expect(Object.isFrozen(shared)).toBe(true);
+    expect(Object.isFrozen((shared as typeof result).items)).toBe(true);
+    expect(() => {
+      (shared as typeof result).items.push("b");
+    }).toThrow();
+  });
 });

--- a/test/components/target-picker/ha-target-picker-item-row.test.ts
+++ b/test/components/target-picker/ha-target-picker-item-row.test.ts
@@ -173,4 +173,31 @@ describe("ha-target-picker-item-row target extraction", () => {
     expect(entries!.referenced_devices).toEqual(["dev_1"]);
     expect(entries!.referenced_entities).toEqual(["light.on_dev1"]);
   });
+
+  it("does not mutate the extracted target result", async () => {
+    const result = extractResult({
+      referenced_areas: ["area_missing"],
+      referenced_devices: ["dev_missing"],
+      referenced_entities: ["light.missing"],
+    });
+
+    const entries = await extractedBy(
+      result,
+      {
+        areas: {},
+        devices: {},
+        entities: {},
+      },
+      { type: "floor", itemId: "floor_1" }
+    );
+
+    expect(entries).toBeDefined();
+    expect(entries).not.toBe(result);
+    expect(entries!.referenced_areas).toEqual([]);
+    expect(entries!.referenced_devices).toEqual([]);
+    expect(entries!.referenced_entities).toEqual([]);
+    expect(result.referenced_areas).toEqual(["area_missing"]);
+    expect(result.referenced_devices).toEqual(["dev_missing"]);
+    expect(result.referenced_entities).toEqual(["light.missing"]);
+  });
 });

--- a/test/data/recorder-statistic-ids.test.ts
+++ b/test/data/recorder-statistic-ids.test.ts
@@ -5,11 +5,10 @@ import {
   type StatisticsMetaData,
 } from "../../src/data/recorder";
 
-const createHass = (callWS = vi.fn(), connection = {}) =>
+const createHass = (callWS = vi.fn()) =>
   ({
-    connection,
     callWS,
-  }) as unknown as Pick<HomeAssistant, "connection" | "callWS">;
+  }) as unknown as Pick<HomeAssistant, "callWS">;
 
 const deferred = <T>() => {
   let resolve!: (value: T) => void;
@@ -39,7 +38,7 @@ describe("getStatisticIds", () => {
     await Promise.all([first, second]);
   });
 
-  it("shares concurrent requests when the caller has no connection", async () => {
+  it("works with callers that only expose callWS", async () => {
     const request = deferred<StatisticsMetaData[]>();
     const callWS = vi.fn().mockReturnValue(request.promise);
     const api = { callWS } as Pick<HomeAssistant, "callWS">;
@@ -54,12 +53,11 @@ describe("getStatisticIds", () => {
     await Promise.all([first, second]);
   });
 
-  it("shares requests across hass objects with the same connection", async () => {
+  it("shares requests across callers with the same callWS", async () => {
     const request = deferred<StatisticsMetaData[]>();
     const callWS = vi.fn().mockReturnValue(request.promise);
-    const connection = {};
-    const firstHass = createHass(callWS, connection);
-    const secondHass = createHass(callWS, connection);
+    const firstHass = createHass(callWS);
+    const secondHass = createHass(callWS);
 
     const first = getStatisticIds(firstHass);
     const second = getStatisticIds(secondHass);
@@ -96,21 +94,19 @@ describe("getStatisticIds", () => {
     });
   });
 
-  it("does not share requests across connections", async () => {
+  it("does not share requests across different callWS owners", async () => {
     const firstRequest = deferred<StatisticsMetaData[]>();
     const secondRequest = deferred<StatisticsMetaData[]>();
-    const callWS = vi
-      .fn()
-      .mockReturnValueOnce(firstRequest.promise)
-      .mockReturnValueOnce(secondRequest.promise);
 
-    const firstHass = createHass(callWS);
-    const secondHass = createHass(callWS);
+    const firstCallWS = vi.fn().mockReturnValue(firstRequest.promise);
+    const secondCallWS = vi.fn().mockReturnValue(secondRequest.promise);
 
-    const first = getStatisticIds(firstHass);
-    const second = getStatisticIds(secondHass);
+    const first = getStatisticIds(createHass(firstCallWS));
+    const second = getStatisticIds(createHass(secondCallWS));
 
-    expect(callWS).toHaveBeenCalledTimes(2);
+    expect(firstCallWS).toHaveBeenCalledTimes(1);
+    expect(secondCallWS).toHaveBeenCalledTimes(1);
+    expect(second).not.toBe(first);
 
     firstRequest.resolve([]);
     secondRequest.resolve([]);

--- a/test/data/recorder-statistic-ids.test.ts
+++ b/test/data/recorder-statistic-ids.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import type { HomeAssistant } from "../../src/types";
+import {
+  getStatisticIds,
+  type StatisticsMetaData,
+} from "../../src/data/recorder";
+
+const createHass = (callWS = vi.fn(), connection = {}) =>
+  ({
+    connection,
+    callWS,
+  }) as unknown as Pick<HomeAssistant, "connection" | "callWS">;
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+};
+
+describe("getStatisticIds", () => {
+  it("shares concurrent requests for the same statistic type", async () => {
+    const request = deferred<StatisticsMetaData[]>();
+    const callWS = vi.fn().mockReturnValue(request.promise);
+    const hass = createHass(callWS);
+
+    const first = getStatisticIds(hass);
+    const second = getStatisticIds(hass);
+
+    expect(callWS).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+
+    request.resolve([]);
+    await Promise.all([first, second]);
+  });
+
+  it("shares concurrent requests when the caller has no connection", async () => {
+    const request = deferred<StatisticsMetaData[]>();
+    const callWS = vi.fn().mockReturnValue(request.promise);
+    const api = { callWS } as Pick<HomeAssistant, "callWS">;
+
+    const first = getStatisticIds(api);
+    const second = getStatisticIds(api);
+
+    expect(callWS).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+
+    request.resolve([]);
+    await Promise.all([first, second]);
+  });
+
+  it("shares requests across hass objects with the same connection", async () => {
+    const request = deferred<StatisticsMetaData[]>();
+    const callWS = vi.fn().mockReturnValue(request.promise);
+    const connection = {};
+    const firstHass = createHass(callWS, connection);
+    const secondHass = createHass(callWS, connection);
+
+    const first = getStatisticIds(firstHass);
+    const second = getStatisticIds(secondHass);
+
+    expect(callWS).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+
+    request.resolve([]);
+    await Promise.all([first, second]);
+  });
+
+  it("does not share requests for different statistic types", async () => {
+    const callWS = vi.fn().mockResolvedValue([]);
+    const hass = createHass(callWS);
+
+    await Promise.all([
+      getStatisticIds(hass),
+      getStatisticIds(hass, "mean"),
+      getStatisticIds(hass, "sum"),
+    ]);
+
+    expect(callWS).toHaveBeenCalledTimes(3);
+    expect(callWS).toHaveBeenNthCalledWith(1, {
+      type: "recorder/list_statistic_ids",
+      statistic_type: undefined,
+    });
+    expect(callWS).toHaveBeenNthCalledWith(2, {
+      type: "recorder/list_statistic_ids",
+      statistic_type: "mean",
+    });
+    expect(callWS).toHaveBeenNthCalledWith(3, {
+      type: "recorder/list_statistic_ids",
+      statistic_type: "sum",
+    });
+  });
+
+  it("does not share requests across connections", async () => {
+    const firstRequest = deferred<StatisticsMetaData[]>();
+    const secondRequest = deferred<StatisticsMetaData[]>();
+    const callWS = vi
+      .fn()
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise);
+
+    const firstHass = createHass(callWS);
+    const secondHass = createHass(callWS);
+
+    const first = getStatisticIds(firstHass);
+    const second = getStatisticIds(secondHass);
+
+    expect(callWS).toHaveBeenCalledTimes(2);
+
+    firstRequest.resolve([]);
+    secondRequest.resolve([]);
+    await Promise.all([first, second]);
+  });
+
+  it("fetches again after the previous request settles", async () => {
+    const callWS = vi.fn().mockResolvedValue([]);
+    const hass = createHass(callWS);
+
+    await getStatisticIds(hass, "sum");
+    await getStatisticIds(hass, "sum");
+
+    expect(callWS).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries after a failed request", async () => {
+    const callWS = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("failed"))
+      .mockResolvedValueOnce([]);
+    const hass = createHass(callWS);
+
+    await expect(getStatisticIds(hass)).rejects.toThrow("failed");
+    await getStatisticIds(hass);
+
+    expect(callWS).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/data/recorder-statistic-ids.test.ts
+++ b/test/data/recorder-statistic-ids.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { HomeAssistant } from "../../src/types";
-import {
-  getStatisticIds,
-  type StatisticsMetaData,
-} from "../../src/data/recorder";
+import { getStatisticIds } from "../../src/data/recorder_statistic_ids";
+import type { StatisticsMetaData } from "../../src/data/recorder";
 
 const createHass = (callWS = vi.fn()) =>
   ({

--- a/test/data/target-in-flight.test.ts
+++ b/test/data/target-in-flight.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { extractFromTarget } from "../../src/data/target";
+
+type CallWS = Parameters<typeof extractFromTarget>[0];
+
+const callWS = () => vi.fn().mockResolvedValue({}) as unknown as CallWS;
+
+describe("extractFromTarget in-flight sharing", () => {
+  it("shares identical concurrent requests", async () => {
+    const ws = callWS();
+    const target = { area_id: ["bathroom"] };
+
+    await Promise.all([
+      extractFromTarget(ws, target),
+      extractFromTarget(ws, target),
+    ]);
+
+    expect(ws).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not share different targets", async () => {
+    const ws = callWS();
+
+    await Promise.all([
+      extractFromTarget(ws, { area_id: ["bathroom"] }),
+      extractFromTarget(ws, { area_id: ["kitchen"] }),
+    ]);
+
+    expect(ws).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not share different expandGroup values", async () => {
+    const ws = callWS();
+    const target = { area_id: ["bathroom"] };
+
+    await Promise.all([
+      extractFromTarget(ws, target, false),
+      extractFromTarget(ws, target, true),
+    ]);
+
+    expect(ws).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not share different primaryEntitiesOnly values", async () => {
+    const ws = callWS();
+    const target = { area_id: ["bathroom"] };
+
+    await Promise.all([
+      extractFromTarget(ws, target, false, true),
+      extractFromTarget(ws, target, false, false),
+    ]);
+
+    expect(ws).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not share between different callWS owners", async () => {
+    const first = callWS();
+    const second = callWS();
+    const target = { area_id: ["bathroom"] };
+
+    await Promise.all([
+      extractFromTarget(first, target),
+      extractFromTarget(second, target),
+    ]);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches again after the request settles", async () => {
+    const ws = callWS();
+    const target = { area_id: ["bathroom"] };
+
+    await extractFromTarget(ws, target);
+    await extractFromTarget(ws, target);
+
+    expect(ws).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Identical one-shot WebSocket requests can be started concurrently by multiple frontend consumers, causing the same backend lookup to run more than once while an equivalent request is already pending.

Concurrent requests are now shared by request owner and request key for `recorder/list_statistic_ids` and `extract_from_target`. The shared entry is removed when the request resolves or rejects, so settled results are not cached and later calls still perform a new request.

Regression tests cover request sharing, owner and key isolation, cleanup after success and failure, statistic type isolation, and target option differences.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr