### PR TITLE
Timer UI enhancements

### DIFF
--- a/gallery/src/pages/more-info/timer.ts
+++ b/gallery/src/pages/more-info/timer.ts
@@ -16,6 +16,25 @@ const ENTITIES = [
       duration: "0:05:00",
     },
   },
+  {
+    entity_id: "timer.active_timer",
+    state: "active",
+    attributes: {
+      friendly_name: "Active timer",
+      duration: "0:10:00",
+      remaining: "0:10:00",
+      finishes_at: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+    },
+  },
+  {
+    entity_id: "timer.paused_timer",
+    state: "paused",
+    attributes: {
+      friendly_name: "Paused timer",
+      duration: "0:10:00",
+      remaining: "0:03:21",
+    },
+  },
 ];
 
 @customElement("demo-more-info-timer")

--- a/src/common/controllers/timer-remaining-time-controller.ts
+++ b/src/common/controllers/timer-remaining-time-controller.ts
@@ -1,0 +1,70 @@
+import type {
+  ReactiveController,
+  ReactiveControllerHost,
+} from "@lit/reactive-element/reactive-controller";
+import type { HassEntity } from "home-assistant-js-websocket";
+import { timerTimeRemaining } from "../../data/timer";
+
+/**
+ * Tracks the live remaining time of a timer entity. While the timer is
+ * active, the host is re-rendered every second with an updated
+ * `timeRemaining`, computed from the entity's `finishes_at` attribute.
+ *
+ * The host must call `setStateObj` whenever its timer entity changes.
+ */
+export class TimerRemainingTimeController implements ReactiveController {
+  public timeRemaining?: number;
+
+  private _host: ReactiveControllerHost;
+
+  private _stateObj?: HassEntity;
+
+  private _interval?: number;
+
+  constructor(host: ReactiveControllerHost) {
+    this._host = host;
+    host.addController(this);
+  }
+
+  public setStateObj(stateObj: HassEntity | undefined): void {
+    this._stateObj = stateObj;
+    this._startInterval();
+  }
+
+  public hostConnected(): void {
+    this._startInterval();
+  }
+
+  public hostDisconnected(): void {
+    this._clearInterval();
+  }
+
+  private _startInterval(): void {
+    this._clearInterval();
+    if (!this._stateObj) {
+      this.timeRemaining = undefined;
+      return;
+    }
+    this._calculateRemaining();
+
+    if (this._stateObj.state === "active") {
+      this._interval = window.setInterval(() => {
+        this._calculateRemaining();
+        this._host.requestUpdate();
+      }, 1000);
+    }
+  }
+
+  private _clearInterval(): void {
+    if (this._interval) {
+      clearInterval(this._interval);
+      this._interval = undefined;
+    }
+  }
+
+  private _calculateRemaining(): void {
+    this.timeRemaining = this._stateObj
+      ? timerTimeRemaining(this._stateObj)
+      : undefined;
+  }
+}

--- a/src/data/entity/entity_registry.ts
+++ b/src/data/entity/entity_registry.ts
@@ -96,10 +96,17 @@ export interface ValveEntityOptions {
   favorite_positions?: number[];
 }
 
-export type FavoriteOption =
-  "favorite_colors" | "favorite_positions" | "favorite_tilt_positions";
+export interface TimerEntityOptions {
+  presets?: number[];
+}
 
-export type FavoritesDomain = "light" | "cover" | "valve";
+export type FavoriteOption =
+  | "favorite_colors"
+  | "favorite_positions"
+  | "favorite_tilt_positions"
+  | "presets";
+
+export type FavoritesDomain = "light" | "cover" | "valve" | "timer";
 
 export type FavoriteOptionValue = LightColor[] | number[];
 
@@ -107,6 +114,7 @@ export const DOMAINS_WITH_FAVORITES: FavoritesDomain[] = [
   "light",
   "cover",
   "valve",
+  "timer",
 ];
 
 export const isFavoritesDomain = (domain: string): domain is FavoritesDomain =>
@@ -173,6 +181,7 @@ export interface EntityRegistryOptions {
   light?: LightEntityOptions;
   cover?: CoverEntityOptions;
   valve?: ValveEntityOptions;
+  timer?: TimerEntityOptions;
   vacuum?: VacuumEntityOptions;
   device_tracker?: DeviceTrackerEntityOptions;
   switch_as_x?: SwitchAsXEntityOptions;
@@ -200,6 +209,7 @@ export interface EntityRegistryEntryUpdateParams {
     | LightEntityOptions
     | CoverEntityOptions
     | ValveEntityOptions
+    | TimerEntityOptions
     | VacuumEntityOptions
     | DeviceTrackerEntityOptions;
   aliases?: (string | null)[];

--- a/src/data/timer.ts
+++ b/src/data/timer.ts
@@ -4,8 +4,11 @@ import type {
   HassEntityBase,
 } from "home-assistant-js-websocket";
 import { createDurationData } from "../common/datetime/create_duration_data";
-import durationToSeconds from "../common/datetime/duration_to_seconds";
+import durationToSeconds, {
+  durationDataToSeconds,
+} from "../common/datetime/duration_to_seconds";
 import secondsToDuration from "../common/datetime/seconds_to_duration";
+import type { FormatEntityStateFunc } from "../common/translations/entity-state";
 import type { HaDurationData } from "../components/ha-duration-input";
 import type { HomeAssistant } from "../types";
 
@@ -14,6 +17,7 @@ export type TimerEntity = HassEntityBase & {
     duration: string;
     remaining: string;
     restore: boolean;
+    finishes_at?: string;
   };
 };
 
@@ -82,7 +86,7 @@ export const timerTimeRemaining = (
 };
 
 export const computeDisplayTimer = (
-  hass: HomeAssistant,
+  formatEntityState: FormatEntityStateFunc,
   stateObj: HassEntity,
   timeRemaining?: number
 ): string | null => {
@@ -91,16 +95,38 @@ export const computeDisplayTimer = (
   }
 
   if (stateObj.state === "idle" || timeRemaining === 0) {
-    return hass.formatEntityState(stateObj);
+    return formatEntityState(stateObj);
   }
 
   let display = secondsToDuration(timeRemaining || 0) || "0";
 
   if (stateObj.state === "paused") {
-    display = `${display} (${hass.formatEntityState(stateObj)})`;
+    display = `${display} (${formatEntityState(stateObj)})`;
   }
 
   return display;
+};
+
+const leftPad = (num: number) => (num < 10 ? `0${num}` : `${num}`);
+
+// Normalize duration data to whole-second hours/minutes/seconds fields, so
+// out-of-range values ({seconds: 3600}) and fractional seconds cannot reach
+// duration inputs or the serialized config. Timers only support whole seconds.
+export const normalizeTimerDuration = (
+  data: HaDurationData
+): HaDurationData => {
+  const totalSeconds = Math.floor(durationDataToSeconds(data));
+  return {
+    hours: Math.floor(totalSeconds / 3600),
+    minutes: Math.floor((totalSeconds % 3600) / 60),
+    seconds: totalSeconds % 60,
+  };
+};
+
+// Serialize duration data to the "H:MM:SS" format accepted by timer.start.
+export const durationDataToTimerString = (data: HaDurationData): string => {
+  const { hours = 0, minutes = 0, seconds = 0 } = normalizeTimerDuration(data);
+  return `${hours}:${leftPad(minutes)}:${leftPad(seconds)}`;
 };
 
 // Prefill for the duration input: always the configured duration, independent

--- a/src/data/timer.ts
+++ b/src/data/timer.ts
@@ -8,9 +8,11 @@ import durationToSeconds, {
   durationDataToSeconds,
 } from "../common/datetime/duration_to_seconds";
 import secondsToDuration from "../common/datetime/seconds_to_duration";
+import { formatNumericDuration } from "../common/datetime/format_duration";
 import type { FormatEntityStateFunc } from "../common/translations/entity-state";
 import type { HaDurationData } from "../components/ha-duration-input";
 import type { HomeAssistant } from "../types";
+import type { FrontendLocaleData } from "./translation";
 
 export type TimerEntity = HassEntityBase & {
   attributes: HassEntityAttributeBase & {
@@ -149,3 +151,18 @@ export const timerDurationData = (
   stateObj: HassEntity
 ): HaDurationData | undefined =>
   createDurationData(stateObj.attributes.duration);
+
+export const normalizeTimerPresets = (presets?: number[]): number[] => [
+  ...new Set(
+    (presets ?? [])
+      .map((preset) => Math.floor(Number(preset)))
+      .filter((seconds) => Number.isFinite(seconds) && seconds > 0)
+  ),
+];
+
+// Presets are at least one second, so the formatter never returns null here.
+export const timerPresetLabel = (
+  locale: FrontendLocaleData,
+  seconds: number
+): string =>
+  formatNumericDuration(locale, normalizeTimerDuration({ seconds })) ?? "";

--- a/src/data/timer.ts
+++ b/src/data/timer.ts
@@ -18,6 +18,7 @@ export type TimerEntity = HassEntityBase & {
     remaining: string;
     restore: boolean;
     finishes_at?: string;
+    last_transition?: string;
   };
 };
 
@@ -67,6 +68,18 @@ export const deleteTimer = (hass: HomeAssistant, id: string) =>
     type: "timer/delete",
     timer_id: id,
   });
+
+// True when this state change is the timer completing: it ran out or
+// timer.finish was called. Cancel also ends in "idle" but sets
+// last_transition to "cancelled", so it does not match.
+export const timerJustFinished = (
+  oldStateObj: HassEntity | undefined,
+  stateObj: HassEntity
+): boolean =>
+  oldStateObj !== undefined &&
+  oldStateObj.state !== "idle" &&
+  stateObj.state === "idle" &&
+  stateObj.attributes.last_transition === "finished";
 
 export const timerTimeRemaining = (
   stateObj: HassEntity

--- a/src/dialogs/form/dialog-form.ts
+++ b/src/dialogs/form/dialog-form.ts
@@ -300,6 +300,12 @@ export class DialogForm
       return;
     }
 
+    const validationError = this._params?.validate?.(this._data);
+    if (validationError && Object.keys(validationError).length) {
+      this._error = validationError;
+      return;
+    }
+
     const submit = this._params?.submit;
     const data = this._data;
     const stackEntry = this._popStack();

--- a/src/dialogs/form/show-form-dialog.ts
+++ b/src/dialogs/form/show-form-dialog.ts
@@ -7,6 +7,10 @@ export interface FormDialogParams {
   title: string;
   schema: HaFormSchema[];
   data?: FormDialogData;
+  // Extra submit-time validation beyond the schema's own checks. Returned
+  // errors are shown on the named fields ("base" for a general error) and
+  // block the submit; they clear when the user edits the form.
+  validate?: (data: FormDialogData) => Record<string, string> | undefined;
   submit?: (data?: FormDialogData) => void;
   cancel?: () => void;
   computeLabel?: (schema, data) => string | undefined;

--- a/src/dialogs/more-info/components/timers/ha-more-info-timer-presets.ts
+++ b/src/dialogs/more-info/components/timers/ha-more-info-timer-presets.ts
@@ -1,0 +1,366 @@
+import { consume } from "@lit/context";
+import type { PropertyValues, TemplateResult } from "lit";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
+import { durationDataToSeconds } from "../../../../common/datetime/duration_to_seconds";
+import { consumeLocalize } from "../../../../common/decorators/consume-context-entry";
+import { transform } from "../../../../common/decorators/transform";
+import type { HASSDomEvent } from "../../../../common/dom/fire_event";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import "../../../../components/ha-control-button";
+import type { HaDurationData } from "../../../../components/ha-duration-input";
+import {
+  apiContext,
+  configContext,
+  internationalizationContext,
+} from "../../../../data/context";
+import { UNAVAILABLE } from "../../../../data/entity/entity";
+import type {
+  ExtEntityRegistryEntry,
+  TimerEntityOptions,
+} from "../../../../data/entity/entity_registry";
+import { updateEntityRegistryEntry } from "../../../../data/entity/entity_registry";
+import type { TimerEntity } from "../../../../data/timer";
+import {
+  normalizeTimerDuration,
+  normalizeTimerPresets,
+  timerPresetLabel,
+} from "../../../../data/timer";
+import type { FrontendLocaleData } from "../../../../data/translation";
+import type {
+  HomeAssistant,
+  HomeAssistantApi,
+  HomeAssistantConfig,
+  HomeAssistantInternationalization,
+} from "../../../../types";
+import { showFormDialog } from "../../../form/show-form-dialog";
+import { showConfirmationDialog } from "../../../generic/show-dialog-box";
+import "../ha-more-info-favorites";
+import type { HaMoreInfoFavorites } from "../ha-more-info-favorites";
+
+type PresetLocalizeKey =
+  | "set"
+  | "edit"
+  | "delete"
+  | "delete_confirm_title"
+  | "delete_confirm_text"
+  | "delete_confirm_action"
+  | "add"
+  | "edit_title"
+  | "add_title"
+  | "duration";
+
+@customElement("ha-more-info-timer-presets")
+export class HaMoreInfoTimerPresets extends LitElement {
+  @state()
+  @consume({ context: apiContext, subscribe: true })
+  private _api!: HomeAssistantApi;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
+
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  @transform<HomeAssistantConfig, HomeAssistant["user"]>({
+    transformer: ({ user }) => user,
+  })
+  private _user!: HomeAssistant["user"];
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale?: FrontendLocaleData;
+
+  @property({ attribute: false }) public stateObj!: TimerEntity;
+
+  @property({ attribute: false }) public entry?: ExtEntityRegistryEntry | null;
+
+  @property({ attribute: false }) public editMode?: boolean;
+
+  @state() private _presets: number[] = [];
+
+  protected updated(changedProps: PropertyValues<this>): void {
+    // Sync from entry only; a stateObj tick must not clobber optimistic edits.
+    if (changedProps.has("entry") && this.entry) {
+      this._presets = normalizeTimerPresets(this.entry.options?.timer?.presets);
+    }
+  }
+
+  private _localizePreset(
+    key: PresetLocalizeKey,
+    values?: Record<string, string | number>
+  ): string {
+    return this._localize(
+      `ui.dialogs.more_info_control.timer.preset.${key}`,
+      values
+    );
+  }
+
+  private async _save(presets: number[]): Promise<void> {
+    if (!this.entry) {
+      return;
+    }
+
+    const currentOptions: TimerEntityOptions = {
+      ...(this.entry.options?.timer ?? {}),
+    };
+
+    const result = await updateEntityRegistryEntry(
+      this._api,
+      this.entry.entity_id,
+      {
+        options_domain: "timer",
+        options: {
+          ...currentOptions,
+          presets: presets.length ? presets : undefined,
+        },
+      }
+    );
+
+    fireEvent(this, "entity-entry-updated", result.entity_entry);
+  }
+
+  private async _setPresets(presets: number[]): Promise<void> {
+    const normalized = normalizeTimerPresets(presets);
+    this._presets = normalized;
+    await this._save(normalized);
+  }
+
+  private _move(index: number, newIndex: number): void {
+    const presets = this._presets.concat();
+    const moved = presets.splice(index, 1)[0];
+    presets.splice(newIndex, 0, moved);
+    this._setPresets(presets);
+  }
+
+  private _applyPreset(index: number): void {
+    const preset = this._presets[index];
+
+    if (preset === undefined) {
+      return;
+    }
+
+    this._api.callService("timer", "start", {
+      entity_id: this.stateObj.entity_id,
+      duration: preset,
+    });
+  }
+
+  private async _promptPresetValue(
+    seconds?: number
+  ): Promise<number | undefined> {
+    const response = await showFormDialog(this, {
+      title: this._localizePreset(
+        seconds === undefined ? "add_title" : "edit_title"
+      ),
+      schema: [
+        {
+          name: "duration",
+          required: true,
+          selector: {
+            duration: { enable_day: false, enable_millisecond: false },
+          },
+        },
+      ],
+      data: {
+        duration: normalizeTimerDuration({ seconds: seconds ?? 0 }),
+      },
+      computeLabel: () => this._localizePreset("duration"),
+    });
+
+    if (!response?.duration) {
+      return undefined;
+    }
+
+    const value = Math.floor(
+      durationDataToSeconds(response.duration as HaDurationData)
+    );
+
+    return value > 0 ? value : undefined;
+  }
+
+  private async _addPreset(): Promise<void> {
+    const value = await this._promptPresetValue();
+
+    if (value === undefined) {
+      return;
+    }
+
+    await this._setPresets([...this._presets, value]);
+  }
+
+  private async _editPreset(index: number): Promise<void> {
+    const current = this._presets[index];
+
+    if (current === undefined) {
+      return;
+    }
+
+    const value = await this._promptPresetValue(current);
+
+    if (value === undefined) {
+      return;
+    }
+
+    const updated = [...this._presets];
+    updated[index] = value;
+    await this._setPresets(updated);
+  }
+
+  private async _deletePreset(index: number): Promise<void> {
+    const confirmed = await showConfirmationDialog(this, {
+      destructive: true,
+      title: this._localizePreset("delete_confirm_title"),
+      text: this._localizePreset("delete_confirm_text"),
+      confirmText: this._localizePreset("delete_confirm_action"),
+    });
+
+    if (!confirmed) {
+      return;
+    }
+
+    await this._setPresets(
+      this._presets.filter((_, itemIndex) => itemIndex !== index)
+    );
+  }
+
+  private _renderPreset: HaMoreInfoFavorites["renderItem"] = (
+    preset,
+    _index,
+    editMode
+  ) => {
+    const seconds = preset as number;
+    const value = timerPresetLabel(this._locale!, seconds);
+    const label = this._localizePreset(editMode ? "edit" : "set", { value });
+
+    return html`
+      <ha-control-button
+        style=${styleMap({
+          "--control-button-border-radius": "var(--ha-border-radius-pill)",
+          "min-width": "72px",
+          width: "auto",
+          height: "36px",
+          padding: "0 var(--ha-space-3)",
+        })}
+        .label=${label}
+        .disabled=${this.stateObj.state === UNAVAILABLE}
+      >
+        ${value}
+      </ha-control-button>
+    `;
+  };
+
+  private _deleteLabel = (index: number): string =>
+    this._localizePreset("delete", {
+      number: index + 1,
+    });
+
+  private _handlePresetAction = (
+    ev: HASSDomEvent<HASSDomEvents["favorite-item-action"]>
+  ): void => {
+    ev.stopPropagation();
+
+    const { action, index } = ev.detail;
+
+    if (action === "hold" && this._user?.is_admin) {
+      fireEvent(this, "toggle-edit-mode", true);
+      return;
+    }
+
+    if (this.editMode) {
+      this._editPreset(index);
+      return;
+    }
+
+    this._applyPreset(index);
+  };
+
+  private _handlePresetMoved = (
+    ev: HASSDomEvent<HASSDomEvents["favorite-item-moved"]>
+  ): void => {
+    ev.stopPropagation();
+    this._move(ev.detail.oldIndex, ev.detail.newIndex);
+  };
+
+  private _handlePresetDelete = (
+    ev: HASSDomEvent<HASSDomEvents["favorite-item-delete"]>
+  ): void => {
+    ev.stopPropagation();
+    this._deletePreset(ev.detail.index);
+  };
+
+  private _handlePresetAdd = (
+    ev: HASSDomEvent<HASSDomEvents["favorite-item-add"]>
+  ): void => {
+    ev.stopPropagation();
+    this._addPreset();
+  };
+
+  private _handlePresetDone = (
+    ev: HASSDomEvent<HASSDomEvents["favorite-item-done"]>
+  ): void => {
+    ev.stopPropagation();
+    fireEvent(this, "toggle-edit-mode", false);
+  };
+
+  protected render(): TemplateResult | typeof nothing {
+    if (!this.stateObj || !this.entry || !this._locale) {
+      return nothing;
+    }
+
+    if (!this.editMode && this._presets.length === 0) {
+      return nothing;
+    }
+
+    return html`
+      <section class="presets">
+        <ha-more-info-favorites
+          .items=${this._presets}
+          .renderItem=${this._renderPreset}
+          .deleteLabel=${this._deleteLabel}
+          .editMode=${this.editMode ?? false}
+          .disabled=${this.stateObj.state === UNAVAILABLE}
+          .isAdmin=${Boolean(this._user?.is_admin)}
+          .showDone=${true}
+          .addLabel=${this._localizePreset("add")}
+          .doneLabel=${this._localize(
+            "ui.dialogs.more_info_control.exit_edit_mode"
+          )}
+          @favorite-item-action=${this._handlePresetAction}
+          @favorite-item-moved=${this._handlePresetMoved}
+          @favorite-item-delete=${this._handlePresetDelete}
+          @favorite-item-add=${this._handlePresetAdd}
+          @favorite-item-done=${this._handlePresetDone}
+        ></ha-more-info-favorites>
+      </section>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+      width: 100%;
+    }
+
+    .presets {
+      width: 100%;
+      max-width: 384px;
+      margin: 0 auto;
+    }
+
+    .presets ha-more-info-favorites {
+      --favorite-items-max-width: 384px;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-more-info-timer-presets": HaMoreInfoTimerPresets;
+  }
+}

--- a/src/dialogs/more-info/components/timers/ha-more-info-timer-presets.ts
+++ b/src/dialogs/more-info/components/timers/ha-more-info-timer-presets.ts
@@ -50,7 +50,8 @@ type PresetLocalizeKey =
   | "add"
   | "edit_title"
   | "add_title"
-  | "duration";
+  | "duration"
+  | "duration_error";
 
 @customElement("ha-more-info-timer-presets")
 export class HaMoreInfoTimerPresets extends LitElement {
@@ -171,6 +172,11 @@ export class HaMoreInfoTimerPresets extends LitElement {
         duration: normalizeTimerDuration({ seconds: seconds ?? 0 }),
       },
       computeLabel: () => this._localizePreset("duration"),
+      validate: (data) =>
+        data.duration &&
+        Math.floor(durationDataToSeconds(data.duration as HaDurationData)) > 0
+          ? undefined
+          : { duration: this._localizePreset("duration_error") },
     });
 
     if (!response?.duration) {

--- a/src/dialogs/more-info/const.ts
+++ b/src/dialogs/more-info/const.ts
@@ -38,6 +38,7 @@ export const DOMAINS_WITH_NEW_MORE_INFO = [
   "siren",
   "script",
   "switch",
+  "timer",
   "vacuum",
   "valve",
   "water_heater",

--- a/src/dialogs/more-info/controls/more-info-timer.ts
+++ b/src/dialogs/more-info/controls/more-info-timer.ts
@@ -12,6 +12,8 @@ import type { HaButton } from "../../../components/ha-button";
 import "../../../components/ha-duration-input";
 import type { HaDurationData } from "../../../components/ha-duration-input";
 import { apiContext, formattersContext } from "../../../data/context";
+import type { ExtEntityRegistryEntry } from "../../../data/entity/entity_registry";
+import { shouldShowFavoriteOptions } from "../../../data/entity/entity_registry";
 import type { TimerEntity } from "../../../data/timer";
 import {
   computeDisplayTimer,
@@ -24,11 +26,16 @@ import type {
   ValueChangedEvent,
 } from "../../../types";
 import "../components/ha-more-info-state-header";
+import "../components/timers/ha-more-info-timer-presets";
 import { moreInfoControlStyle } from "../components/more-info-control-style";
 
 @customElement("more-info-timer")
 class MoreInfoTimer extends LitElement {
   @property({ attribute: false }) public stateObj?: TimerEntity;
+
+  @property({ attribute: false }) public entry?: ExtEntityRegistryEntry | null;
+
+  @property({ attribute: false }) public editMode?: boolean;
 
   @state()
   @consumeLocalize()
@@ -76,6 +83,12 @@ class MoreInfoTimer extends LitElement {
     }
 
     const timerState = this.stateObj.state;
+
+    const showPresets = Boolean(
+      this.entry &&
+      (this.editMode ||
+        shouldShowFavoriteOptions(this.entry.options?.timer?.presets))
+    );
 
     return html`
       <ha-more-info-state-header
@@ -166,6 +179,17 @@ class MoreInfoTimer extends LitElement {
               : nothing
           }
         </div>
+        ${
+          showPresets
+            ? html`
+                <ha-more-info-timer-presets
+                  .stateObj=${this.stateObj}
+                  .entry=${this.entry}
+                  .editMode=${this.editMode}
+                ></ha-more-info-timer-presets>
+              `
+            : nothing
+        }
       </div>
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-timer.ts
+++ b/src/dialogs/more-info/controls/more-info-timer.ts
@@ -218,7 +218,7 @@ class MoreInfoTimer extends LitElement {
       }
       @media (prefers-reduced-motion: reduce) {
         ha-more-info-state-header.finished {
-          animation: none;
+          animation-duration: var(--ha-animation-duration-none);
         }
       }
     `,

--- a/src/dialogs/more-info/controls/more-info-timer.ts
+++ b/src/dialogs/more-info/controls/more-info-timer.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { TimerRemainingTimeController } from "../../../common/controllers/timer-remaining-time-controller";
 import { consumeLocalize } from "../../../common/decorators/consume-context-entry";
 import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../common/translations/localize";
@@ -9,10 +10,16 @@ import "../../../components/ha-button";
 import type { HaButton } from "../../../components/ha-button";
 import "../../../components/ha-duration-input";
 import type { HaDurationData } from "../../../components/ha-duration-input";
-import { apiContext } from "../../../data/context";
+import { apiContext, formattersContext } from "../../../data/context";
 import type { TimerEntity } from "../../../data/timer";
-import { timerDurationData } from "../../../data/timer";
-import type { HomeAssistantApi, ValueChangedEvent } from "../../../types";
+import { computeDisplayTimer, timerDurationData } from "../../../data/timer";
+import type {
+  HomeAssistantApi,
+  HomeAssistantFormatters,
+  ValueChangedEvent,
+} from "../../../types";
+import "../components/ha-more-info-state-header";
+import { moreInfoControlStyle } from "../components/more-info-control-style";
 
 @customElement("more-info-timer")
 class MoreInfoTimer extends LitElement {
@@ -26,7 +33,13 @@ class MoreInfoTimer extends LitElement {
   @consume({ context: apiContext, subscribe: true })
   private _api!: HomeAssistantApi;
 
+  @state()
+  @consume({ context: formattersContext, subscribe: true })
+  private _formatters!: HomeAssistantFormatters;
+
   @state() private _duration?: HaDurationData;
+
+  private _remainingTime = new TimerRemainingTimeController(this);
 
   protected willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
@@ -35,90 +48,105 @@ class MoreInfoTimer extends LitElement {
     if (this._duration === undefined && this.stateObj) {
       this._duration = timerDurationData(this.stateObj);
     }
+    if (changedProps.has("stateObj")) {
+      this._remainingTime.setStateObj(this.stateObj);
+    }
   }
 
   protected render() {
-    if (!this._localize || !this.stateObj) {
+    if (!this._localize || !this._formatters || !this.stateObj) {
       return nothing;
     }
 
     const timerState = this.stateObj.state;
 
     return html`
-      <ha-duration-input
-        .data=${this._duration}
-        required
-        @value-changed=${this._durationChanged}
-      ></ha-duration-input>
-      <div class="actions">
-        ${
-          timerState === "idle"
-            ? html`
-                <ha-button appearance="plain" size="s" @click=${this._start}>
-                  ${this._localize("ui.card.timer.actions.start")}
-                </ha-button>
-              `
-            : nothing
+      <ha-more-info-state-header
+        .stateObj=${this.stateObj}
+        .stateOverride=${
+          computeDisplayTimer(
+            this._formatters.formatEntityState,
+            this.stateObj,
+            this._remainingTime.timeRemaining
+          ) ?? undefined
         }
-        ${
-          timerState === "active" || timerState === "paused"
-            ? html`
-                <ha-button appearance="plain" size="s" @click=${this._start}>
-                  ${this._localize("ui.card.timer.actions.set")}
-                </ha-button>
-              `
-            : nothing
-        }
-        ${
-          timerState === "active"
-            ? html`
-                <ha-button
-                  appearance="plain"
-                  size="s"
-                  .action=${"pause"}
-                  @click=${this._handleActionClick}
-                >
-                  ${this._localize("ui.card.timer.actions.pause")}
-                </ha-button>
-              `
-            : nothing
-        }
-        ${
-          timerState === "paused"
-            ? html`
-                <ha-button
-                  appearance="plain"
-                  size="s"
-                  .action=${"start"}
-                  @click=${this._handleActionClick}
-                >
-                  ${this._localize("ui.card.timer.actions.start")}
-                </ha-button>
-              `
-            : nothing
-        }
-        ${
-          timerState === "active" || timerState === "paused"
-            ? html`
-                <ha-button
-                  appearance="plain"
-                  size="s"
-                  .action=${"cancel"}
-                  @click=${this._handleActionClick}
-                >
-                  ${this._localize("ui.card.timer.actions.cancel")}
-                </ha-button>
-                <ha-button
-                  appearance="plain"
-                  size="s"
-                  .action=${"finish"}
-                  @click=${this._handleActionClick}
-                >
-                  ${this._localize("ui.card.timer.actions.finish")}
-                </ha-button>
-              `
-            : nothing
-        }
+      ></ha-more-info-state-header>
+      <div class="controls">
+        <ha-duration-input
+          .data=${this._duration}
+          required
+          @value-changed=${this._durationChanged}
+        ></ha-duration-input>
+        <div class="actions">
+          ${
+            timerState === "idle"
+              ? html`
+                  <ha-button appearance="plain" size="s" @click=${this._start}>
+                    ${this._localize("ui.card.timer.actions.start")}
+                  </ha-button>
+                `
+              : nothing
+          }
+          ${
+            timerState === "active" || timerState === "paused"
+              ? html`
+                  <ha-button appearance="plain" size="s" @click=${this._start}>
+                    ${this._localize("ui.card.timer.actions.set")}
+                  </ha-button>
+                `
+              : nothing
+          }
+          ${
+            timerState === "active"
+              ? html`
+                  <ha-button
+                    appearance="plain"
+                    size="s"
+                    .action=${"pause"}
+                    @click=${this._handleActionClick}
+                  >
+                    ${this._localize("ui.card.timer.actions.pause")}
+                  </ha-button>
+                `
+              : nothing
+          }
+          ${
+            timerState === "paused"
+              ? html`
+                  <ha-button
+                    appearance="plain"
+                    size="s"
+                    .action=${"start"}
+                    @click=${this._handleActionClick}
+                  >
+                    ${this._localize("ui.card.timer.actions.start")}
+                  </ha-button>
+                `
+              : nothing
+          }
+          ${
+            timerState === "active" || timerState === "paused"
+              ? html`
+                  <ha-button
+                    appearance="plain"
+                    size="s"
+                    .action=${"cancel"}
+                    @click=${this._handleActionClick}
+                  >
+                    ${this._localize("ui.card.timer.actions.cancel")}
+                  </ha-button>
+                  <ha-button
+                    appearance="plain"
+                    size="s"
+                    .action=${"finish"}
+                    @click=${this._handleActionClick}
+                  >
+                    ${this._localize("ui.card.timer.actions.finish")}
+                  </ha-button>
+                `
+              : nothing
+          }
+        </div>
       </div>
     `;
   }
@@ -148,20 +176,21 @@ class MoreInfoTimer extends LitElement {
     });
   }
 
-  static styles = css`
-    ha-duration-input {
-      display: flex;
-      justify-content: center;
-      margin: var(--ha-space-4) 0 var(--ha-space-2);
-    }
-    .actions {
-      margin: var(--ha-space-2) 0;
-      display: flex;
-      flex-wrap: wrap;
-      gap: var(--ha-space-2);
-      justify-content: center;
-    }
-  `;
+  static styles = [
+    moreInfoControlStyle,
+    css`
+      ha-duration-input {
+        display: flex;
+        justify-content: center;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--ha-space-2);
+        justify-content: center;
+      }
+    `,
+  ];
 }
 
 declare global {

--- a/src/dialogs/more-info/controls/more-info-timer.ts
+++ b/src/dialogs/more-info/controls/more-info-timer.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
 import { TimerRemainingTimeController } from "../../../common/controllers/timer-remaining-time-controller";
 import { consumeLocalize } from "../../../common/decorators/consume-context-entry";
 import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
@@ -12,7 +13,11 @@ import "../../../components/ha-duration-input";
 import type { HaDurationData } from "../../../components/ha-duration-input";
 import { apiContext, formattersContext } from "../../../data/context";
 import type { TimerEntity } from "../../../data/timer";
-import { computeDisplayTimer, timerDurationData } from "../../../data/timer";
+import {
+  computeDisplayTimer,
+  timerDurationData,
+  timerJustFinished,
+} from "../../../data/timer";
 import type {
   HomeAssistantApi,
   HomeAssistantFormatters,
@@ -39,6 +44,8 @@ class MoreInfoTimer extends LitElement {
 
   @state() private _duration?: HaDurationData;
 
+  @state() private _finished = false;
+
   private _remainingTime = new TimerRemainingTimeController(this);
 
   protected willUpdate(changedProps: PropertyValues<this>): void {
@@ -50,7 +57,17 @@ class MoreInfoTimer extends LitElement {
     }
     if (changedProps.has("stateObj")) {
       this._remainingTime.setStateObj(this.stateObj);
+      if (
+        this.stateObj &&
+        timerJustFinished(changedProps.get("stateObj"), this.stateObj)
+      ) {
+        this._finished = true;
+      }
     }
+  }
+
+  private _finishedAnimationEnded(): void {
+    this._finished = false;
   }
 
   protected render() {
@@ -62,6 +79,7 @@ class MoreInfoTimer extends LitElement {
 
     return html`
       <ha-more-info-state-header
+        class=${classMap({ finished: this._finished })}
         .stateObj=${this.stateObj}
         .stateOverride=${
           computeDisplayTimer(
@@ -70,6 +88,7 @@ class MoreInfoTimer extends LitElement {
             this._remainingTime.timeRemaining
           ) ?? undefined
         }
+        @animationend=${this._finishedAnimationEnded}
       ></ha-more-info-state-header>
       <div class="controls">
         <ha-duration-input
@@ -188,6 +207,19 @@ class MoreInfoTimer extends LitElement {
         flex-wrap: wrap;
         gap: var(--ha-space-2);
         justify-content: center;
+      }
+      ha-more-info-state-header.finished {
+        animation: timer-finished-pulse 0.5s ease-in-out 2;
+      }
+      @keyframes timer-finished-pulse {
+        50% {
+          color: var(--error-color);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        ha-more-info-state-header.finished {
+          animation: none;
+        }
       }
     `,
   ];

--- a/src/dialogs/more-info/favorites.ts
+++ b/src/dialogs/more-info/favorites.ts
@@ -30,6 +30,8 @@ import {
   lightSupportsColorMode,
   lightSupportsFavoriteColors,
 } from "../../data/light";
+import type { TimerEntity } from "../../data/timer";
+import { normalizeTimerPresets } from "../../data/timer";
 import type { ValveEntity } from "../../data/valve";
 import {
   DEFAULT_VALVE_FAVORITE_POSITIONS,
@@ -58,6 +60,8 @@ export interface FavoritesDialogHandler {
   domain: FavoritesDomain;
   supports: (stateObj: HassEntity) => boolean;
   hasCustomFavorites: (entry: ExtEntityRegistryEntry) => boolean;
+  // Omitted means there is always something to copy (domains with defaults).
+  canCopy?: (entry: ExtEntityRegistryEntry) => boolean;
   getResetOptions: (
     stateObj: HassEntity
   ) => Partial<Record<FavoriteOption, undefined>>;
@@ -315,6 +319,25 @@ const valveFavoritesHandler = createNumericFavoritesDialogHandler<ValveEntity>({
   ],
 });
 
+const timerFavoritesHandler: FavoritesDialogHandler = {
+  ...createNumericFavoritesDialogHandler<TimerEntity>({
+    domain: "timer",
+    supports: () => true,
+    specs: [
+      {
+        option: "presets",
+        supports: () => true,
+        getStoredFavorites: (entry) => entry.options?.timer?.presets,
+        getFavorites: (entry) =>
+          normalizeTimerPresets(entry.options?.timer?.presets),
+      },
+    ],
+  }),
+  // No default presets, so an empty timer has nothing to copy.
+  canCopy: (entry) =>
+    normalizeTimerPresets(entry.options?.timer?.presets).length > 0,
+};
+
 const FAVORITES_DIALOG_HANDLERS: Record<
   FavoritesDomain,
   FavoritesDialogHandler
@@ -322,6 +345,7 @@ const FAVORITES_DIALOG_HANDLERS: Record<
   cover: coverFavoritesHandler,
   light: lightFavoritesHandler,
   valve: valveFavoritesHandler,
+  timer: timerFavoritesHandler,
 };
 
 export const getFavoritesDialogHandler = (

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -636,6 +636,11 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
         ? !favoritesHandler.hasCustomFavorites(favoritesContext.entry)
         : false;
 
+    const copyFavoritesDisabled =
+      favoritesContext && favoritesHandler?.canCopy
+        ? !favoritesHandler.canCopy(favoritesContext.entry)
+        : false;
+
     const isRTL = computeRTL(
       this.hass.language,
       this.hass.translationMetadata.translations
@@ -790,7 +795,10 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
                                     ></ha-svg-icon>
                                     ${favoritesLabels?.reset}
                                   </ha-dropdown-item>
-                                  <ha-dropdown-item value="copy_favorites">
+                                  <ha-dropdown-item
+                                    value="copy_favorites"
+                                    .disabled=${copyFavoritesDisabled}
+                                  >
                                     <ha-svg-icon
                                       slot="icon"
                                       .path=${mdiContentDuplicate}

--- a/src/panels/lovelace/card-features/hui-timer-actions-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-timer-actions-card-feature.ts
@@ -1,0 +1,193 @@
+import { consume } from "@lit/context";
+import {
+  mdiFlagCheckered,
+  mdiPause,
+  mdiPlay,
+  mdiRestart,
+  mdiStop,
+} from "@mdi/js";
+import type { HassEntity } from "home-assistant-js-websocket";
+import type { TemplateResult } from "lit";
+import { LitElement, html } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import {
+  consumeEntityState,
+  consumeLocalize,
+} from "../../../common/decorators/consume-context-entry";
+import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
+import { computeDomain } from "../../../common/entity/compute_domain";
+import type { LocalizeFunc } from "../../../common/translations/localize";
+import "../../../components/ha-control-button";
+import type { HaControlButton } from "../../../components/ha-control-button";
+import "../../../components/ha-control-button-group";
+import "../../../components/ha-svg-icon";
+import { apiContext } from "../../../data/context";
+import { UNAVAILABLE } from "../../../data/entity/entity";
+import type { HomeAssistant, HomeAssistantApi } from "../../../types";
+import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
+import { cardFeatureStyles } from "./common/card-feature-styles";
+import {
+  DEFAULT_TIMER_ACTIONS,
+  TIMER_ACTIONS,
+  type TimerActionsCardFeatureConfig,
+  type LovelaceCardFeatureContext,
+} from "./types";
+
+const supportsTimerActionsCardFeatureFromState = (stateObj: HassEntity) => {
+  const domain = computeDomain(stateObj.entity_id);
+  return domain === "timer";
+};
+
+export const supportsTimerActionsCardFeature = (
+  hass: HomeAssistant,
+  context: LovelaceCardFeatureContext
+) => {
+  const stateObj = context.entity_id
+    ? hass.states[context.entity_id]
+    : undefined;
+  if (!stateObj) return false;
+  return supportsTimerActionsCardFeatureFromState(stateObj);
+};
+
+interface TimerButton {
+  translationKey: string;
+  icon: string;
+  serviceName: string;
+  disabled: boolean;
+}
+
+export const TIMER_ACTIONS_BUTTON: Record<
+  string,
+  (stateObj: HassEntity) => TimerButton
+> = {
+  // timer.start starts an idle timer, resumes a paused one, and restarts an
+  // active one with its configured duration.
+  start: (stateObj) =>
+    stateObj.state === "active"
+      ? {
+          translationKey: "restart",
+          icon: mdiRestart,
+          serviceName: "start",
+          disabled: false,
+        }
+      : {
+          translationKey: "start",
+          icon: mdiPlay,
+          serviceName: "start",
+          disabled: false,
+        },
+  pause: (stateObj) => ({
+    translationKey: "pause",
+    icon: mdiPause,
+    serviceName: "pause",
+    disabled: stateObj.state !== "active",
+  }),
+  cancel: (stateObj) => ({
+    translationKey: "cancel",
+    icon: mdiStop,
+    serviceName: "cancel",
+    disabled: stateObj.state === "idle",
+  }),
+  finish: (stateObj) => ({
+    translationKey: "finish",
+    icon: mdiFlagCheckered,
+    serviceName: "finish",
+    disabled: stateObj.state === "idle",
+  }),
+};
+
+@customElement("hui-timer-actions-card-feature")
+class HuiTimerActionsCardFeature
+  extends LitElement
+  implements LovelaceCardFeature
+{
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state()
+  @consumeEntityState({ entityIdPath: ["context", "entity_id"] })
+  private _stateObj?: HassEntity;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
+
+  @state()
+  @consume({ context: apiContext, subscribe: true })
+  private _api!: HomeAssistantApi;
+
+  @state() private _config?: TimerActionsCardFeatureConfig;
+
+  public static async getConfigElement(): Promise<LovelaceCardFeatureEditor> {
+    await import("../editor/config-elements/hui-timer-actions-card-feature-editor");
+    return document.createElement("hui-timer-actions-card-feature-editor");
+  }
+
+  static getStubConfig(): TimerActionsCardFeatureConfig {
+    return {
+      type: "timer-actions",
+    };
+  }
+
+  public setConfig(config: TimerActionsCardFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  protected render(): TemplateResult | null {
+    if (
+      !this._config ||
+      !this.context ||
+      !this._stateObj ||
+      !supportsTimerActionsCardFeatureFromState(this._stateObj)
+    ) {
+      return null;
+    }
+
+    const actions = this._config?.actions ?? DEFAULT_TIMER_ACTIONS;
+
+    return html`
+      <ha-control-button-group>
+        ${actions
+          .filter((action) => TIMER_ACTIONS.includes(action))
+          .map((action) => {
+            const button = TIMER_ACTIONS_BUTTON[action](this._stateObj!);
+            return html`
+              <ha-control-button
+                .entry=${button}
+                .label=${this._localize(
+                  // @ts-ignore
+                  `ui.card.timer.actions.${button.translationKey}`
+                )}
+                @click=${this._onActionTap}
+                .disabled=${
+                  button.disabled || this._stateObj?.state === UNAVAILABLE
+                }
+              >
+                <ha-svg-icon .path=${button.icon}></ha-svg-icon>
+              </ha-control-button>
+            `;
+          })}
+      </ha-control-button-group>
+    `;
+  }
+
+  private _onActionTap(
+    ev: MouseEvent &
+      HASSDomCurrentTargetEvent<HaControlButton & { entry: TimerButton }>
+  ): void {
+    ev.stopPropagation();
+    this._api.callService("timer", ev.currentTarget.entry.serviceName, {
+      entity_id: this._stateObj!.entity_id,
+    });
+  }
+
+  static styles = cardFeatureStyles;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-timer-actions-card-feature": HuiTimerActionsCardFeature;
+  }
+}

--- a/src/panels/lovelace/card-features/hui-timer-presets-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-timer-presets-card-feature.ts
@@ -53,26 +53,28 @@ export const supportsTimerPresetsCardFeature = (
 };
 
 interface TimerPreset {
-  duration: string | number;
+  duration: number;
   label: string;
 }
 
-// Presets with an unparseable or zero duration are dropped. Labels are
-// normalized to hours/minutes/seconds so numeric presets ("90") render the
-// same as their string form ("0:01:30").
+// Presets with an unparseable or zero duration are dropped. Durations are
+// normalized to seconds so what is shown and what is sent to timer.start
+// always match, and numeric presets ("90") render the same as their string
+// form ("0:01:30").
 export const computeTimerPresets = (
   presets: (string | number)[],
   locale: FrontendLocaleData
 ): TimerPreset[] =>
   presets.reduce<TimerPreset[]>((result, preset) => {
     const durationData = createDurationData(preset);
-    if (durationData && durationDataToSeconds(durationData) > 0) {
+    const seconds = durationData ? durationDataToSeconds(durationData) : 0;
+    if (durationData && seconds > 0) {
       const label = formatNumericDuration(
         locale,
         normalizeTimerDuration(durationData)
       );
       if (label) {
-        result.push({ duration: preset, label });
+        result.push({ duration: seconds, label });
       }
     }
     return result;

--- a/src/panels/lovelace/card-features/hui-timer-presets-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-timer-presets-card-feature.ts
@@ -1,12 +1,13 @@
 import { consume } from "@lit/context";
 import { mdiTimerOutline } from "@mdi/js";
-import type { HassEntity } from "home-assistant-js-websocket";
+import type {
+  Connection,
+  HassEntity,
+  UnsubscribeFunc,
+} from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import memoizeOne from "memoize-one";
-import { createDurationData } from "../../../common/datetime/create_duration_data";
-import { durationDataToSeconds } from "../../../common/datetime/duration_to_seconds";
-import { formatNumericDuration } from "../../../common/datetime/format_duration";
 import {
   consumeEntityState,
   consumeLocalize,
@@ -20,13 +21,20 @@ import type { HaControlButton } from "../../../components/ha-control-button";
 import "../../../components/ha-control-button-group";
 import "../../../components/ha-control-select-menu";
 import "../../../components/ha-svg-icon";
-import { apiContext, internationalizationContext } from "../../../data/context";
+import {
+  apiContext,
+  connectionContext,
+  internationalizationContext,
+} from "../../../data/context";
 import { UNAVAILABLE } from "../../../data/entity/entity";
-import { normalizeTimerDuration } from "../../../data/timer";
+import type { EntityRegistryEntry } from "../../../data/entity/entity_registry";
+import { subscribeEntityRegistry } from "../../../data/entity/entity_registry";
+import { normalizeTimerPresets, timerPresetLabel } from "../../../data/timer";
 import type { FrontendLocaleData } from "../../../data/translation";
 import type {
   HomeAssistant,
   HomeAssistantApi,
+  HomeAssistantConnection,
   HomeAssistantInternationalization,
 } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
@@ -52,34 +60,6 @@ export const supportsTimerPresetsCardFeature = (
   return supportsTimerPresetsCardFeatureFromState(stateObj);
 };
 
-interface TimerPreset {
-  duration: number;
-  label: string;
-}
-
-// Presets with an unparseable or zero duration are dropped. Durations are
-// normalized to seconds so what is shown and what is sent to timer.start
-// always match, and numeric presets ("90") render the same as their string
-// form ("0:01:30").
-export const computeTimerPresets = (
-  presets: (string | number)[],
-  locale: FrontendLocaleData
-): TimerPreset[] =>
-  presets.reduce<TimerPreset[]>((result, preset) => {
-    const durationData = createDurationData(preset);
-    const seconds = durationData ? durationDataToSeconds(durationData) : 0;
-    if (durationData && seconds > 0) {
-      const label = formatNumericDuration(
-        locale,
-        normalizeTimerDuration(durationData)
-      );
-      if (label) {
-        result.push({ duration: seconds, label });
-      }
-    }
-    return result;
-  }, []);
-
 @customElement("hui-timer-presets-card-feature")
 class HuiTimerPresetsCardFeature
   extends LitElement
@@ -100,6 +80,13 @@ class HuiTimerPresetsCardFeature
   private _api!: HomeAssistantApi;
 
   @state()
+  @consume({ context: connectionContext, subscribe: true })
+  @transform<HomeAssistantConnection, Connection>({
+    transformer: ({ connection }) => connection,
+  })
+  private _connection?: Connection;
+
+  @state()
   @consume({ context: internationalizationContext, subscribe: true })
   @transform<HomeAssistantInternationalization, FrontendLocaleData>({
     transformer: ({ locale }) => locale,
@@ -108,10 +95,57 @@ class HuiTimerPresetsCardFeature
 
   @state() private _config?: TimerPresetsCardFeatureConfig;
 
-  private _presets = memoizeOne(
-    (presets: (string | number)[] | undefined, locale: FrontendLocaleData) =>
-      computeTimerPresets(presets ?? [], locale)
-  );
+  @state() private _entry?: EntityRegistryEntry | null;
+
+  @state() private _presets: number[] = [];
+
+  private _unsubEntityRegistry?: UnsubscribeFunc;
+
+  public connectedCallback() {
+    super.connectedCallback();
+    this._subscribeEntityEntry();
+  }
+
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    this._unsubscribeEntityRegistry();
+  }
+
+  private _unsubscribeEntityRegistry() {
+    if (this._unsubEntityRegistry) {
+      this._unsubEntityRegistry();
+      this._unsubEntityRegistry = undefined;
+    }
+  }
+
+  private _subscribeEntityEntry() {
+    if (this._connection && this.context?.entity_id) {
+      const id = this.context.entity_id;
+      try {
+        this._unsubEntityRegistry = subscribeEntityRegistry(
+          this._connection,
+          (entries) => {
+            this._entry = entries.find((e) => e.entity_id === id) ?? null;
+          }
+        );
+      } catch (_e) {
+        this._entry = null;
+      }
+    }
+  }
+
+  protected updated(changedProps: PropertyValues): void {
+    if (changedProps.has("context") || changedProps.has("_connection")) {
+      this._unsubscribeEntityRegistry();
+      this._subscribeEntityEntry();
+    }
+
+    if (changedProps.has("_entry")) {
+      this._presets = normalizeTimerPresets(
+        this._entry?.options?.timer?.presets
+      );
+    }
+  }
 
   public static async getConfigElement(): Promise<LovelaceCardFeatureEditor> {
     await import("../editor/config-elements/hui-timer-presets-card-feature-editor");
@@ -121,7 +155,6 @@ class HuiTimerPresetsCardFeature
   static getStubConfig(): TimerPresetsCardFeatureConfig {
     return {
       type: "timer-presets",
-      presets: ["0:01:00", "0:05:00", "0:10:00"],
     };
   }
 
@@ -143,7 +176,7 @@ class HuiTimerPresetsCardFeature
       return nothing;
     }
 
-    const presets = this._presets(this._config.presets, this._locale);
+    const presets = this._presets;
 
     if (!presets.length) {
       return nothing;
@@ -155,8 +188,8 @@ class HuiTimerPresetsCardFeature
           show-arrow
           .label=${this._localize("ui.card.timer.presets")}
           .options=${presets.map((preset) => ({
-            value: String(preset.duration),
-            label: preset.label,
+            value: String(preset),
+            label: timerPresetLabel(this._locale!, preset),
           }))}
           .disabled=${this._stateObj.state === UNAVAILABLE}
           @wa-select=${this._onPresetSelect}
@@ -168,27 +201,29 @@ class HuiTimerPresetsCardFeature
 
     return html`
       <ha-control-button-group>
-        ${presets.map(
-          (preset) => html`
+        ${presets.map((preset) => {
+          const label = timerPresetLabel(this._locale!, preset);
+          return html`
             <ha-control-button
               .preset=${preset}
-              .label=${this._localize("ui.card.timer.start_preset", {
-                duration: preset.label,
-              })}
+              .label=${this._localize(
+                "ui.dialogs.more_info_control.timer.preset.set",
+                { value: label }
+              )}
               .disabled=${this._stateObj!.state === UNAVAILABLE}
               @click=${this._onPresetTap}
             >
-              ${preset.label}
+              ${label}
             </ha-control-button>
-          `
-        )}
+          `;
+        })}
       </ha-control-button-group>
     `;
   }
 
   private _onPresetTap(
     ev: MouseEvent &
-      HASSDomCurrentTargetEvent<HaControlButton & { preset: TimerPreset }>
+      HASSDomCurrentTargetEvent<HaControlButton & { preset: number }>
   ): void {
     ev.stopPropagation();
     this._startPreset(ev.currentTarget.preset);
@@ -197,20 +232,19 @@ class HuiTimerPresetsCardFeature
   private _onPresetSelect(ev: CustomEvent<{ item?: { value: string } }>): void {
     ev.stopPropagation();
     const value = ev.detail.item?.value;
-    if (value === undefined || !this._config || !this._locale) {
+    if (value === undefined) {
       return;
     }
-    const presets = this._presets(this._config.presets, this._locale);
-    const preset = presets.find((p) => String(p.duration) === value);
-    if (preset) {
+    const preset = this._presets.find((p) => String(p) === value);
+    if (preset !== undefined) {
       this._startPreset(preset);
     }
   }
 
-  private _startPreset(preset: TimerPreset): void {
+  private _startPreset(preset: number): void {
     this._api.callService("timer", "start", {
       entity_id: this._stateObj!.entity_id,
-      duration: preset.duration,
+      duration: preset,
     });
   }
 

--- a/src/panels/lovelace/card-features/hui-timer-presets-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-timer-presets-card-feature.ts
@@ -1,0 +1,222 @@
+import { consume } from "@lit/context";
+import { mdiTimerOutline } from "@mdi/js";
+import type { HassEntity } from "home-assistant-js-websocket";
+import { LitElement, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { createDurationData } from "../../../common/datetime/create_duration_data";
+import { durationDataToSeconds } from "../../../common/datetime/duration_to_seconds";
+import { formatNumericDuration } from "../../../common/datetime/format_duration";
+import {
+  consumeEntityState,
+  consumeLocalize,
+} from "../../../common/decorators/consume-context-entry";
+import { transform } from "../../../common/decorators/transform";
+import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
+import { computeDomain } from "../../../common/entity/compute_domain";
+import type { LocalizeFunc } from "../../../common/translations/localize";
+import "../../../components/ha-control-button";
+import type { HaControlButton } from "../../../components/ha-control-button";
+import "../../../components/ha-control-button-group";
+import "../../../components/ha-control-select-menu";
+import "../../../components/ha-svg-icon";
+import { apiContext, internationalizationContext } from "../../../data/context";
+import { UNAVAILABLE } from "../../../data/entity/entity";
+import { normalizeTimerDuration } from "../../../data/timer";
+import type { FrontendLocaleData } from "../../../data/translation";
+import type {
+  HomeAssistant,
+  HomeAssistantApi,
+  HomeAssistantInternationalization,
+} from "../../../types";
+import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
+import { cardFeatureStyles } from "./common/card-feature-styles";
+import type {
+  LovelaceCardFeatureContext,
+  TimerPresetsCardFeatureConfig,
+} from "./types";
+
+const supportsTimerPresetsCardFeatureFromState = (stateObj: HassEntity) => {
+  const domain = computeDomain(stateObj.entity_id);
+  return domain === "timer";
+};
+
+export const supportsTimerPresetsCardFeature = (
+  hass: HomeAssistant,
+  context: LovelaceCardFeatureContext
+) => {
+  const stateObj = context.entity_id
+    ? hass.states[context.entity_id]
+    : undefined;
+  if (!stateObj) return false;
+  return supportsTimerPresetsCardFeatureFromState(stateObj);
+};
+
+interface TimerPreset {
+  duration: string | number;
+  label: string;
+}
+
+// Presets with an unparseable or zero duration are dropped. Labels are
+// normalized to hours/minutes/seconds so numeric presets ("90") render the
+// same as their string form ("0:01:30").
+export const computeTimerPresets = (
+  presets: (string | number)[],
+  locale: FrontendLocaleData
+): TimerPreset[] =>
+  presets.reduce<TimerPreset[]>((result, preset) => {
+    const durationData = createDurationData(preset);
+    if (durationData && durationDataToSeconds(durationData) > 0) {
+      const label = formatNumericDuration(
+        locale,
+        normalizeTimerDuration(durationData)
+      );
+      if (label) {
+        result.push({ duration: preset, label });
+      }
+    }
+    return result;
+  }, []);
+
+@customElement("hui-timer-presets-card-feature")
+class HuiTimerPresetsCardFeature
+  extends LitElement
+  implements LovelaceCardFeature
+{
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state()
+  @consumeEntityState({ entityIdPath: ["context", "entity_id"] })
+  private _stateObj?: HassEntity;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
+
+  @state()
+  @consume({ context: apiContext, subscribe: true })
+  private _api!: HomeAssistantApi;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale?: FrontendLocaleData;
+
+  @state() private _config?: TimerPresetsCardFeatureConfig;
+
+  private _presets = memoizeOne(
+    (presets: (string | number)[] | undefined, locale: FrontendLocaleData) =>
+      computeTimerPresets(presets ?? [], locale)
+  );
+
+  public static async getConfigElement(): Promise<LovelaceCardFeatureEditor> {
+    await import("../editor/config-elements/hui-timer-presets-card-feature-editor");
+    return document.createElement("hui-timer-presets-card-feature-editor");
+  }
+
+  static getStubConfig(): TimerPresetsCardFeatureConfig {
+    return {
+      type: "timer-presets",
+      presets: ["0:01:00", "0:05:00", "0:10:00"],
+    };
+  }
+
+  public setConfig(config: TimerPresetsCardFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  protected render() {
+    if (
+      !this._config ||
+      !this.context ||
+      !this._stateObj ||
+      !this._locale ||
+      !supportsTimerPresetsCardFeatureFromState(this._stateObj)
+    ) {
+      return nothing;
+    }
+
+    const presets = this._presets(this._config.presets, this._locale);
+
+    if (!presets.length) {
+      return nothing;
+    }
+
+    if (this._config.style === "dropdown") {
+      return html`
+        <ha-control-select-menu
+          show-arrow
+          .label=${this._localize("ui.card.timer.presets")}
+          .options=${presets.map((preset) => ({
+            value: String(preset.duration),
+            label: preset.label,
+          }))}
+          .disabled=${this._stateObj.state === UNAVAILABLE}
+          @wa-select=${this._onPresetSelect}
+        >
+          <ha-svg-icon slot="icon" .path=${mdiTimerOutline}></ha-svg-icon>
+        </ha-control-select-menu>
+      `;
+    }
+
+    return html`
+      <ha-control-button-group>
+        ${presets.map(
+          (preset) => html`
+            <ha-control-button
+              .preset=${preset}
+              .label=${this._localize("ui.card.timer.start_preset", {
+                duration: preset.label,
+              })}
+              .disabled=${this._stateObj!.state === UNAVAILABLE}
+              @click=${this._onPresetTap}
+            >
+              ${preset.label}
+            </ha-control-button>
+          `
+        )}
+      </ha-control-button-group>
+    `;
+  }
+
+  private _onPresetTap(
+    ev: MouseEvent &
+      HASSDomCurrentTargetEvent<HaControlButton & { preset: TimerPreset }>
+  ): void {
+    ev.stopPropagation();
+    this._startPreset(ev.currentTarget.preset);
+  }
+
+  private _onPresetSelect(ev: CustomEvent<{ item?: { value: string } }>): void {
+    ev.stopPropagation();
+    const value = ev.detail.item?.value;
+    if (value === undefined || !this._config || !this._locale) {
+      return;
+    }
+    const presets = this._presets(this._config.presets, this._locale);
+    const preset = presets.find((p) => String(p.duration) === value);
+    if (preset) {
+      this._startPreset(preset);
+    }
+  }
+
+  private _startPreset(preset: TimerPreset): void {
+    this._api.callService("timer", "start", {
+      entity_id: this._stateObj!.entity_id,
+      duration: preset.duration,
+    });
+  }
+
+  static styles = cardFeatureStyles;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-timer-presets-card-feature": HuiTimerPresetsCardFeature;
+  }
+}

--- a/src/panels/lovelace/card-features/registry.ts
+++ b/src/panels/lovelace/card-features/registry.ts
@@ -40,6 +40,8 @@ import { supportsSelectOptionsCardFeature } from "./hui-select-options-card-feat
 import { supportsTemperatureForecastCardFeature } from "./hui-temperature-forecast-card-feature";
 import { supportsTargetHumidityCardFeature } from "./hui-target-humidity-card-feature";
 import { supportsTargetTemperatureCardFeature } from "./hui-target-temperature-card-feature";
+import { supportsTimerActionsCardFeature } from "./hui-timer-actions-card-feature";
+import { supportsTimerPresetsCardFeature } from "./hui-timer-presets-card-feature";
 import { supportsToggleCardFeature } from "./hui-toggle-card-feature";
 import { supportsTrendGraphCardFeature } from "./hui-trend-graph-card-feature";
 import { supportsUpdateActionsCardFeature } from "./hui-update-actions-card-feature";
@@ -104,6 +106,8 @@ export const UI_FEATURE_TYPES = [
   "trend-graph",
   "target-humidity",
   "target-temperature",
+  "timer-actions",
+  "timer-presets",
   "toggle",
   "update-actions",
   "vacuum-commands",
@@ -160,6 +164,8 @@ export const SUPPORTS_FEATURE_TYPES: Record<UiFeatureType, SupportsFeature> = {
   "target-humidity": supportsTargetHumidityCardFeature,
   "target-temperature": supportsTargetTemperatureCardFeature,
   "temperature-forecast": supportsTemperatureForecastCardFeature,
+  "timer-actions": supportsTimerActionsCardFeature,
+  "timer-presets": supportsTimerPresetsCardFeature,
   toggle: supportsToggleCardFeature,
   "update-actions": supportsUpdateActionsCardFeature,
   "vacuum-commands": supportsVacuumCommandsCardFeature,

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -213,7 +213,6 @@ export interface TimerActionsCardFeatureConfig {
 export interface TimerPresetsCardFeatureConfig {
   type: "timer-presets";
   style?: "buttons" | "dropdown";
-  presets?: (string | number)[];
 }
 
 export interface WaterHeaterOperationModesCardFeatureConfig {

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -195,6 +195,27 @@ export interface ToggleCardFeatureConfig {
   type: "toggle";
 }
 
+export const TIMER_ACTIONS = ["start", "pause", "cancel", "finish"] as const;
+
+export type TimerActions = (typeof TIMER_ACTIONS)[number];
+
+export const DEFAULT_TIMER_ACTIONS: TimerActions[] = [
+  "start",
+  "pause",
+  "cancel",
+];
+
+export interface TimerActionsCardFeatureConfig {
+  type: "timer-actions";
+  actions?: TimerActions[];
+}
+
+export interface TimerPresetsCardFeatureConfig {
+  type: "timer-presets";
+  style?: "buttons" | "dropdown";
+  presets?: (string | number)[];
+}
+
 export interface WaterHeaterOperationModesCardFeatureConfig {
   type: "water-heater-operation-modes";
   style?: "dropdown" | "icons";
@@ -359,6 +380,8 @@ export type LovelaceCardFeatureConfig =
   | TrendGraphCardFeatureConfig
   | TargetHumidityCardFeatureConfig
   | TargetTemperatureCardFeatureConfig
+  | TimerActionsCardFeatureConfig
+  | TimerPresetsCardFeatureConfig
   | ToggleCardFeatureConfig
   | UpdateActionsCardFeatureConfig
   | VacuumCommandsCardFeatureConfig

--- a/src/panels/lovelace/card-suggestions/hui-tile-card-suggestions.ts
+++ b/src/panels/lovelace/card-suggestions/hui-tile-card-suggestions.ts
@@ -83,6 +83,7 @@ const DOMAIN_VARIANTS: Record<string, TileVariant[]> = {
   ],
   alarm_control_panel: [TILE_VARIANT, ["alarm-modes"]],
   counter: [TILE_VARIANT, ["counter-actions"]],
+  timer: [TILE_VARIANT, ["timer-actions"]],
   input_select: SELECT_VARIANTS,
   select: SELECT_VARIANTS,
   input_number: NUMERIC_INPUT_VARIANTS,

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -1,4 +1,5 @@
 import type { HassEntity } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
@@ -18,6 +19,7 @@ import "../../../components/tile/ha-tile-container";
 import "../../../components/tile/ha-tile-icon";
 import "../../../components/tile/ha-tile-info";
 import { cameraUrlWithWidthHeight } from "../../../data/camera";
+import { timerJustFinished } from "../../../data/timer";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import "../../../state-display/state-display";
 import type { HomeAssistant } from "../../../types";
@@ -90,6 +92,31 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
   @state() private _config?: TileCardConfig;
 
   @state() private _featureContext: LovelaceCardFeatureContext = {};
+
+  @state() private _timerFinished = false;
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (
+      !changedProps.has("hass") ||
+      !this._config?.entity ||
+      computeDomain(this._config.entity) !== "timer"
+    ) {
+      return;
+    }
+    const stateObj = this.hass?.states[this._config.entity];
+    const oldStateObj = (changedProps.get("hass") as HomeAssistant | undefined)
+      ?.states[this._config.entity];
+    if (stateObj && timerJustFinished(oldStateObj, stateObj)) {
+      this._timerFinished = true;
+    }
+  }
+
+  private _timerFinishedAnimationEnded(ev: AnimationEvent): void {
+    if (ev.animationName === "timer-finished-pulse") {
+      this._timerFinished = false;
+    }
+  }
 
   public setConfig(config: TileCardConfig): void {
     if (!config.entity) {
@@ -312,7 +339,11 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
             .imageUrl=${imageUrl}
             data-domain=${ifDefined(domain)}
             data-state=${ifDefined(stateObj?.state)}
-            class=${classMap({ image: hasImage })}
+            class=${classMap({
+              image: hasImage,
+              "timer-finished": this._timerFinished,
+            })}
+            @animationend=${this._timerFinishedAnimationEnded}
           >
             ${
               hasImage
@@ -392,6 +423,22 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       ha-tile-icon[data-domain="alarm_control_panel"][data-state="triggered"],
       ha-tile-icon[data-domain="lock"][data-state="jammed"] {
         animation: pulse 1s infinite;
+      }
+
+      ha-tile-icon.timer-finished {
+        animation: timer-finished-pulse 0.5s ease-in-out 2;
+      }
+
+      @keyframes timer-finished-pulse {
+        50% {
+          --tile-icon-color: var(--error-color);
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        ha-tile-icon.timer-finished {
+          animation: none;
+        }
       }
 
       /* Make sure we display the whole image */

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -437,7 +437,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
 
       @media (prefers-reduced-motion: reduce) {
         ha-tile-icon.timer-finished {
-          animation: none;
+          animation-duration: var(--ha-animation-duration-none);
         }
       }
 

--- a/src/panels/lovelace/create-element/create-card-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-card-feature-element.ts
@@ -35,6 +35,8 @@ import "../card-features/hui-numeric-input-card-feature";
 import "../card-features/hui-select-options-card-feature";
 import "../card-features/hui-target-humidity-card-feature";
 import "../card-features/hui-target-temperature-card-feature";
+import "../card-features/hui-timer-actions-card-feature";
+import "../card-features/hui-timer-presets-card-feature";
 import "../card-features/hui-toggle-card-feature";
 import "../card-features/hui-update-actions-card-feature";
 import "../card-features/hui-vacuum-commands-card-feature";
@@ -98,6 +100,8 @@ const TYPES = new Set<LovelaceCardFeatureConfig["type"]>([
   "target-humidity",
   "target-temperature",
   "temperature-forecast",
+  "timer-actions",
+  "timer-presets",
   "toggle",
   "update-actions",
   "vacuum-commands",

--- a/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
@@ -64,6 +64,8 @@ import { supportsNumericInputCardFeature } from "../../card-features/hui-numeric
 import { supportsSelectOptionsCardFeature } from "../../card-features/hui-select-options-card-feature";
 import { supportsTargetHumidityCardFeature } from "../../card-features/hui-target-humidity-card-feature";
 import { supportsTargetTemperatureCardFeature } from "../../card-features/hui-target-temperature-card-feature";
+import { supportsTimerActionsCardFeature } from "../../card-features/hui-timer-actions-card-feature";
+import { supportsTimerPresetsCardFeature } from "../../card-features/hui-timer-presets-card-feature";
 import { supportsToggleCardFeature } from "../../card-features/hui-toggle-card-feature";
 import { supportsTrendGraphCardFeature } from "../../card-features/hui-trend-graph-card-feature";
 import { supportsUpdateActionsCardFeature } from "../../card-features/hui-update-actions-card-feature";
@@ -130,6 +132,8 @@ const UI_FEATURE_TYPES = [
   "target-humidity",
   "target-temperature",
   "temperature-forecast",
+  "timer-actions",
+  "timer-presets",
   "toggle",
   "update-actions",
   "vacuum-commands",
@@ -169,6 +173,8 @@ const EDITABLES_FEATURE_TYPES = new Set<UiFeatureTypes>([
   "media-player-volume-slider",
   "numeric-input",
   "select-options",
+  "timer-actions",
+  "timer-presets",
   "trend-graph",
   "update-actions",
   "vacuum-commands",
@@ -224,6 +230,8 @@ const SUPPORTS_FEATURE_TYPES: Record<
   "target-humidity": supportsTargetHumidityCardFeature,
   "target-temperature": supportsTargetTemperatureCardFeature,
   "temperature-forecast": supportsTemperatureForecastCardFeature,
+  "timer-actions": supportsTimerActionsCardFeature,
+  "timer-presets": supportsTimerPresetsCardFeature,
   toggle: supportsToggleCardFeature,
   "update-actions": supportsUpdateActionsCardFeature,
   "vacuum-commands": supportsVacuumCommandsCardFeature,

--- a/src/panels/lovelace/editor/config-elements/hui-timer-actions-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-timer-actions-card-feature-editor.ts
@@ -1,0 +1,91 @@
+import { html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import type { SchemaUnion } from "../../../../components/ha-form/types";
+import "../../../../components/ha-form/ha-form";
+import type { HomeAssistant } from "../../../../types";
+import type {
+  TimerActionsCardFeatureConfig,
+  LovelaceCardFeatureContext,
+} from "../../card-features/types";
+import {
+  DEFAULT_TIMER_ACTIONS,
+  TIMER_ACTIONS,
+} from "../../card-features/types";
+import type { LovelaceCardFeatureEditor } from "../../types";
+import {
+  customizableListData,
+  customizableListSchema,
+  processCustomizableListValue,
+} from "./customizable-list-feature";
+
+@customElement("hui-timer-actions-card-feature-editor")
+export class HuiTimerActionsCardFeatureEditor
+  extends LitElement
+  implements LovelaceCardFeatureEditor
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state() private _config?: TimerActionsCardFeatureConfig;
+
+  public setConfig(config: TimerActionsCardFeatureConfig): void {
+    this._config = config;
+  }
+
+  private _schema = memoizeOne((localize: LocalizeFunc) =>
+    customizableListSchema({
+      field: "actions",
+      options: TIMER_ACTIONS.map((action) => ({
+        value: action,
+        label: localize(
+          `ui.panel.lovelace.editor.features.types.timer-actions.actions_list.${action}`
+        ),
+      })),
+    })
+  );
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const data = customizableListData(this._config, "actions");
+    const schema = this._schema(this.hass.localize);
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${schema}
+        .computeLabel=${this._computeLabelCallback}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    const config = processCustomizableListValue<TimerActionsCardFeatureConfig>(
+      ev.detail.value,
+      "actions",
+      DEFAULT_TIMER_ACTIONS
+    );
+    fireEvent(this, "config-changed", { config });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) =>
+    this.hass!.localize(
+      `ui.panel.lovelace.editor.features.types.timer-actions.${schema.name}`
+    );
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-timer-actions-card-feature-editor": HuiTimerActionsCardFeatureEditor;
+  }
+}

--- a/src/panels/lovelace/editor/config-elements/hui-timer-presets-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-timer-presets-card-feature-editor.ts
@@ -1,0 +1,235 @@
+import { mdiDelete, mdiDragHorizontalVariant, mdiPlus } from "@mdi/js";
+import type { PropertyValues } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { repeat } from "lit/directives/repeat";
+import memoizeOne from "memoize-one";
+import { createDurationData } from "../../../../common/datetime/create_duration_data";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import { uid } from "../../../../common/util/uid";
+import "../../../../components/ha-button";
+import "../../../../components/ha-duration-input";
+import type { HaDurationData } from "../../../../components/ha-duration-input";
+import "../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../components/ha-form/types";
+import "../../../../components/ha-icon-button";
+import "../../../../components/ha-sortable";
+import "../../../../components/ha-svg-icon";
+import {
+  durationDataToTimerString,
+  normalizeTimerDuration,
+} from "../../../../data/timer";
+import type { HomeAssistant } from "../../../../types";
+import type {
+  LovelaceCardFeatureContext,
+  TimerPresetsCardFeatureConfig,
+} from "../../card-features/types";
+import type { LovelaceCardFeatureEditor } from "../../types";
+
+const NEW_PRESET = "0:05:00";
+
+@customElement("hui-timer-presets-card-feature-editor")
+export class HuiTimerPresetsCardFeatureEditor
+  extends LitElement
+  implements LovelaceCardFeatureEditor
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state() private _config?: TimerPresetsCardFeatureConfig;
+
+  // Stable key per row so rows keep their DOM (and input focus) while other
+  // rows are added, removed, or dragged. Presets are plain strings, so keys
+  // are tracked in a parallel array, mirroring ha-input-multi.
+  @state() private _keys: string[] = [];
+
+  public setConfig(config: TimerPresetsCardFeatureConfig): void {
+    this._config = config;
+  }
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (changedProps.has("_config")) {
+      const length = this._config?.presets?.length ?? 0;
+      if (this._keys.length !== length) {
+        this._keys = Array.from(
+          { length },
+          (_, index) => this._keys[index] ?? uid()
+        );
+      }
+    }
+  }
+
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc) =>
+      [
+        {
+          name: "style",
+          selector: {
+            select: {
+              multiple: false,
+              mode: "list",
+              options: ["buttons", "dropdown"].map((mode) => ({
+                value: mode,
+                label: localize(
+                  `ui.panel.lovelace.editor.features.types.timer-presets.style_list.${mode}`
+                ),
+              })),
+            },
+          },
+        },
+      ] as const
+  );
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const presets = this._config.presets ?? [];
+
+    const data: TimerPresetsCardFeatureConfig = {
+      style: "buttons",
+      ...this._config,
+    };
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._schema(this.hass.localize)}
+        .computeLabel=${this._computeLabelCallback}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      <ha-sortable
+        handle-selector=".handle"
+        draggable-selector=".preset"
+        @item-moved=${this._presetMoved}
+      >
+        <div class="presets">
+          ${repeat(
+            presets,
+            (_preset, index) => this._keys[index],
+            (preset, index) => html`
+              <div class="preset">
+                <ha-svg-icon
+                  class="handle"
+                  .path=${mdiDragHorizontalVariant}
+                ></ha-svg-icon>
+                <ha-duration-input
+                  .data=${this._presetDurationData(preset)}
+                  .index=${index}
+                  required
+                  @value-changed=${this._presetChanged}
+                ></ha-duration-input>
+                <ha-icon-button
+                  .path=${mdiDelete}
+                  .index=${index}
+                  .label=${this.hass!.localize("ui.common.remove")}
+                  @click=${this._removePreset}
+                ></ha-icon-button>
+              </div>
+            `
+          )}
+        </div>
+      </ha-sortable>
+      <ha-button appearance="plain" @click=${this._addPreset}>
+        <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
+        ${this.hass.localize("ui.common.add")}
+      </ha-button>
+    `;
+  }
+
+  private _formChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    fireEvent(this, "config-changed", { config: ev.detail.value });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) =>
+    this.hass!.localize(
+      `ui.panel.lovelace.editor.features.types.timer-presets.${schema.name}`
+    );
+
+  // Normalize before binding so numeric presets ({seconds: 3600}) show as
+  // 1:00:00 instead of overflowing the seconds field, where the input's
+  // carry-over logic would corrupt the value on the next edit.
+  private _presetDurationData(
+    preset: string | number
+  ): HaDurationData | undefined {
+    const durationData = createDurationData(preset);
+    return durationData ? normalizeTimerDuration(durationData) : undefined;
+  }
+
+  private _presetChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const index = (ev.currentTarget as any).index as number;
+    const value = ev.detail.value as HaDurationData | undefined;
+    const presets = [...(this._config!.presets ?? [])];
+    presets[index] = durationDataToTimerString(value ?? {});
+    this._updatePresets(presets);
+  }
+
+  private _presetMoved(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const { oldIndex, newIndex } = ev.detail;
+    const presets = [...(this._config!.presets ?? [])];
+    const [moved] = presets.splice(oldIndex, 1);
+    presets.splice(newIndex, 0, moved);
+    // Move the row's key with it so its DOM identity is preserved.
+    const keys = [...this._keys];
+    const [movedKey] = keys.splice(oldIndex, 1);
+    keys.splice(newIndex, 0, movedKey);
+    this._keys = keys;
+    this._updatePresets(presets);
+  }
+
+  private _removePreset(ev: Event): void {
+    const index = (ev.currentTarget as any).index as number;
+    this._keys = this._keys.filter((_, i) => i !== index);
+    const presets = [...(this._config!.presets ?? [])];
+    presets.splice(index, 1);
+    this._updatePresets(presets);
+  }
+
+  private _addPreset(): void {
+    this._keys = [...this._keys, uid()];
+    this._updatePresets([...(this._config!.presets ?? []), NEW_PRESET]);
+  }
+
+  private _updatePresets(presets: (string | number)[]): void {
+    fireEvent(this, "config-changed", {
+      config: { ...this._config!, presets },
+    });
+  }
+
+  static styles = css`
+    ha-form {
+      display: block;
+      margin-bottom: var(--ha-space-4);
+    }
+    .preset {
+      display: flex;
+      align-items: center;
+      gap: var(--ha-space-2);
+      margin-bottom: var(--ha-space-2);
+    }
+    .preset ha-duration-input {
+      flex: 1;
+    }
+    .handle {
+      cursor: grab;
+      padding: var(--ha-space-2);
+      margin: calc(var(--ha-space-2) * -1);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-timer-presets-card-feature-editor": HuiTimerPresetsCardFeatureEditor;
+  }
+}

--- a/src/panels/lovelace/editor/config-elements/hui-timer-presets-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-timer-presets-card-feature-editor.ts
@@ -1,33 +1,17 @@
-import { mdiDelete, mdiDragHorizontalVariant, mdiPlus } from "@mdi/js";
-import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { repeat } from "lit/directives/repeat";
 import memoizeOne from "memoize-one";
-import { createDurationData } from "../../../../common/datetime/create_duration_data";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
-import { uid } from "../../../../common/util/uid";
-import "../../../../components/ha-button";
-import "../../../../components/ha-duration-input";
-import type { HaDurationData } from "../../../../components/ha-duration-input";
+import "../../../../components/ha-alert";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
-import "../../../../components/ha-icon-button";
-import "../../../../components/ha-sortable";
-import "../../../../components/ha-svg-icon";
-import {
-  durationDataToTimerString,
-  normalizeTimerDuration,
-} from "../../../../data/timer";
 import type { HomeAssistant } from "../../../../types";
 import type {
   LovelaceCardFeatureContext,
   TimerPresetsCardFeatureConfig,
 } from "../../card-features/types";
 import type { LovelaceCardFeatureEditor } from "../../types";
-
-const NEW_PRESET = "0:05:00";
 
 @customElement("hui-timer-presets-card-feature-editor")
 export class HuiTimerPresetsCardFeatureEditor
@@ -40,26 +24,8 @@ export class HuiTimerPresetsCardFeatureEditor
 
   @state() private _config?: TimerPresetsCardFeatureConfig;
 
-  // Stable key per row so rows keep their DOM (and input focus) while other
-  // rows are added, removed, or dragged. Presets are plain strings, so keys
-  // are tracked in a parallel array, mirroring ha-input-multi.
-  @state() private _keys: string[] = [];
-
   public setConfig(config: TimerPresetsCardFeatureConfig): void {
     this._config = config;
-  }
-
-  protected willUpdate(changedProps: PropertyValues): void {
-    super.willUpdate(changedProps);
-    if (changedProps.has("_config")) {
-      const length = this._config?.presets?.length ?? 0;
-      if (this._keys.length !== length) {
-        this._keys = Array.from(
-          { length },
-          (_, index) => this._keys[index] ?? uid()
-        );
-      }
-    }
   }
 
   private _schema = memoizeOne(
@@ -88,8 +54,6 @@ export class HuiTimerPresetsCardFeatureEditor
       return nothing;
     }
 
-    const presets = this._config.presets ?? [];
-
     const data: TimerPresetsCardFeatureConfig = {
       style: "buttons",
       ...this._config,
@@ -103,42 +67,11 @@ export class HuiTimerPresetsCardFeatureEditor
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._formChanged}
       ></ha-form>
-      <ha-sortable
-        handle-selector=".handle"
-        draggable-selector=".preset"
-        @item-moved=${this._presetMoved}
-      >
-        <div class="presets">
-          ${repeat(
-            presets,
-            (_preset, index) => this._keys[index],
-            (preset, index) => html`
-              <div class="preset">
-                <ha-svg-icon
-                  class="handle"
-                  .path=${mdiDragHorizontalVariant}
-                ></ha-svg-icon>
-                <ha-duration-input
-                  .data=${this._presetDurationData(preset)}
-                  .index=${index}
-                  required
-                  @value-changed=${this._presetChanged}
-                ></ha-duration-input>
-                <ha-icon-button
-                  .path=${mdiDelete}
-                  .index=${index}
-                  .label=${this.hass!.localize("ui.common.remove")}
-                  @click=${this._removePreset}
-                ></ha-icon-button>
-              </div>
-            `
-          )}
-        </div>
-      </ha-sortable>
-      <ha-button appearance="plain" @click=${this._addPreset}>
-        <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
-        ${this.hass.localize("ui.common.add")}
-      </ha-button>
+      <ha-alert alert-type="info">
+        ${this.hass.localize(
+          "ui.panel.lovelace.editor.features.types.timer-presets.description"
+        )}
+      </ha-alert>
     `;
   }
 
@@ -154,76 +87,10 @@ export class HuiTimerPresetsCardFeatureEditor
       `ui.panel.lovelace.editor.features.types.timer-presets.${schema.name}`
     );
 
-  // Normalize before binding so numeric presets ({seconds: 3600}) show as
-  // 1:00:00 instead of overflowing the seconds field, where the input's
-  // carry-over logic would corrupt the value on the next edit.
-  private _presetDurationData(
-    preset: string | number
-  ): HaDurationData | undefined {
-    const durationData = createDurationData(preset);
-    return durationData ? normalizeTimerDuration(durationData) : undefined;
-  }
-
-  private _presetChanged(ev: CustomEvent): void {
-    ev.stopPropagation();
-    const index = (ev.currentTarget as any).index as number;
-    const value = ev.detail.value as HaDurationData | undefined;
-    const presets = [...(this._config!.presets ?? [])];
-    presets[index] = durationDataToTimerString(value ?? {});
-    this._updatePresets(presets);
-  }
-
-  private _presetMoved(ev: CustomEvent): void {
-    ev.stopPropagation();
-    const { oldIndex, newIndex } = ev.detail;
-    const presets = [...(this._config!.presets ?? [])];
-    const [moved] = presets.splice(oldIndex, 1);
-    presets.splice(newIndex, 0, moved);
-    // Move the row's key with it so its DOM identity is preserved.
-    const keys = [...this._keys];
-    const [movedKey] = keys.splice(oldIndex, 1);
-    keys.splice(newIndex, 0, movedKey);
-    this._keys = keys;
-    this._updatePresets(presets);
-  }
-
-  private _removePreset(ev: Event): void {
-    const index = (ev.currentTarget as any).index as number;
-    this._keys = this._keys.filter((_, i) => i !== index);
-    const presets = [...(this._config!.presets ?? [])];
-    presets.splice(index, 1);
-    this._updatePresets(presets);
-  }
-
-  private _addPreset(): void {
-    this._keys = [...this._keys, uid()];
-    this._updatePresets([...(this._config!.presets ?? []), NEW_PRESET]);
-  }
-
-  private _updatePresets(presets: (string | number)[]): void {
-    fireEvent(this, "config-changed", {
-      config: { ...this._config!, presets },
-    });
-  }
-
   static styles = css`
     ha-form {
       display: block;
       margin-bottom: var(--ha-space-4);
-    }
-    .preset {
-      display: flex;
-      align-items: center;
-      gap: var(--ha-space-2);
-      margin-bottom: var(--ha-space-2);
-    }
-    .preset ha-duration-input {
-      flex: 1;
-    }
-    .handle {
-      cursor: grab;
-      padding: var(--ha-space-2);
-      margin: calc(var(--ha-space-2) * -1);
     }
   `;
 }

--- a/src/state-display/ha-timer-remaining-time.ts
+++ b/src/state-display/ha-timer-remaining-time.ts
@@ -1,8 +1,9 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import { ReactiveElement } from "lit";
-import { customElement, property, state } from "lit/decorators";
-import { computeDisplayTimer, timerTimeRemaining } from "../data/timer";
+import { customElement, property } from "lit/decorators";
+import { TimerRemainingTimeController } from "../common/controllers/timer-remaining-time-controller";
+import { computeDisplayTimer } from "../data/timer";
 import type { HomeAssistant } from "../types";
 
 @customElement("ha-timer-remaining-time")
@@ -11,60 +12,27 @@ class HaTimerRemainingTime extends ReactiveElement {
 
   @property({ attribute: false }) public stateObj!: HassEntity;
 
-  @state() private timeRemaining?: number;
-
-  private _updateRemaining: any;
+  private _remainingTime = new TimerRemainingTimeController(this);
 
   protected createRenderRoot() {
     return this;
   }
 
+  protected willUpdate(changedProps: PropertyValues<this>): void {
+    super.willUpdate(changedProps);
+    if (changedProps.has("stateObj")) {
+      this._remainingTime.setStateObj(this.stateObj);
+    }
+  }
+
   protected update(changedProps: PropertyValues<this>) {
     super.update(changedProps);
     this.innerHTML =
-      computeDisplayTimer(this.hass, this.stateObj, this.timeRemaining) ?? "-";
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-    if (this.stateObj) {
-      this._startInterval(this.stateObj);
-    }
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._clearInterval();
-  }
-
-  protected willUpdate(changedProp: PropertyValues<this>): void {
-    super.willUpdate(changedProp);
-    if (changedProp.has("stateObj")) {
-      this._startInterval(this.stateObj);
-    }
-  }
-
-  private _clearInterval() {
-    if (this._updateRemaining) {
-      clearInterval(this._updateRemaining);
-      this._updateRemaining = null;
-    }
-  }
-
-  private _startInterval(stateObj: HassEntity) {
-    this._clearInterval();
-    this._calculateRemaining(stateObj);
-
-    if (stateObj.state === "active") {
-      this._updateRemaining = setInterval(
-        () => this._calculateRemaining(this.stateObj),
-        1000
-      );
-    }
-  }
-
-  private _calculateRemaining(stateObj: HassEntity) {
-    this.timeRemaining = timerTimeRemaining(stateObj);
+      computeDisplayTimer(
+        this.hass.formatEntityState,
+        this.stateObj,
+        this._remainingTime.timeRemaining
+      ) ?? "-";
   }
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1918,7 +1918,8 @@
             "add": "Add new preset",
             "edit_title": "Edit preset",
             "add_title": "Add preset",
-            "duration": "[%key:ui::dialogs::helper_settings::timer::duration%]"
+            "duration": "[%key:ui::dialogs::helper_settings::timer::duration%]",
+            "duration_error": "The duration must be at least one second."
           }
         }
       },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -328,8 +328,7 @@
           "restart": "Restart",
           "set": "Set"
         },
-        "presets": "Presets",
-        "start_preset": "Start {duration}"
+        "presets": "Presets"
       },
       "vacuum": {
         "actions": {
@@ -1901,6 +1900,26 @@
         "camera": {
           "download_snapshot": "Download snapshot",
           "failed_to_download": "Failed to download snapshot. Please check the logs for more information."
+        },
+        "timer": {
+          "edit_mode": "Edit presets",
+          "reset_favorites": "Remove all presets",
+          "reset_favorites_text": "Do you want to remove all presets for this timer?",
+          "copy_favorites": "Copy presets to...",
+          "copy_favorites_helper": "Select one or more timers to receive the copied presets from this timer.",
+          "copy_favorites_entities": "[%key:ui::panel::lovelace::editor::card::generic::entities%]",
+          "preset": {
+            "set": "Start timer for {value}",
+            "edit": "Edit preset {value}",
+            "delete": "Delete preset {number}",
+            "delete_confirm_title": "Delete preset?",
+            "delete_confirm_text": "This preset will be permanently deleted.",
+            "delete_confirm_action": "[%key:ui::common::delete%]",
+            "add": "Add new preset",
+            "edit_title": "Edit preset",
+            "add_title": "Add preset",
+            "duration": "[%key:ui::dialogs::helper_settings::timer::duration%]"
+          }
         }
       },
       "entity_registry": {
@@ -10914,6 +10933,7 @@
               },
               "timer-presets": {
                 "label": "Timer presets",
+                "description": "This feature uses the timer's presets. To manage them, open the timer's more info dialog and select 'Edit presets' in the overflow menu.",
                 "style": "[%key:ui::panel::lovelace::editor::features::types::numeric-input::style%]",
                 "style_list": {
                   "buttons": "[%key:ui::panel::lovelace::editor::features::types::numeric-input::style_list::buttons%]",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -325,8 +325,11 @@
           "pause": "Pause",
           "cancel": "Cancel",
           "finish": "Finish",
+          "restart": "Restart",
           "set": "Set"
-        }
+        },
+        "presets": "Presets",
+        "start_preset": "Start {duration}"
       },
       "vacuum": {
         "actions": {
@@ -10896,6 +10899,25 @@
                   "increment": "Increment",
                   "decrement": "Decrement",
                   "reset": "Reset"
+                }
+              },
+              "timer-actions": {
+                "label": "Timer actions",
+                "customize": "[%key:ui::panel::lovelace::editor::features::types::counter-actions::customize%]",
+                "actions": "[%key:ui::panel::lovelace::editor::features::types::counter-actions::actions%]",
+                "actions_list": {
+                  "start": "[%key:ui::card::timer::actions::start%]",
+                  "pause": "[%key:ui::card::timer::actions::pause%]",
+                  "cancel": "[%key:ui::card::timer::actions::cancel%]",
+                  "finish": "[%key:ui::card::timer::actions::finish%]"
+                }
+              },
+              "timer-presets": {
+                "label": "Timer presets",
+                "style": "[%key:ui::panel::lovelace::editor::features::types::numeric-input::style%]",
+                "style_list": {
+                  "buttons": "[%key:ui::panel::lovelace::editor::features::types::numeric-input::style_list::buttons%]",
+                  "dropdown": "[%key:ui::panel::lovelace::editor::features::types::climate-preset-modes::style_list::dropdown%]"
                 }
               },
               "fan-preset-modes": {

--- a/test/data/timer.test.ts
+++ b/test/data/timer.test.ts
@@ -5,6 +5,7 @@ import {
   computeDisplayTimer,
   durationDataToTimerString,
   normalizeTimerDuration,
+  normalizeTimerPresets,
   timerDurationData,
   timerJustFinished,
 } from "../../src/data/timer";
@@ -203,6 +204,29 @@ describe("computeDisplayTimer", () => {
         90
       ),
       "1:30 (Paused)"
+    );
+  });
+});
+
+describe("normalizeTimerPresets", () => {
+  it("returns an empty list when nothing is stored", () => {
+    assert.deepEqual(normalizeTimerPresets(undefined), []);
+    assert.deepEqual(normalizeTimerPresets([]), []);
+  });
+
+  it("keeps the stored order and drops duplicates", () => {
+    assert.deepEqual(normalizeTimerPresets([600, 60, 300, 60]), [600, 60, 300]);
+  });
+
+  it("truncates fractional seconds", () => {
+    // Timers only accept whole seconds, and 90.4 and 90.9 are the same preset.
+    assert.deepEqual(normalizeTimerPresets([90.4, 90.9]), [90]);
+  });
+
+  it("drops values that cannot start a timer", () => {
+    assert.deepEqual(
+      normalizeTimerPresets([0, -60, NaN, Infinity, 300] as number[]),
+      [300]
     );
   });
 });

--- a/test/data/timer.test.ts
+++ b/test/data/timer.test.ts
@@ -1,6 +1,12 @@
 import { assert, describe, it } from "vitest";
 
-import { timerDurationData } from "../../src/data/timer";
+import { createDurationData } from "../../src/common/datetime/create_duration_data";
+import {
+  computeDisplayTimer,
+  durationDataToTimerString,
+  normalizeTimerDuration,
+  timerDurationData,
+} from "../../src/data/timer";
 
 describe("timerDurationData", () => {
   it("derives the input prefill from the configured duration", () => {
@@ -40,6 +46,121 @@ describe("timerDurationData", () => {
         },
       } as any),
       { hours: 3, minutes: 30, seconds: 0, milliseconds: 0 }
+    );
+  });
+});
+
+describe("durationDataToTimerString", () => {
+  it("serializes with zero-padded minutes and seconds", () => {
+    assert.strictEqual(
+      durationDataToTimerString({ hours: 1, minutes: 5, seconds: 7 }),
+      "1:05:07"
+    );
+  });
+
+  it("treats missing fields as zero", () => {
+    assert.strictEqual(durationDataToTimerString({ minutes: 30 }), "0:30:00");
+    assert.strictEqual(durationDataToTimerString({}), "0:00:00");
+  });
+
+  it("folds days into hours", () => {
+    assert.strictEqual(
+      durationDataToTimerString({ days: 1, hours: 2 }),
+      "26:00:00"
+    );
+  });
+
+  it("round-trips through createDurationData", () => {
+    const data = createDurationData("2:15:30")!;
+    assert.strictEqual(durationDataToTimerString(data), "2:15:30");
+  });
+
+  it("normalizes out-of-range fields", () => {
+    assert.strictEqual(durationDataToTimerString({ seconds: 3600 }), "1:00:00");
+    assert.strictEqual(durationDataToTimerString({ minutes: 90 }), "1:30:00");
+  });
+
+  it("floors fractional seconds instead of serializing decimals", () => {
+    assert.strictEqual(durationDataToTimerString({ seconds: 1.5 }), "0:00:01");
+    assert.strictEqual(
+      durationDataToTimerString({ seconds: 1, milliseconds: 500 }),
+      "0:00:01"
+    );
+  });
+});
+
+describe("normalizeTimerDuration", () => {
+  it("decomposes overflowing fields into hours/minutes/seconds", () => {
+    assert.deepEqual(normalizeTimerDuration({ seconds: 3600 }), {
+      hours: 1,
+      minutes: 0,
+      seconds: 0,
+    });
+    assert.deepEqual(normalizeTimerDuration({ days: 1, hours: 2 }), {
+      hours: 26,
+      minutes: 0,
+      seconds: 0,
+    });
+  });
+
+  it("drops fractional seconds", () => {
+    assert.deepEqual(normalizeTimerDuration({ seconds: 90.9 }), {
+      hours: 0,
+      minutes: 1,
+      seconds: 30,
+    });
+  });
+});
+
+describe("computeDisplayTimer", () => {
+  const formatEntityState = (stateObj: any) =>
+    stateObj.state === "idle"
+      ? "Idle"
+      : stateObj.state === "paused"
+        ? "Paused"
+        : "Active";
+
+  it("shows the formatted state when idle", () => {
+    assert.strictEqual(
+      computeDisplayTimer(
+        formatEntityState,
+        { state: "idle", attributes: {} } as any,
+        undefined
+      ),
+      "Idle"
+    );
+  });
+
+  it("shows the formatted state when the remaining time is zero", () => {
+    assert.strictEqual(
+      computeDisplayTimer(
+        formatEntityState,
+        { state: "active", attributes: {} } as any,
+        0
+      ),
+      "Active"
+    );
+  });
+
+  it("shows the remaining time when active", () => {
+    assert.strictEqual(
+      computeDisplayTimer(
+        formatEntityState,
+        { state: "active", attributes: {} } as any,
+        90
+      ),
+      "1:30"
+    );
+  });
+
+  it("appends the formatted state when paused", () => {
+    assert.strictEqual(
+      computeDisplayTimer(
+        formatEntityState,
+        { state: "paused", attributes: {} } as any,
+        90
+      ),
+      "1:30 (Paused)"
     );
   });
 });

--- a/test/data/timer.test.ts
+++ b/test/data/timer.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 
 import { createDurationData } from "../../src/common/datetime/create_duration_data";
 import {
@@ -6,7 +6,14 @@ import {
   durationDataToTimerString,
   normalizeTimerDuration,
   timerDurationData,
+  timerJustFinished,
 } from "../../src/data/timer";
+
+const timerState = (state: string, lastTransition?: string) =>
+  ({
+    state,
+    attributes: { last_transition: lastTransition },
+  }) as any;
 
 describe("timerDurationData", () => {
   it("derives the input prefill from the configured duration", () => {
@@ -109,6 +116,41 @@ describe("normalizeTimerDuration", () => {
       minutes: 1,
       seconds: 30,
     });
+  });
+});
+
+describe("timerJustFinished", () => {
+  it("detects a timer running out or being finished", () => {
+    expect(
+      timerJustFinished(timerState("active"), timerState("idle", "finished"))
+    ).toBe(true);
+    expect(
+      timerJustFinished(timerState("paused"), timerState("idle", "finished"))
+    ).toBe(true);
+  });
+
+  it("does not match a cancelled timer", () => {
+    expect(
+      timerJustFinished(timerState("active"), timerState("idle", "cancelled"))
+    ).toBe(false);
+  });
+
+  it("does not match without a state transition", () => {
+    expect(
+      timerJustFinished(
+        timerState("idle", "finished"),
+        timerState("idle", "finished")
+      )
+    ).toBe(false);
+    expect(timerJustFinished(undefined, timerState("idle", "finished"))).toBe(
+      false
+    );
+  });
+
+  it("does not match on older cores without last_transition", () => {
+    expect(timerJustFinished(timerState("active"), timerState("idle"))).toBe(
+      false
+    );
   });
 });
 

--- a/test/panels/lovelace/card-features/hui-timer-actions-card-feature.test.ts
+++ b/test/panels/lovelace/card-features/hui-timer-actions-card-feature.test.ts
@@ -1,0 +1,89 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { describe, expect, it } from "vitest";
+import {
+  supportsTimerActionsCardFeature,
+  TIMER_ACTIONS_BUTTON,
+} from "../../../../src/panels/lovelace/card-features/hui-timer-actions-card-feature";
+import type { HomeAssistant } from "../../../../src/types";
+
+const entity = (entityId: string, state = "idle"): HassEntity =>
+  ({
+    entity_id: entityId,
+    state,
+    attributes: {},
+    last_changed: "",
+    last_updated: "",
+    context: { id: "", parent_id: null, user_id: null },
+  }) as HassEntity;
+
+const hassWith = (...entities: HassEntity[]): HomeAssistant =>
+  ({
+    states: Object.fromEntries(entities.map((e) => [e.entity_id, e])),
+  }) as unknown as HomeAssistant;
+
+describe("supportsTimerActionsCardFeature", () => {
+  it("supports a timer entity", () => {
+    const stateObj = entity("timer.test");
+    const hass = hassWith(stateObj);
+    expect(
+      supportsTimerActionsCardFeature(hass, { entity_id: stateObj.entity_id })
+    ).toBe(true);
+  });
+
+  it("does not support other domains", () => {
+    const stateObj = entity("switch.test");
+    const hass = hassWith(stateObj);
+    expect(
+      supportsTimerActionsCardFeature(hass, { entity_id: stateObj.entity_id })
+    ).toBe(false);
+  });
+
+  it("does not support a context with no entity_id", () => {
+    const hass = hassWith();
+    expect(supportsTimerActionsCardFeature(hass, {})).toBe(false);
+  });
+});
+
+describe("TIMER_ACTIONS_BUTTON", () => {
+  it("shows start when the timer is idle or paused", () => {
+    for (const state of ["idle", "paused"]) {
+      const button = TIMER_ACTIONS_BUTTON.start(entity("timer.test", state));
+      expect(button.translationKey).toBe("start");
+      expect(button.serviceName).toBe("start");
+      expect(button.disabled).toBe(false);
+    }
+  });
+
+  it("shows restart when the timer is active", () => {
+    const button = TIMER_ACTIONS_BUTTON.start(entity("timer.test", "active"));
+    expect(button.translationKey).toBe("restart");
+    expect(button.serviceName).toBe("start");
+    expect(button.disabled).toBe(false);
+  });
+
+  it("only enables pause when the timer is active", () => {
+    expect(
+      TIMER_ACTIONS_BUTTON.pause(entity("timer.test", "active")).disabled
+    ).toBe(false);
+    expect(
+      TIMER_ACTIONS_BUTTON.pause(entity("timer.test", "paused")).disabled
+    ).toBe(true);
+    expect(
+      TIMER_ACTIONS_BUTTON.pause(entity("timer.test", "idle")).disabled
+    ).toBe(true);
+  });
+
+  it("disables cancel and finish when the timer is idle", () => {
+    for (const action of ["cancel", "finish"]) {
+      expect(
+        TIMER_ACTIONS_BUTTON[action](entity("timer.test", "idle")).disabled
+      ).toBe(true);
+      expect(
+        TIMER_ACTIONS_BUTTON[action](entity("timer.test", "active")).disabled
+      ).toBe(false);
+      expect(
+        TIMER_ACTIONS_BUTTON[action](entity("timer.test", "paused")).disabled
+      ).toBe(false);
+    }
+  });
+});

--- a/test/panels/lovelace/card-features/hui-timer-presets-card-feature.test.ts
+++ b/test/panels/lovelace/card-features/hui-timer-presets-card-feature.test.ts
@@ -1,0 +1,77 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { describe, expect, it } from "vitest";
+import type { FrontendLocaleData } from "../../../../src/data/translation";
+import {
+  computeTimerPresets,
+  supportsTimerPresetsCardFeature,
+} from "../../../../src/panels/lovelace/card-features/hui-timer-presets-card-feature";
+import type { HomeAssistant } from "../../../../src/types";
+
+const entity = (entityId: string): HassEntity =>
+  ({
+    entity_id: entityId,
+    state: "idle",
+    attributes: {},
+    last_changed: "",
+    last_updated: "",
+    context: { id: "", parent_id: null, user_id: null },
+  }) as HassEntity;
+
+const hassWith = (...entities: HassEntity[]): HomeAssistant =>
+  ({
+    states: Object.fromEntries(entities.map((e) => [e.entity_id, e])),
+  }) as unknown as HomeAssistant;
+
+const locale = { language: "en" } as FrontendLocaleData;
+
+describe("supportsTimerPresetsCardFeature", () => {
+  it("supports a timer entity", () => {
+    const stateObj = entity("timer.test");
+    const hass = hassWith(stateObj);
+    expect(
+      supportsTimerPresetsCardFeature(hass, { entity_id: stateObj.entity_id })
+    ).toBe(true);
+  });
+
+  it("does not support other domains", () => {
+    const stateObj = entity("switch.test");
+    const hass = hassWith(stateObj);
+    expect(
+      supportsTimerPresetsCardFeature(hass, { entity_id: stateObj.entity_id })
+    ).toBe(false);
+  });
+
+  it("does not support a context with no entity_id", () => {
+    const hass = hassWith();
+    expect(supportsTimerPresetsCardFeature(hass, {})).toBe(false);
+  });
+});
+
+describe("computeTimerPresets", () => {
+  it("formats string presets", () => {
+    expect(computeTimerPresets(["0:05:00", "1:00:00"], locale)).toEqual([
+      { duration: "0:05:00", label: "5:00" },
+      { duration: "1:00:00", label: "1:00:00" },
+    ]);
+  });
+
+  it("labels numeric presets the same as their string form", () => {
+    expect(computeTimerPresets([90, "0:01:30"], locale)).toEqual([
+      { duration: 90, label: "1:30" },
+      { duration: "0:01:30", label: "1:30" },
+    ]);
+    expect(computeTimerPresets([3600], locale)).toEqual([
+      { duration: 3600, label: "1:00:00" },
+    ]);
+    expect(computeTimerPresets([45, "0:00:45"], locale)).toEqual([
+      { duration: 45, label: "45 seconds" },
+      { duration: "0:00:45", label: "45 seconds" },
+    ]);
+  });
+
+  it("drops zero and unparseable presets", () => {
+    expect(
+      computeTimerPresets(["0:00:00", 0, "1:2:3:4", "0:10:00"], locale)
+    ).toEqual([{ duration: "0:10:00", label: "10:00" }]);
+  });
+});

--- a/test/panels/lovelace/card-features/hui-timer-presets-card-feature.test.ts
+++ b/test/panels/lovelace/card-features/hui-timer-presets-card-feature.test.ts
@@ -1,10 +1,6 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import { describe, expect, it } from "vitest";
-import type { FrontendLocaleData } from "../../../../src/data/translation";
-import {
-  computeTimerPresets,
-  supportsTimerPresetsCardFeature,
-} from "../../../../src/panels/lovelace/card-features/hui-timer-presets-card-feature";
+import { supportsTimerPresetsCardFeature } from "../../../../src/panels/lovelace/card-features/hui-timer-presets-card-feature";
 import type { HomeAssistant } from "../../../../src/types";
 
 const entity = (entityId: string): HassEntity =>
@@ -21,8 +17,6 @@ const hassWith = (...entities: HassEntity[]): HomeAssistant =>
   ({
     states: Object.fromEntries(entities.map((e) => [e.entity_id, e])),
   }) as unknown as HomeAssistant;
-
-const locale = { language: "en" } as FrontendLocaleData;
 
 describe("supportsTimerPresetsCardFeature", () => {
   it("supports a timer entity", () => {
@@ -44,43 +38,5 @@ describe("supportsTimerPresetsCardFeature", () => {
   it("does not support a context with no entity_id", () => {
     const hass = hassWith();
     expect(supportsTimerPresetsCardFeature(hass, {})).toBe(false);
-  });
-});
-
-describe("computeTimerPresets", () => {
-  it("formats string presets", () => {
-    expect(computeTimerPresets(["0:05:00", "1:00:00"], locale)).toEqual([
-      { duration: 300, label: "5:00" },
-      { duration: 3600, label: "1:00:00" },
-    ]);
-  });
-
-  it("labels numeric presets the same as their string form", () => {
-    expect(computeTimerPresets([90, "0:01:30"], locale)).toEqual([
-      { duration: 90, label: "1:30" },
-      { duration: 90, label: "1:30" },
-    ]);
-    expect(computeTimerPresets([3600], locale)).toEqual([
-      { duration: 3600, label: "1:00:00" },
-    ]);
-    expect(computeTimerPresets([45, "0:00:45"], locale)).toEqual([
-      { duration: 45, label: "45 seconds" },
-      { duration: 45, label: "45 seconds" },
-    ]);
-  });
-
-  it("drops zero and unparseable presets", () => {
-    expect(
-      computeTimerPresets(["0:00:00", 0, "1:2:3:4", "0:10:00"], locale)
-    ).toEqual([{ duration: 600, label: "10:00" }]);
-  });
-
-  it("sends the normalized duration for lenient parsed presets", () => {
-    // createDurationData coerces invalid segments to 0 like the automation
-    // editor does. The normalized seconds must be what is sent to timer.start,
-    // never the raw malformed string.
-    expect(computeTimerPresets(["1:nope:00"], locale)).toEqual([
-      { duration: 3600, label: "1:00:00" },
-    ]);
   });
 });

--- a/test/panels/lovelace/card-features/hui-timer-presets-card-feature.test.ts
+++ b/test/panels/lovelace/card-features/hui-timer-presets-card-feature.test.ts
@@ -50,28 +50,37 @@ describe("supportsTimerPresetsCardFeature", () => {
 describe("computeTimerPresets", () => {
   it("formats string presets", () => {
     expect(computeTimerPresets(["0:05:00", "1:00:00"], locale)).toEqual([
-      { duration: "0:05:00", label: "5:00" },
-      { duration: "1:00:00", label: "1:00:00" },
+      { duration: 300, label: "5:00" },
+      { duration: 3600, label: "1:00:00" },
     ]);
   });
 
   it("labels numeric presets the same as their string form", () => {
     expect(computeTimerPresets([90, "0:01:30"], locale)).toEqual([
       { duration: 90, label: "1:30" },
-      { duration: "0:01:30", label: "1:30" },
+      { duration: 90, label: "1:30" },
     ]);
     expect(computeTimerPresets([3600], locale)).toEqual([
       { duration: 3600, label: "1:00:00" },
     ]);
     expect(computeTimerPresets([45, "0:00:45"], locale)).toEqual([
       { duration: 45, label: "45 seconds" },
-      { duration: "0:00:45", label: "45 seconds" },
+      { duration: 45, label: "45 seconds" },
     ]);
   });
 
   it("drops zero and unparseable presets", () => {
     expect(
       computeTimerPresets(["0:00:00", 0, "1:2:3:4", "0:10:00"], locale)
-    ).toEqual([{ duration: "0:10:00", label: "10:00" }]);
+    ).toEqual([{ duration: 600, label: "10:00" }]);
+  });
+
+  it("sends the normalized duration for lenient parsed presets", () => {
+    // createDurationData coerces invalid segments to 0 like the automation
+    // editor does. The normalized seconds must be what is sent to timer.start,
+    // never the raw malformed string.
+    expect(computeTimerPresets(["1:nope:00"], locale)).toEqual([
+      { duration: 3600, label: "1:00:00" },
+    ]);
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

- **Timer actions tile feature** - Start, pause, cancel, and optionally finish buttons. 
- **Timer presets tile feature** - Configurable preset durations that start the timer with one tap. Two styles: a button row or a dropdown for longer preset lists. 
- **Modernized more-info dialog** 
- **Finish animation**

Under the hood: 
- normalize durations to full seconds
- deduplicated countdown logic

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
| Before  | After  |
| ------------- | ------------- |
| <img width="608" height="311" alt="Screenshot 2026-08-26 at 09 34 25" src="https://github.com/user-attachments/assets/083d298e-5d90-4166-b632-223460f0420e" /> |<img width="602" height="373" alt="Screenshot 2026-08-26 at 09 35 01" src="https://github.com/user-attachments/assets/235315c5-89c8-4e65-aba0-bea99a61ad94" /> |
|<img width="567" height="170" alt="Screenshot 2026-08-26 at 09 34 09" src="https://github.com/user-attachments/assets/3b5cd96f-6a9e-467d-bb10-78e307adc858" /> |  <img width="517" height="397" alt="Screenshot 2026-08-26 at 09 34 44" src="https://github.com/user-attachments/assets/82fd4760-7d11-4870-a7ff-a26ad45601ee" /> |

https://github.com/user-attachments/assets/6f56a60a-45e1-411e-bffc-d827a761fa87

https://github.com/user-attachments/assets/29aef156-2a06-49fd-a354-60c1edfde3fe

<img width="538" height="512" alt="Screenshot 2026-08-26 at 09 35 29" src="https://github.com/user-attachments/assets/3d0cb977-b51a-41a1-afed-6ea8fd310eec" />
<img width="862" height="416" alt="Screenshot 2026-08-26 at 09 38 37" src="https://github.com/user-attachments/assets/c7e5f38e-5c77-4b4d-bd10-86bb343fb4aa" />
<img width="811" height="573" alt="Screenshot 2026-08-26 at 09 38 51" src="https://github.com/user-attachments/assets/11f7742e-f5b3-40d6-a2f5-249721549dfe" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/4173
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47616
- Link to developer documentation pull request:
- Link to backend pull request:


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
