### PR TITLE
Fix choose-view dialog showing another dashboard's views

### DIFF
--- a/src/panels/lovelace/editor/add-entities-to-view.ts
+++ b/src/panels/lovelace/editor/add-entities-to-view.ts
@@ -1,8 +1,15 @@
 import type { LovelacePanelConfig } from "../../../data/lovelace";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import type { LovelaceSectionConfig } from "../../../data/lovelace/config/section";
-import type { LovelaceConfig } from "../../../data/lovelace/config/types";
-import { fetchConfig, saveConfig } from "../../../data/lovelace/config/types";
+import type {
+  LovelaceConfig,
+  LovelaceRawConfig,
+} from "../../../data/lovelace/config/types";
+import {
+  fetchConfig,
+  isStrategyDashboard,
+  saveConfig,
+} from "../../../data/lovelace/config/types";
 import { fetchDashboards } from "../../../data/lovelace/dashboard";
 import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import type { HomeAssistant } from "../../../types";
@@ -37,7 +44,15 @@ export const addEntitiesToLovelaceView = async (
     return;
   }
 
-  let lovelaceConfig;
+  // A strategy dashboard has no views of its own until the user takes control.
+  const hasViewList = (
+    config: LovelaceRawConfig | undefined
+  ): config is LovelaceConfig => !!config && !isStrategyDashboard(config);
+
+  const hasViews = (config: LovelaceRawConfig | undefined) =>
+    hasViewList(config) && !!config.views?.length;
+
+  let lovelaceConfig: LovelaceRawConfig | undefined;
   let urlPath: string | null = null;
   if (mainLovelaceMode === "storage") {
     try {
@@ -47,25 +62,36 @@ export const addEntitiesToLovelaceView = async (
     }
   }
 
-  if (!lovelaceConfig && storageDashs.length) {
-    // find first dashoard not in generated mode
+  if (!hasViews(lovelaceConfig)) {
+    // Prefer a dashboard that has views to add the card to, but keep the first
+    // usable one as a fallback so the user still gets the dashboard picker.
     for (const storageDash of storageDashs) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        lovelaceConfig = await fetchConfig(
+        const dashConfig = await fetchConfig(
           hass.connection,
           storageDash.url_path,
           false
         );
-        urlPath = storageDash.url_path;
-        break;
+        if (!hasViewList(dashConfig)) {
+          continue;
+        }
+        if (!hasViewList(lovelaceConfig)) {
+          lovelaceConfig = dashConfig;
+          urlPath = storageDash.url_path;
+        }
+        if (hasViews(dashConfig)) {
+          lovelaceConfig = dashConfig;
+          urlPath = storageDash.url_path;
+          break;
+        }
       } catch (_err: any) {
         // dashboard is in generated mode
       }
     }
   }
 
-  if (!lovelaceConfig) {
+  if (!hasViewList(lovelaceConfig)) {
     if (dashboards.length > storageDashs.length) {
       // all storage dashboards are generated, but we have YAML dashboards just show the YAML config
       showSuggestCardDialog(element, {
@@ -94,7 +120,7 @@ export const addEntitiesToLovelaceView = async (
     showSuggestCardDialog(element, {
       cardConfig,
       sectionConfig,
-      lovelaceConfig: lovelaceConfig!,
+      lovelaceConfig,
       saveConfig: async (newConfig: LovelaceConfig): Promise<void> => {
         try {
           await saveConfig(hass!, null, newConfig);

--- a/src/panels/lovelace/editor/select-view/hui-dialog-select-view.ts
+++ b/src/panels/lovelace/editor/select-view/hui-dialog-select-view.ts
@@ -9,6 +9,7 @@ import "../../../../components/ha-dialog-footer";
 import "../../../../components/ha-list";
 import "../../../../components/ha-radio-list-item";
 import "../../../../components/ha-select";
+import "../../../../components/ha-spinner";
 import "../../../../components/ha-dialog";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
 import { fetchConfig } from "../../../../data/lovelace/config/types";
@@ -42,12 +43,15 @@ export class HuiDialogSelectView extends LitElement {
 
   @state() private _selectedViewIdx = 0;
 
+  @state() private _loading = false;
+
   @state() private _open = false;
 
   public showDialog(params: SelectViewDialogParams): void {
     this._config = params.lovelaceConfig;
     this._urlPath = params.urlPath;
     this._selectedViewIdx = 0;
+    this._loading = false;
     this._params = params;
     this._open = true;
     if (this._params.allowDashboardChange) {
@@ -105,54 +109,7 @@ export class HuiDialogSelectView extends LitElement {
               </ha-select>`
             : nothing
         }
-        ${
-          !this._config || (this._config.views || []).length < 1
-            ? html`<ha-alert alert-type="error"
-                >${this.hass.localize(
-                  this._config
-                    ? "ui.panel.lovelace.editor.select_view.no_views"
-                    : "ui.panel.lovelace.editor.select_view.no_config"
-                )}</ha-alert
-              >`
-            : this._config.views.length > 1
-              ? html`
-                  <ha-list>
-                    ${this._config.views.map((view, idx) => {
-                      const isStrategy = isStrategyView(view);
-
-                      return html`
-                        <ha-radio-list-item
-                          .graphic=${
-                            this._config?.views.some(({ icon }) => icon)
-                              ? "icon"
-                              : nothing
-                          }
-                          @click=${this._viewChanged}
-                          .value=${idx.toString()}
-                          .selected=${this._selectedViewIdx === idx}
-                          .disabled=${
-                            isStrategy && !this._params?.includeStrategyViews
-                          }
-                          ?autofocus=${
-                            idx === 0 && !this._params!.allowDashboardChange
-                          }
-                        >
-                          <span>
-                            ${view.title}${
-                              isStrategy
-                                ? ` (${this.hass.localize("ui.panel.lovelace.editor.select_view.strategy_type")})`
-                                : nothing
-                            }
-                          </span>
-
-                          <ha-icon .icon=${view.icon} slot="graphic"></ha-icon>
-                        </ha-radio-list-item>
-                      `;
-                    })}
-                  </ha-list>
-                `
-              : nothing
-        }
+        ${this._renderViews()}
         <ha-dialog-footer slot="footer">
           <ha-button
             slot="secondaryAction"
@@ -163,13 +120,75 @@ export class HuiDialogSelectView extends LitElement {
           </ha-button>
           <ha-button
             slot="primaryAction"
-            .disabled=${!this._config || (this._config.views || []).length < 1}
+            .disabled=${!this._selectableConfig}
             @click=${this._selectView}
           >
             ${this._params.actionLabel || this.hass!.localize("ui.common.move")}
           </ha-button>
         </ha-dialog-footer>
       </ha-dialog>
+    `;
+  }
+
+  // While a config is loading the views on screen still belong to the
+  // previously selected dashboard, so nothing may be picked from them.
+  private get _selectableConfig(): LovelaceConfig | undefined {
+    return !this._loading && this._config?.views?.length
+      ? this._config
+      : undefined;
+  }
+
+  private _renderViews() {
+    if (this._loading) {
+      return html`<div class="loading">
+        <ha-spinner size="medium"></ha-spinner>
+      </div>`;
+    }
+
+    if (!this._selectableConfig) {
+      return html`<ha-alert alert-type="error">
+        ${this.hass.localize(
+          this._config
+            ? "ui.panel.lovelace.editor.select_view.no_views"
+            : "ui.panel.lovelace.editor.select_view.no_config"
+        )}
+      </ha-alert>`;
+    }
+
+    const views = this._selectableConfig.views;
+    if (views.length < 2) {
+      return nothing;
+    }
+
+    const hasIcon = views.some(({ icon }) => icon);
+
+    return html`
+      <ha-list>
+        ${views.map((view, idx) => {
+          const isStrategy = isStrategyView(view);
+
+          return html`
+            <ha-radio-list-item
+              .graphic=${hasIcon ? "icon" : nothing}
+              @click=${this._viewChanged}
+              .value=${idx.toString()}
+              .selected=${this._selectedViewIdx === idx}
+              .disabled=${isStrategy && !this._params?.includeStrategyViews}
+              ?autofocus=${idx === 0 && !this._params!.allowDashboardChange}
+            >
+              <span>
+                ${view.title}${
+                  isStrategy
+                    ? ` (${this.hass.localize("ui.panel.lovelace.editor.select_view.strategy_type")})`
+                    : nothing
+                }
+              </span>
+
+              <ha-icon .icon=${view.icon} slot="graphic"></ha-icon>
+            </ha-radio-list-item>
+          `;
+        })}
+      </ha-list>
     `;
   }
 
@@ -184,7 +203,7 @@ export class HuiDialogSelectView extends LitElement {
       return;
     }
     this._urlPath = urlPath;
-    this._selectedViewIdx = 0;
+    this._loading = true;
     let config: LovelaceConfig | undefined;
     try {
       config = (await fetchConfig(
@@ -200,6 +219,8 @@ export class HuiDialogSelectView extends LitElement {
       return;
     }
     this._config = config;
+    this._selectedViewIdx = 0;
+    this._loading = false;
   }
 
   private _viewChanged(e) {
@@ -211,10 +232,14 @@ export class HuiDialogSelectView extends LitElement {
   }
 
   private _selectView(): void {
+    const config = this._selectableConfig;
+    if (!config) {
+      return;
+    }
     fireEvent(this, "view-selected", { view: this._selectedViewIdx });
     this._params!.viewSelectedCallback(
       this._urlPath!,
-      this._config!,
+      config,
       this._selectedViewIdx
     );
     this.closeDialog();
@@ -226,6 +251,10 @@ export class HuiDialogSelectView extends LitElement {
       css`
         ha-select {
           width: 100%;
+        }
+        .loading {
+          display: flex;
+          justify-content: center;
         }
         mwc-radio-list-item {
           direction: ltr;

--- a/src/panels/lovelace/editor/select-view/hui-dialog-select-view.ts
+++ b/src/panels/lovelace/editor/select-view/hui-dialog-select-view.ts
@@ -15,7 +15,7 @@ import { fetchConfig } from "../../../../data/lovelace/config/types";
 import { isStrategyView } from "../../../../data/lovelace/config/view";
 import type { LovelaceDashboard } from "../../../../data/lovelace/dashboard";
 import { fetchDashboards } from "../../../../data/lovelace/dashboard";
-import { getDefaultPanelUrlPath } from "../../../../data/panel";
+import { LOVELACE_PANEL } from "../../../../data/panel";
 import { haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant, ValueChangedEvent } from "../../../../types";
 import type { SelectViewDialogParams } from "./show-select-view-dialog";
@@ -47,6 +47,7 @@ export class HuiDialogSelectView extends LitElement {
   public showDialog(params: SelectViewDialogParams): void {
     this._config = params.lovelaceConfig;
     this._urlPath = params.urlPath;
+    this._selectedViewIdx = 0;
     this._params = params;
     this._open = true;
     if (this._params.allowDashboardChange) {
@@ -68,8 +69,6 @@ export class HuiDialogSelectView extends LitElement {
       return nothing;
     }
 
-    const defaultPanel = getDefaultPanelUrlPath(this.hass);
-
     return html`
       <ha-dialog
         .open=${this._open}
@@ -86,19 +85,19 @@ export class HuiDialogSelectView extends LitElement {
                   "ui.panel.lovelace.editor.select_view.dashboard_label"
                 )}
                 .disabled=${!this._dashboards.length}
-                .value=${this._urlPath || defaultPanel}
+                .value=${this._urlPath ?? LOVELACE_PANEL}
                 @selected=${this._dashboardChanged}
                 autofocus
                 .options=${this._dashboards
                   .map((dashboard) => ({
                     value: dashboard.url_path,
-                    label: `${dashboard.title}${dashboard.id === "lovelace" ? ` (${this.hass.localize("ui.common.default")})` : ""}`,
+                    label: `${dashboard.title}${dashboard.id === LOVELACE_PANEL ? ` (${this.hass.localize("ui.common.default")})` : ""}`,
                     disabled: dashboard.mode !== "storage",
                   }))
                   .sort((a, b) =>
-                    a.value === "lovelace"
+                    a.value === LOVELACE_PANEL
                       ? -1
-                      : b.value === "lovelace"
+                      : b.value === LOVELACE_PANEL
                         ? 1
                         : a.label.localeCompare(b.label)
                   )}
@@ -180,24 +179,27 @@ export class HuiDialogSelectView extends LitElement {
   }
 
   private async _dashboardChanged(ev: ValueChangedEvent<string>) {
-    let urlPath: string | null = ev.detail.value;
+    const urlPath = ev.detail.value === LOVELACE_PANEL ? null : ev.detail.value;
     if (urlPath === this._urlPath) {
       return;
     }
-    if (urlPath === "lovelace") {
-      urlPath = null;
-    }
     this._urlPath = urlPath;
     this._selectedViewIdx = 0;
+    let config: LovelaceConfig | undefined;
     try {
-      this._config = (await fetchConfig(
+      config = (await fetchConfig(
         this.hass.connection,
         urlPath,
         false
       )) as LovelaceConfig;
     } catch (_err: any) {
-      this._config = undefined;
+      config = undefined;
     }
+    // Responses can resolve out of order.
+    if (urlPath !== this._urlPath) {
+      return;
+    }
+    this._config = config;
   }
 
   private _viewChanged(e) {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The dashboard picker in the choose-view dialog followed the user's default panel while the view list came from whichever dashboard's config was loaded, so it could name one dashboard above another dashboard's views. It now follows the dashboard the config belongs to and ignores out-of-order config responses, and adding a card no longer starts on a dashboard that has no views to add it to.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Adding a device to a dashboard, on an instance whose original Overview dashboard has no views and whose default dashboard is "Our Home":

| Before | After |
| --- | --- |
| ![Choose a view dialog showing Our Home selected with the error No views in this dashboard](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pr-before-78fcfc03.png) | ![Choose a view dialog showing Our Home selected and its Home, Kitchen and Garden views listed](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pr-after-6900d8e4.png) |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53715
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
