### PR TITLE
Add show_labels option to the alarm modes card feature

### DIFF
--- a/gallery/src/pages/lovelace/tile-card.ts
+++ b/gallery/src/pages/lovelace/tile-card.ts
@@ -12,6 +12,7 @@ import "../../components/demo-cards";
 import { mockIcons } from "../../../../demo/src/stubs/icons";
 import { ClimateEntityFeature } from "../../../../src/data/climate";
 import { FanEntityFeature } from "../../../../src/data/fan";
+import { AlarmControlPanelEntityFeature } from "../../../../src/data/alarm_control_panel";
 import type { TileCardConfig } from "../../../../src/panels/lovelace/cards/types";
 
 const ENTITIES = [
@@ -161,6 +162,20 @@ const ENTITIES = [
         FanEntityFeature.DIRECTION +
         FanEntityFeature.SET_SPEED +
         FanEntityFeature.OSCILLATE,
+    },
+  },
+  {
+    entity_id: "alarm_control_panel.home",
+    state: "disarmed",
+    attributes: {
+      friendly_name: "Home Alarm",
+      code_format: null,
+      supported_features:
+        AlarmControlPanelEntityFeature.ARM_HOME +
+        AlarmControlPanelEntityFeature.ARM_AWAY +
+        AlarmControlPanelEntityFeature.ARM_NIGHT +
+        AlarmControlPanelEntityFeature.ARM_VACATION +
+        AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS,
     },
   },
 ];
@@ -415,6 +430,31 @@ const CONFIGS = [
         { type: "climate-fan-modes", style: "dropdown" },
         { type: "climate-swing-modes", style: "dropdown" },
         { type: "climate-swing-horizontal-modes", style: "dropdown" },
+      ],
+    },
+  },
+  {
+    heading: "Alarm modes feature",
+    config: {
+      type: "tile",
+      entity: "alarm_control_panel.home",
+      features: [
+        {
+          type: "alarm-modes",
+        },
+      ],
+    },
+  },
+  {
+    heading: "Alarm modes feature with labels",
+    config: {
+      type: "tile",
+      entity: "alarm_control_panel.home",
+      features: [
+        {
+          type: "alarm-modes",
+          show_labels: true,
+        },
       ],
     },
   },

--- a/src/panels/lovelace/card-features/hui-alarm-modes-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-alarm-modes-card-feature.ts
@@ -184,7 +184,7 @@ class HuiAlarmModeCardFeature
         .options=${options}
         .value=${this._currentMode}
         @value-changed=${this._valueChanged}
-        hide-option-label
+        ?hide-option-label=${!this._config.show_labels}
         .label=${this._localize("ui.card.alarm_control_panel.modes_label")}
         style=${styleMap({
           "--control-select-color": color,

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -128,6 +128,7 @@ export interface FanSpeedCardFeatureConfig {
 export interface AlarmModesCardFeatureConfig {
   type: "alarm-modes";
   modes?: AlarmMode[];
+  show_labels?: boolean;
 }
 
 export interface ClimateFanModesCardFeatureConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-alarm-modes-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-modes-card-feature-editor.ts
@@ -63,6 +63,12 @@ export class HuiAlarmModesCardFeatureEditor
             },
           },
         },
+        {
+          name: "show_labels",
+          selector: {
+            boolean: {},
+          },
+        },
       ] as const satisfies readonly HaFormSchema[]
   );
 
@@ -117,6 +123,7 @@ export class HuiAlarmModesCardFeatureEditor
     switch (schema.name) {
       case "modes":
       case "customize_modes":
+      case "show_labels":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.features.types.alarm-modes.${schema.name}`
         );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10674,7 +10674,8 @@
                   "armed_custom_bypass": "[%key:ui::card::alarm_control_panel::modes::armed_custom_bypass%]",
                   "disarmed": "[%key:ui::card::alarm_control_panel::modes::disarmed%]"
                 },
-                "customize_modes": "Customize alarm modes"
+                "customize_modes": "Customize alarm modes",
+                "show_labels": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::show_labels%]"
               },
               "light-brightness": {
                 "label": "Light brightness"


### PR DESCRIPTION
## Proposed change

Splits out the `show_labels` half of #53731 into its own PR, as requested by
@piitaya. The per-mode custom-icons part of that PR is dropped — this change is
only about making the existing alarm mode **labels** visible.

`ha-control-select` already supports rendering a text label under each option
(gated solely by its `hide-option-label` attribute), but the `alarm-modes`
tile-card feature hard-coded `hide-option-label` on, so labels could never be
shown.

This adds an optional `show_labels` config field that toggles that attribute off:

```yaml
features:
  - type: alarm-modes
    show_labels: true
```

- Follows the exact naming/default convention already used by the
  `precipitation-forecast` and `temperature-forecast` features
  (`show_labels?: boolean`, defaulting to unset/false).
- Defaults to icon-only, so existing dashboards are byte-for-byte unchanged.
- Exposed in the visual editor as a boolean toggle; the translation key reuses
  the shared `temperature-forecast::show_labels` string.

## Screenshots

**Default (icon-only, `show_labels` unset) — unchanged behaviour:**

<!-- ⬇️ glisser-déposer ici: showlabels-1-before-desktop.png -->

**`show_labels: true` — labels fit within `ha-control-select` (desktop):**

<!-- ⬇️ glisser-déposer ici: showlabels-2-after-desktop.png -->

**`show_labels: true` at mobile width — labels still fit:**

<!-- ⬇️ glisser-déposer ici: showlabels-3-after-mobile.png -->

Both states are in the tile-card gallery page (`Alarm modes feature` and
`Alarm modes feature with labels`), on an alarm entity that exposes all six arm
modes (Disarmed / Custom / Vacation / Night / Away / Home). The control renders
the short localized mode names, and the captures show every label fits inside
its `ha-control-select` option at both desktop and mobile widths.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: follow-up to #53731 (closed) —
  re-submitting only the `show_labels` option as @piitaya asked, without the
  per-mode custom-icons part.
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
