### PR TITLE
Reset editor state when switching to another automation, script or scene

### DIFF
--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -713,7 +713,11 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
     }
 
     if (changedProps.has("entityId") && this.entityId) {
+      const generation = ++this.loadGeneration;
       getAutomationStateConfig(this.hass, this.entityId).then((c) => {
+        if (generation !== this.loadGeneration) {
+          return;
+        }
         this.config = normalizeAutomationConfig(c.config);
         this._initDirtyTracking(
           { type: "deep" },
@@ -759,11 +763,15 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
     if (stateObj?.state !== UNAVAILABLE) {
       return;
     }
+    const generation = this.loadGeneration;
     const validation = await validateConfig(this.hass, {
       triggers: this.config.triggers,
       conditions: this.config.conditions,
       actions: this.config.actions,
     });
+    if (generation !== this.loadGeneration) {
+      return;
+    }
     this.validationErrors = (
       Object.entries(validation) as Entries<typeof validation>
     ).map(([key, value]) =>
@@ -928,6 +936,7 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
 
   private async _takeControl() {
     const config = this.config as BlueprintAutomationConfig;
+    const generation = this.loadGeneration;
 
     try {
       const result = await substituteBlueprint(
@@ -936,6 +945,9 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
         config.use_blueprint.path,
         config.use_blueprint.input || {}
       );
+      if (generation !== this.loadGeneration) {
+        return;
+      }
 
       const newConfig = {
         ...normalizeAutomationConfig(result.substituted_config),
@@ -952,6 +964,9 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
       this.readOnly = true;
       this.errors = undefined;
     } catch (err: any) {
+      if (generation !== this.loadGeneration) {
+        return;
+      }
       this.errors = err.message;
     }
   }

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -153,7 +153,6 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
   protected override resetEditorState() {
     super.resetEditorState();
     this._undoRedoController.reset();
-    this._newAutomationId = undefined;
   }
 
   protected willUpdate(changedProps: PropertyValues<this>) {
@@ -763,15 +762,11 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
     if (stateObj?.state !== UNAVAILABLE) {
       return;
     }
-    const generation = this.loadGeneration;
     const validation = await validateConfig(this.hass, {
       triggers: this.config.triggers,
       conditions: this.config.conditions,
       actions: this.config.actions,
     });
-    if (generation !== this.loadGeneration) {
-      return;
-    }
     this.validationErrors = (
       Object.entries(validation) as Entries<typeof validation>
     ).map(([key, value]) =>
@@ -964,9 +959,6 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
       this.readOnly = true;
       this.errors = undefined;
     } catch (err: any) {
-      if (generation !== this.loadGeneration) {
-        return;
-      }
       this.errors = err.message;
     }
   }
@@ -1084,7 +1076,8 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
     this.validationErrors = undefined;
 
     let entityRegPromise: Promise<EntityRegistryEntry> | undefined;
-    if (this.entityRegistryUpdate !== undefined && !this.currentEntityId) {
+    const entityRegistryUpdate = this.entityRegistryUpdate;
+    if (entityRegistryUpdate !== undefined && !this.currentEntityId) {
       this._newAutomationId = id;
       entityRegPromise = new Promise<EntityRegistryEntry>((resolve) => {
         this.entityRegCreated = resolve;
@@ -1094,7 +1087,7 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
     try {
       await saveAutomationConfig(this.hass, id, this.config!);
 
-      if (this.entityRegistryUpdate !== undefined) {
+      if (entityRegistryUpdate !== undefined) {
         let entityId = this.currentEntityId;
 
         // wait for automation to appear in entity registry when creating a new automation
@@ -1129,10 +1122,10 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
         if (entityId) {
           await updateEntityRegistryEntry(this.hass, entityId, {
             categories: {
-              automation: this.entityRegistryUpdate.category || null,
+              automation: entityRegistryUpdate.category || null,
             },
-            labels: this.entityRegistryUpdate.labels || [],
-            area_id: this.entityRegistryUpdate.area || null,
+            labels: entityRegistryUpdate.labels || [],
+            area_id: entityRegistryUpdate.area || null,
           });
         }
       }

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -150,6 +150,12 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
     return super.isDirtyState || !!this.yamlErrors;
   }
 
+  protected override resetEditorState() {
+    super.resetEditorState();
+    this._undoRedoController.reset();
+    this._newAutomationId = undefined;
+  }
+
   protected willUpdate(changedProps: PropertyValues<this>) {
     super.willUpdate(changedProps);
 
@@ -659,6 +665,27 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
     const oldAutomationId = changedProps.get("automationId");
     if (
       changedProps.has("automationId") &&
+      oldAutomationId !== undefined &&
+      oldAutomationId !== this.automationId
+    ) {
+      if (this.automationId && this.automationId === this.justSavedId) {
+        this.justSavedId = undefined;
+      } else {
+        this.resetEditorState();
+      }
+    }
+
+    const oldEntityId = changedProps.get("entityId");
+    if (
+      changedProps.has("entityId") &&
+      oldEntityId !== undefined &&
+      oldEntityId !== this.entityId
+    ) {
+      this.resetEditorState();
+    }
+
+    if (
+      changedProps.has("automationId") &&
       this.automationId &&
       // Only refresh config if we picked a new automation. If same ID, don't fetch it.
       oldAutomationId !== this.automationId
@@ -1050,6 +1077,7 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
 
     await this._saveAutomation(id);
     if (!this.automationId) {
+      this.justSavedId = id;
       navigate(`/config/automation/edit/${id}`, { replace: true });
     }
   }

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -663,26 +663,8 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
       );
 
     const oldAutomationId = changedProps.get("automationId");
-    if (
-      changedProps.has("automationId") &&
-      oldAutomationId !== undefined &&
-      oldAutomationId !== this.automationId
-    ) {
-      if (this.automationId && this.automationId === this.justSavedId) {
-        this.justSavedId = undefined;
-      } else {
-        this.resetEditorState();
-      }
-    }
-
-    const oldEntityId = changedProps.get("entityId");
-    if (
-      changedProps.has("entityId") &&
-      oldEntityId !== undefined &&
-      oldEntityId !== this.entityId
-    ) {
-      this.resetEditorState();
-    }
+    this.resetOnItemSwitch(oldAutomationId, this.automationId);
+    this.resetOnItemSwitch(changedProps.get("entityId"), this.entityId);
 
     if (
       changedProps.has("automationId") &&

--- a/src/panels/config/automation/ha-automation-script-editor-mixin.ts
+++ b/src/panels/config/automation/ha-automation-script-editor-mixin.ts
@@ -286,7 +286,8 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
     /**
      * Reset per-item state when the edited item changes while this element is
      * reused (same route page, different id), emulating a freshly opened
-     * editor.
+     * editor. `saving` and `entityRegCreated` are deliberately absent: they
+     * are owned by an in-flight save.
      */
     protected resetEditorState() {
       this.loadGeneration++;
@@ -299,9 +300,7 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
       this.blueprintConfig = undefined;
       this.deprecatedConfigMigrated = false;
       this.entityRegistryUpdate = undefined;
-      this.entityRegCreated = undefined;
       this.currentEntityId = undefined;
-      this.saving = false;
       this._initDirtyTracking({ type: "deep" });
     }
 

--- a/src/panels/config/automation/ha-automation-script-editor-mixin.ts
+++ b/src/panels/config/automation/ha-automation-script-editor-mixin.ts
@@ -155,6 +155,13 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
       value: PromiseLike<EntityRegistryEntry> | EntityRegistryEntry
     ) => void;
 
+    /**
+     * Id of an item that was just saved from the "new" editor. The follow-up
+     * navigation from edit/new to edit/<id> reuses this element and must not
+     * reset the editor state.
+     */
+    protected justSavedId?: string;
+
     private _relatedContextAreaId?: string;
 
     protected willUpdate(changedProps: PropertyValues): void {
@@ -271,6 +278,28 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
      */
     protected confirmUnsavedChanged(): Promise<boolean> {
       return Promise.resolve(true);
+    }
+
+    /**
+     * Reset per-item state when the edited item changes while this element is
+     * reused (same route page, different id), emulating a freshly opened
+     * editor. Callers skip the reset when the changed property's old value is
+     * `undefined`, which marks the first assignment on a fresh element.
+     */
+    protected resetEditorState() {
+      this.config = undefined;
+      this.mode = "gui";
+      this.readOnly = false;
+      this.errors = undefined;
+      this.yamlErrors = undefined;
+      this.validationErrors = undefined;
+      this.blueprintConfig = undefined;
+      this.deprecatedConfigMigrated = false;
+      this.entityRegistryUpdate = undefined;
+      this.entityRegCreated = undefined;
+      this.currentEntityId = undefined;
+      this.saving = false;
+      this._initDirtyTracking({ type: "deep" });
     }
 
     protected async loadConfig(id: string) {

--- a/src/panels/config/automation/ha-automation-script-editor-mixin.ts
+++ b/src/panels/config/automation/ha-automation-script-editor-mixin.ts
@@ -283,8 +283,7 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
     /**
      * Reset per-item state when the edited item changes while this element is
      * reused (same route page, different id), emulating a freshly opened
-     * editor. Callers skip the reset when the changed property's old value is
-     * `undefined`, which marks the first assignment on a fresh element.
+     * editor.
      */
     protected resetEditorState() {
       this.config = undefined;
@@ -300,6 +299,26 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
       this.currentEntityId = undefined;
       this.saving = false;
       this._initDirtyTracking({ type: "deep" });
+    }
+
+    /**
+     * Invoke from `updated()` with a changed id property's old and new value.
+     * Resets the editor state on a switch to a different item, except when
+     * the old value is `undefined` (the first assignment on a fresh element)
+     * or the id was just assigned by saving a new item.
+     */
+    protected resetOnItemSwitch(
+      oldId: string | null | undefined,
+      newId: string | null
+    ) {
+      if (oldId === undefined || oldId === newId) {
+        return;
+      }
+      if (newId && newId === this.justSavedId) {
+        this.justSavedId = undefined;
+      } else {
+        this.resetEditorState();
+      }
     }
 
     protected async loadConfig(id: string) {

--- a/src/panels/config/automation/ha-automation-script-editor-mixin.ts
+++ b/src/panels/config/automation/ha-automation-script-editor-mixin.ts
@@ -162,6 +162,9 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
      */
     protected justSavedId?: string;
 
+    /** Bumped when the edited item changes so stale item loads are ignored. */
+    protected loadGeneration = 0;
+
     private _relatedContextAreaId?: string;
 
     protected willUpdate(changedProps: PropertyValues): void {
@@ -286,6 +289,7 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
      * editor.
      */
     protected resetEditorState() {
+      this.loadGeneration++;
       this.config = undefined;
       this.mode = "gui";
       this.readOnly = false;
@@ -324,8 +328,12 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
     protected async loadConfig(id: string) {
       const hooks = this.domainHooks;
       const domain = hooks.domain;
+      const generation = ++this.loadGeneration;
       try {
         const config = await hooks.fetchFileConfig(this.hass, id);
+        if (generation !== this.loadGeneration) {
+          return;
+        }
         this.readOnly = false;
         const report: AutomationMigrationReport = { deprecated: false };
         this.config = hooks.normalizeConfig(config, report);
@@ -342,6 +350,9 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
         );
         hooks.checkValidation();
       } catch (err: any) {
+        if (generation !== this.loadGeneration) {
+          return;
+        }
         if (err.status_code !== 404) {
           const alertText =
             err.body?.message || err.body || err.error || "Unknown error";

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -32,6 +32,7 @@ import { promiseTimeout } from "../../../common/util/promise-timeout";
 import { afterNextRender } from "../../../common/util/render-status";
 import "../../../components/device/ha-device-picker";
 import "../../../components/entity/ha-entities-picker";
+import "../../../components/animation/ha-fade-in";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
 import "../../../components/ha-card";
@@ -40,6 +41,7 @@ import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
 import "../../../components/ha-dropdown-item";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-list";
+import "../../../components/ha-spinner";
 import "../../../components/ha-svg-icon";
 import {
   fireRelatedContext,
@@ -164,6 +166,13 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
 
   private _newSceneId?: string;
 
+  /**
+   * Id of a scene that was just saved from the "new" editor. The follow-up
+   * navigation from edit/new to edit/<id> reuses this element and must not
+   * reset the editor state.
+   */
+  private _justSavedId?: string;
+
   private _entityRegCreated?: (
     value: PromiseLike<EntityRegistryEntry> | EntityRegistryEntry
   ) => void;
@@ -230,6 +239,13 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
   protected render() {
     if (!this.hass) {
       return nothing;
+    }
+    if (!this._config) {
+      return html`
+        <ha-fade-in .delay=${500}>
+          <ha-spinner size="large"></ha-spinner>
+        </ha-fade-in>
+      `;
     }
     return html`
       <hass-subpage
@@ -669,6 +685,18 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
 
     if (
       changedProps.has("sceneId") &&
+      oldscene !== undefined &&
+      oldscene !== this.sceneId
+    ) {
+      if (this.sceneId && this.sceneId === this._justSavedId) {
+        this._justSavedId = undefined;
+      } else {
+        this._resetEditorState();
+      }
+    }
+
+    if (
+      changedProps.has("sceneId") &&
       this.sceneId &&
       this.hass &&
       // Only refresh config if we picked a new scene. If same ID, don't fetch it.
@@ -956,6 +984,33 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
     this._sceneRevision = 0;
     this._initDirtyTracking({ type: "shallow" }, 0);
     this._config = config;
+  }
+
+  /** Emulate a freshly opened editor when the edited scene changes. */
+  private _resetEditorState() {
+    if (this._mode === "live") {
+      applyScene(this.hass, this._storedStates);
+    }
+    this._config = undefined;
+    this._mode = "review";
+    this._errors = undefined;
+    this._yamlErrors = undefined;
+    this._scene = undefined;
+    this._entities = [];
+    this._single_entities = [];
+    this._devices = [];
+    this._storedStates = {};
+    this._activateContextId = undefined;
+    this._entityRegistryUpdate = undefined;
+    this._entityRegCreated = undefined;
+    this._newSceneId = undefined;
+    this._saving = false;
+    if (this._unsubscribeEvents) {
+      this._unsubscribeEvents();
+      this._unsubscribeEvents = undefined;
+    }
+    this._sceneRevision = 0;
+    this._initDirtyTracking({ type: "shallow" }, 0);
   }
 
   private _initEntities(config: SceneConfig) {
@@ -1311,6 +1366,7 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
 
       this._markDirtyStateClean();
       if (isNewScene) {
+        this._justSavedId = id;
         navigate(`/config/scene/edit/${id}`, { replace: true });
       }
     } catch (err: any) {
@@ -1400,6 +1456,12 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
     return [
       haStyle,
       css`
+        ha-fade-in {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          height: 100%;
+        }
         ha-card {
           overflow: hidden;
           margin-top: 8px;

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -683,11 +683,7 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
 
     const oldscene = changedProps.get("sceneId");
 
-    if (
-      changedProps.has("sceneId") &&
-      oldscene !== undefined &&
-      oldscene !== this.sceneId
-    ) {
+    if (oldscene !== undefined && oldscene !== this.sceneId) {
       if (this.sceneId && this.sceneId === this._justSavedId) {
         this._justSavedId = undefined;
       } else {
@@ -867,13 +863,18 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
   private _enterYamlMode() {
     if (this._mode === "live") {
       this._generateConfigFromLive();
-      if (this._unsubscribeEvents) {
-        this._unsubscribeEvents();
-        this._unsubscribeEvents = undefined;
-      }
-      applyScene(this.hass, this._storedStates);
+      this._stopLiveMode();
     }
     this._mode = "yaml";
+  }
+
+  /** Unsubscribe from live updates and restore the pre-live entity states. */
+  private _stopLiveMode() {
+    if (this._unsubscribeEvents) {
+      this._unsubscribeEvents();
+      this._unsubscribeEvents = undefined;
+    }
+    applyScene(this.hass, this._storedStates);
   }
 
   private async _toggleLiveMode() {
@@ -909,11 +910,7 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
 
   private _exitLiveMode() {
     this._generateConfigFromLive();
-    if (this._unsubscribeEvents) {
-      this._unsubscribeEvents();
-      this._unsubscribeEvents = undefined;
-    }
-    applyScene(this.hass, this._storedStates);
+    this._stopLiveMode();
     this._mode = "review";
   }
 
@@ -989,7 +986,7 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
   /** Emulate a freshly opened editor when the edited scene changes. */
   private _resetEditorState() {
     if (this._mode === "live") {
-      applyScene(this.hass, this._storedStates);
+      this._stopLiveMode();
     }
     this._config = undefined;
     this._mode = "review";
@@ -1005,10 +1002,6 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
     this._entityRegCreated = undefined;
     this._newSceneId = undefined;
     this._saving = false;
-    if (this._unsubscribeEvents) {
-      this._unsubscribeEvents();
-      this._unsubscribeEvents = undefined;
-    }
     this._sceneRevision = 0;
     this._initDirtyTracking({ type: "shallow" }, 0);
   }

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -32,7 +32,6 @@ import { promiseTimeout } from "../../../common/util/promise-timeout";
 import { afterNextRender } from "../../../common/util/render-status";
 import "../../../components/device/ha-device-picker";
 import "../../../components/entity/ha-entities-picker";
-import "../../../components/animation/ha-fade-in";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
 import "../../../components/ha-card";
@@ -41,7 +40,6 @@ import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
 import "../../../components/ha-dropdown-item";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-list";
-import "../../../components/ha-spinner";
 import "../../../components/ha-svg-icon";
 import {
   fireRelatedContext,
@@ -176,8 +174,6 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
   /** Bumped when the edited scene changes so stale scene loads are ignored. */
   private _loadGeneration = 0;
 
-  private _subscribeGeneration = 0;
-
   private _entityRegCreated?: (
     value: PromiseLike<EntityRegistryEntry> | EntityRegistryEntry
   ) => void;
@@ -245,13 +241,6 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
     if (!this.hass) {
       return nothing;
     }
-    if (!this._config) {
-      return html`
-        <ha-fade-in .delay=${500}>
-          <ha-spinner size="large"></ha-spinner>
-        </ha-fade-in>
-      `;
-    }
     return html`
       <hass-subpage
         .hass=${this.hass}
@@ -309,7 +298,7 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
             <ha-svg-icon slot="icon" .path=${mdiPencil}></ha-svg-icon>
           </ha-dropdown-item>
 
-          <ha-dropdown-item value="toggle-yaml">
+          <ha-dropdown-item value="toggle-yaml" .disabled=${!this._config}>
             ${this.hass.localize(
               `ui.panel.config.automation.editor.edit_${this._mode !== "yaml" ? "yaml" : "ui"}`
             )}
@@ -941,16 +930,11 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
   }
 
   private async _subscribeEvents() {
-    const generation = ++this._subscribeGeneration;
     const unsubscribe = await this.hass!.connection.subscribeEvents<HassEvent>(
       (event) => this._stateChanged(event),
       "state_changed"
     );
-    if (
-      generation !== this._subscribeGeneration ||
-      this._mode !== "live" ||
-      !this.isConnected
-    ) {
+    if (this._mode !== "live") {
       unsubscribe();
       return;
     }
@@ -1022,9 +1006,6 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
     this._storedStates = {};
     this._activateContextId = undefined;
     this._entityRegistryUpdate = undefined;
-    this._entityRegCreated = undefined;
-    this._newSceneId = undefined;
-    this._saving = false;
     this._sceneRevision = 0;
     this._initDirtyTracking({ type: "shallow" }, 0);
   }
@@ -1326,7 +1307,8 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
     this._saving = true;
 
     let entityRegPromise: Promise<EntityRegistryEntry> | undefined;
-    if (this._entityRegistryUpdate !== undefined && !this.sceneId) {
+    const entityRegistryUpdate = this._entityRegistryUpdate;
+    if (entityRegistryUpdate !== undefined && !this.sceneId) {
       this._newSceneId = id;
       entityRegPromise = new Promise<EntityRegistryEntry>((resolve) => {
         this._entityRegCreated = resolve;
@@ -1337,7 +1319,7 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
       await saveScene(this.hass, id, this._config!);
       this._errors = undefined;
 
-      if (this._entityRegistryUpdate !== undefined) {
+      if (entityRegistryUpdate !== undefined) {
         let entityId = this._scene?.entity_id;
 
         // wait for scene to appear in entity registry when creating a new scene
@@ -1371,10 +1353,10 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
 
         if (entityId) {
           await updateEntityRegistryEntry(this.hass, entityId, {
-            area_id: this._entityRegistryUpdate.area || null,
-            labels: this._entityRegistryUpdate.labels || [],
+            area_id: entityRegistryUpdate.area || null,
+            labels: entityRegistryUpdate.labels || [],
             categories: {
-              scene: this._entityRegistryUpdate.category || null,
+              scene: entityRegistryUpdate.category || null,
             },
           });
         }
@@ -1472,12 +1454,6 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
     return [
       haStyle,
       css`
-        ha-fade-in {
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          height: 100%;
-        }
         ha-card {
           overflow: hidden;
           margin-top: 8px;

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -173,6 +173,11 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
    */
   private _justSavedId?: string;
 
+  /** Bumped when the edited scene changes so stale scene loads are ignored. */
+  private _loadGeneration = 0;
+
+  private _subscribeGeneration = 0;
+
   private _entityRegCreated?: (
     value: PromiseLike<EntityRegistryEntry> | EntityRegistryEntry
   ) => void;
@@ -936,11 +941,20 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
   }
 
   private async _subscribeEvents() {
-    this._unsubscribeEvents =
-      await this.hass!.connection.subscribeEvents<HassEvent>(
-        (event) => this._stateChanged(event),
-        "state_changed"
-      );
+    const generation = ++this._subscribeGeneration;
+    const unsubscribe = await this.hass!.connection.subscribeEvents<HassEvent>(
+      (event) => this._stateChanged(event),
+      "state_changed"
+    );
+    if (
+      generation !== this._subscribeGeneration ||
+      this._mode !== "live" ||
+      !this.isConnected
+    ) {
+      unsubscribe();
+      return;
+    }
+    this._unsubscribeEvents = unsubscribe;
   }
 
   private _showMoreInfo(ev: Event) {
@@ -949,10 +963,14 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
   }
 
   private async _loadConfig() {
+    const generation = ++this._loadGeneration;
     let config: SceneConfig;
     try {
       config = await getSceneConfig(this.hass, this.sceneId!);
     } catch (err: any) {
+      if (generation !== this._loadGeneration) {
+        return;
+      }
       await showAlertDialog(this, {
         text:
           err.status_code === 404
@@ -965,6 +983,10 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
               ),
       });
       goBack("/config/scene/dashboard");
+      return;
+    }
+
+    if (generation !== this._loadGeneration) {
       return;
     }
 
@@ -985,6 +1007,7 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
 
   /** Emulate a freshly opened editor when the edited scene changes. */
   private _resetEditorState() {
+    this._loadGeneration++;
     if (this._mode === "live") {
       this._stopLiveMode();
     }

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -621,7 +621,11 @@ export class HaScriptEditor extends SubscribeMixin(
     }
 
     if (changedProps.has("entityId") && this.entityId) {
+      const generation = ++this.loadGeneration;
       getScriptStateConfig(this.hass, this.entityId).then((c) => {
+        if (generation !== this.loadGeneration) {
+          return;
+        }
         this.config = normalizeScriptConfig(c.config);
         this._initDirtyTracking(
           { type: "deep" },
@@ -652,9 +656,13 @@ export class HaScriptEditor extends SubscribeMixin(
     if (stateObj?.state !== UNAVAILABLE) {
       return;
     }
+    const generation = this.loadGeneration;
     const validation = await validateConfig(this.hass, {
       actions: this.config.sequence,
     });
+    if (generation !== this.loadGeneration) {
+      return;
+    }
     this.validationErrors = (
       Object.entries(validation) as Entries<typeof validation>
     ).map(([key, value]) =>
@@ -839,6 +847,7 @@ export class HaScriptEditor extends SubscribeMixin(
 
   private async _takeControl() {
     const config = this.config as BlueprintScriptConfig;
+    const generation = this.loadGeneration;
 
     try {
       const result = await substituteBlueprint(
@@ -847,6 +856,9 @@ export class HaScriptEditor extends SubscribeMixin(
         config.use_blueprint.path,
         config.use_blueprint.input || {}
       );
+      if (generation !== this.loadGeneration) {
+        return;
+      }
 
       const newConfig = {
         ...normalizeScriptConfig(result.substituted_config),
@@ -862,6 +874,9 @@ export class HaScriptEditor extends SubscribeMixin(
       this.readOnly = true;
       this.errors = undefined;
     } catch (err: any) {
+      if (generation !== this.loadGeneration) {
+        return;
+      }
       this.errors = err.message;
     }
   }

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -114,7 +114,6 @@ export class HaScriptEditor extends SubscribeMixin(
   protected override resetEditorState() {
     super.resetEditorState();
     this._undoRedoController.reset();
-    this._newScriptId = undefined;
   }
 
   protected willUpdate(changedProps: PropertyValues<this>) {
@@ -656,13 +655,9 @@ export class HaScriptEditor extends SubscribeMixin(
     if (stateObj?.state !== UNAVAILABLE) {
       return;
     }
-    const generation = this.loadGeneration;
     const validation = await validateConfig(this.hass, {
       actions: this.config.sequence,
     });
-    if (generation !== this.loadGeneration) {
-      return;
-    }
     this.validationErrors = (
       Object.entries(validation) as Entries<typeof validation>
     ).map(([key, value]) =>
@@ -874,9 +869,6 @@ export class HaScriptEditor extends SubscribeMixin(
       this.readOnly = true;
       this.errors = undefined;
     } catch (err: any) {
-      if (generation !== this.loadGeneration) {
-        return;
-      }
       this.errors = err.message;
     }
   }
@@ -1000,7 +992,8 @@ export class HaScriptEditor extends SubscribeMixin(
     this.saving = true;
 
     let entityRegPromise: Promise<EntityRegistryEntry> | undefined;
-    if (this.entityRegistryUpdate !== undefined && !this.scriptId) {
+    const entityRegistryUpdate = this.entityRegistryUpdate;
+    if (entityRegistryUpdate !== undefined && !this.scriptId) {
       this._newScriptId = id.toString();
       entityRegPromise = new Promise<EntityRegistryEntry>((resolve) => {
         this.entityRegCreated = resolve;
@@ -1014,7 +1007,7 @@ export class HaScriptEditor extends SubscribeMixin(
         this.config
       );
 
-      if (this.entityRegistryUpdate !== undefined) {
+      if (entityRegistryUpdate !== undefined) {
         let entityId = this.currentEntityId;
 
         // wait for new script to appear in entity registry
@@ -1050,10 +1043,10 @@ export class HaScriptEditor extends SubscribeMixin(
         if (entityId) {
           await updateEntityRegistryEntry(this.hass, entityId, {
             categories: {
-              script: this.entityRegistryUpdate.category || null,
+              script: entityRegistryUpdate.category || null,
             },
-            labels: this.entityRegistryUpdate.labels || [],
-            area_id: this.entityRegistryUpdate.area || null,
+            labels: entityRegistryUpdate.labels || [],
+            area_id: entityRegistryUpdate.area || null,
           });
         }
       }

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -111,6 +111,12 @@ export class HaScriptEditor extends SubscribeMixin(
     return super.isDirtyState || !!this.yamlErrors;
   }
 
+  protected override resetEditorState() {
+    super.resetEditorState();
+    this._undoRedoController.reset();
+    this._newScriptId = undefined;
+  }
+
   protected willUpdate(changedProps: PropertyValues<this>) {
     super.willUpdate(changedProps);
 
@@ -566,6 +572,29 @@ export class HaScriptEditor extends SubscribeMixin(
     const oldScript = changedProps.get("scriptId");
     if (
       changedProps.has("scriptId") &&
+      // the show route assigns scriptId internally
+      !this.entityId &&
+      oldScript !== undefined &&
+      oldScript !== this.scriptId
+    ) {
+      if (this.scriptId && this.scriptId === this.justSavedId) {
+        this.justSavedId = undefined;
+      } else {
+        this.resetEditorState();
+      }
+    }
+
+    const oldEntityId = changedProps.get("entityId");
+    if (
+      changedProps.has("entityId") &&
+      oldEntityId !== undefined &&
+      oldEntityId !== this.entityId
+    ) {
+      this.resetEditorState();
+    }
+
+    if (
+      changedProps.has("scriptId") &&
       this.scriptId &&
       !this.entityId &&
       this.hass &&
@@ -964,6 +993,7 @@ export class HaScriptEditor extends SubscribeMixin(
 
     await this._saveScript(id);
     if (!this.scriptId) {
+      this.justSavedId = String(id);
       navigate(`/config/script/edit/${id}`, { replace: true });
     }
   }

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -570,28 +570,11 @@ export class HaScriptEditor extends SubscribeMixin(
     super.updated(changedProps);
 
     const oldScript = changedProps.get("scriptId");
-    if (
-      changedProps.has("scriptId") &&
+    if (!this.entityId) {
       // the show route assigns scriptId internally
-      !this.entityId &&
-      oldScript !== undefined &&
-      oldScript !== this.scriptId
-    ) {
-      if (this.scriptId && this.scriptId === this.justSavedId) {
-        this.justSavedId = undefined;
-      } else {
-        this.resetEditorState();
-      }
+      this.resetOnItemSwitch(oldScript, this.scriptId);
     }
-
-    const oldEntityId = changedProps.get("entityId");
-    if (
-      changedProps.has("entityId") &&
-      oldEntityId !== undefined &&
-      oldEntityId !== this.entityId
-    ) {
-      this.resetEditorState();
-    }
+    this.resetOnItemSwitch(changedProps.get("entityId"), this.entityId);
 
     if (
       changedProps.has("scriptId") &&

--- a/test/fixtures/lit.ts
+++ b/test/fixtures/lit.ts
@@ -1,0 +1,14 @@
+/** Wait a macrotask so async work started by a lifecycle hook settles. */
+export const flush = () =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+/**
+ * Simulate the router re-pointing a reused editor element at another item:
+ * set the property, then invoke the lifecycle hook with the old value the
+ * way Lit would after an update.
+ */
+export const runUpdated = (el: any, changed: Record<string, unknown>) => {
+  el.updated(new Map(Object.entries(changed)));
+};

--- a/test/panels/config/automation/automation-editor-item-switch.test.ts
+++ b/test/panels/config/automation/automation-editor-item-switch.test.ts
@@ -107,6 +107,33 @@ describe("automation editor item switch", () => {
     expect(el.config?.alias).toBe("a");
   });
 
+  test("ignores a config fetch that resolves after switching items", async () => {
+    const el = createEditor();
+    let resolveA!: (value: AutomationConfig) => void;
+    (el.hass.callApi as any).mockImplementation(
+      (_method: string, path: string) => {
+        const id = path.split("/").pop();
+        if (id === "a") {
+          return new Promise((resolve) => {
+            resolveA = resolve;
+          });
+        }
+        return Promise.resolve(configFor(id!));
+      }
+    );
+    el.automationId = "a";
+    runUpdated(el, { automationId: undefined });
+
+    el.automationId = "b";
+    runUpdated(el, { automationId: "a" });
+    await flush();
+    expect(el.config?.alias).toBe("b");
+
+    resolveA(configFor("a"));
+    await flush();
+    expect(el.config?.alias).toBe("b");
+  });
+
   test("switching to another entity in the read-only view resets the editor state", async () => {
     const el = createEditor();
     el.entityId = "automation.one";

--- a/test/panels/config/automation/automation-editor-item-switch.test.ts
+++ b/test/panels/config/automation/automation-editor-item-switch.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test, vi } from "vitest";
+
+import "../../../../src/panels/config/automation/ha-automation-editor";
+import type { HaAutomationEditor } from "../../../../src/panels/config/automation/ha-automation-editor";
+import type { AutomationConfig } from "../../../../src/data/automation";
+import { createMockHass } from "../../../fixtures/hass";
+
+const configFor = (alias: string): AutomationConfig => ({
+  alias,
+  triggers: [],
+  conditions: [],
+  actions: [],
+});
+
+const flush = () =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+const createEditor = (): any => {
+  const el = document.createElement(
+    "ha-automation-editor"
+  ) as HaAutomationEditor;
+  const hass = createMockHass();
+  (hass as any).callApi = vi.fn(async (_method: string, path: string) =>
+    configFor(path.split("/").pop()!)
+  );
+  (hass as any).callWS = vi.fn(async () => ({ config: configFor("state") }));
+  el.hass = hass;
+  el.automations = [];
+  el.narrow = false;
+  el.isWide = false;
+  return el;
+};
+
+// Simulate the router re-pointing a reused editor element at another item:
+// set the property, then invoke the lifecycle hook with the old value the
+// way Lit would after an update.
+const runUpdated = (el: any, changed: Record<string, unknown>) => {
+  el.updated(new Map(Object.entries(changed)));
+};
+
+describe("automation editor item switch", () => {
+  test("switching to another automation resets the editor state", async () => {
+    const el = createEditor();
+    el.automationId = "a";
+    runUpdated(el, { automationId: undefined });
+    await flush();
+    expect(el.config?.alias).toBe("a");
+
+    el.mode = "yaml";
+    el.yamlErrors = "unparseable";
+    el.errors = "save failed";
+    el._undoRedoController.commit(configFor("a-edited"));
+    expect(el._undoRedoController.canUndo).toBe(true);
+
+    el.automationId = "b";
+    runUpdated(el, { automationId: "a" });
+
+    expect(el.mode).toBe("gui");
+    expect(el.yamlErrors).toBeUndefined();
+    expect(el.errors).toBeUndefined();
+    expect(el._undoRedoController.canUndo).toBe(false);
+    await flush();
+    expect(el.config?.alias).toBe("b");
+    expect(el.isDirtyState).toBe(false);
+  });
+
+  test("keeps state when the id change comes from saving a new automation", async () => {
+    const el = createEditor();
+    el.automationId = null;
+    runUpdated(el, { automationId: undefined });
+    expect(el.config).toBeDefined();
+
+    el.mode = "yaml";
+    el.justSavedId = "123";
+    el.automationId = "123";
+    runUpdated(el, { automationId: null });
+
+    expect(el.mode).toBe("yaml");
+    expect(el.justSavedId).toBeUndefined();
+    await flush();
+    expect(el.config?.alias).toBe("123");
+  });
+
+  test("resets when leaving an unsaved new automation for an existing one", () => {
+    const el = createEditor();
+    el.automationId = null;
+    runUpdated(el, { automationId: undefined });
+    el.mode = "yaml";
+
+    el.automationId = "b";
+    runUpdated(el, { automationId: null });
+
+    expect(el.mode).toBe("gui");
+  });
+
+  test("resets when switching from an existing automation to a new one", async () => {
+    const el = createEditor();
+    el.automationId = "a";
+    runUpdated(el, { automationId: undefined });
+    await flush();
+    el.mode = "yaml";
+
+    el.automationId = null;
+    runUpdated(el, { automationId: "a" });
+
+    expect(el.mode).toBe("gui");
+    expect(el.config?.triggers).toEqual([]);
+  });
+
+  test("does not reset on the first id assignment of a fresh element", async () => {
+    const el = createEditor();
+    el.yamlErrors = "sentinel";
+    el.automationId = "a";
+    runUpdated(el, { automationId: undefined });
+
+    expect(el.yamlErrors).toBe("sentinel");
+    await flush();
+    expect(el.config?.alias).toBe("a");
+  });
+
+  test("switching to another entity in the read-only view resets the editor state", async () => {
+    const el = createEditor();
+    el.entityId = "automation.one";
+    runUpdated(el, { entityId: undefined });
+    await flush();
+    el.mode = "yaml";
+
+    el.entityId = "automation.two";
+    runUpdated(el, { entityId: "automation.one" });
+
+    expect(el.mode).toBe("gui");
+    expect(el.readOnly).toBe(true);
+    await flush();
+    expect(el.config?.alias).toBe("state");
+  });
+});

--- a/test/panels/config/automation/automation-editor-item-switch.test.ts
+++ b/test/panels/config/automation/automation-editor-item-switch.test.ts
@@ -4,6 +4,7 @@ import "../../../../src/panels/config/automation/ha-automation-editor";
 import type { HaAutomationEditor } from "../../../../src/panels/config/automation/ha-automation-editor";
 import type { AutomationConfig } from "../../../../src/data/automation";
 import { createMockHass } from "../../../fixtures/hass";
+import { flush, runUpdated } from "../../../fixtures/lit";
 
 const configFor = (alias: string): AutomationConfig => ({
   alias,
@@ -11,11 +12,6 @@ const configFor = (alias: string): AutomationConfig => ({
   conditions: [],
   actions: [],
 });
-
-const flush = () =>
-  new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
 
 const createEditor = (): any => {
   const el = document.createElement(
@@ -28,16 +24,7 @@ const createEditor = (): any => {
   (hass as any).callWS = vi.fn(async () => ({ config: configFor("state") }));
   el.hass = hass;
   el.automations = [];
-  el.narrow = false;
-  el.isWide = false;
   return el;
-};
-
-// Simulate the router re-pointing a reused editor element at another item:
-// set the property, then invoke the lifecycle hook with the old value the
-// way Lit would after an update.
-const runUpdated = (el: any, changed: Record<string, unknown>) => {
-  el.updated(new Map(Object.entries(changed)));
 };
 
 describe("automation editor item switch", () => {

--- a/test/panels/config/scene/scene-editor-item-switch.test.ts
+++ b/test/panels/config/scene/scene-editor-item-switch.test.ts
@@ -4,11 +4,7 @@ import "../../../../src/panels/config/scene/ha-scene-editor";
 import type { HaSceneEditor } from "../../../../src/panels/config/scene/ha-scene-editor";
 import { showSceneEditor } from "../../../../src/data/scene";
 import { createMockHass } from "../../../fixtures/hass";
-
-const flush = () =>
-  new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
+import { flush, runUpdated } from "../../../fixtures/lit";
 
 const createEditor = (): any => {
   const el = document.createElement("ha-scene-editor") as HaSceneEditor;
@@ -21,16 +17,7 @@ const createEditor = (): any => {
   (hass as any).connection = { subscribeEvents: vi.fn(async () => vi.fn()) };
   el.hass = hass;
   el.scenes = [];
-  el.narrow = false;
-  el.isWide = false;
   return el;
-};
-
-// Simulate the router re-pointing a reused editor element at another scene:
-// set the property, then invoke the lifecycle hook with the old value the
-// way Lit would after an update.
-const runUpdated = (el: any, changed: Record<string, unknown>) => {
-  el.updated(new Map(Object.entries(changed)));
 };
 
 describe("scene editor item switch", () => {

--- a/test/panels/config/scene/scene-editor-item-switch.test.ts
+++ b/test/panels/config/scene/scene-editor-item-switch.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test, vi } from "vitest";
+
+import "../../../../src/panels/config/scene/ha-scene-editor";
+import type { HaSceneEditor } from "../../../../src/panels/config/scene/ha-scene-editor";
+import { showSceneEditor } from "../../../../src/data/scene";
+import { createMockHass } from "../../../fixtures/hass";
+
+const flush = () =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+const createEditor = (): any => {
+  const el = document.createElement("ha-scene-editor") as HaSceneEditor;
+  const hass = createMockHass();
+  (hass as any).callApi = vi.fn(async (_method: string, path: string) => ({
+    name: `${path.split("/").pop()} name`,
+    entities: {},
+  }));
+  (hass as any).callService = vi.fn(async () => ({}));
+  (hass as any).connection = { subscribeEvents: vi.fn(async () => vi.fn()) };
+  el.hass = hass;
+  el.scenes = [];
+  el.narrow = false;
+  el.isWide = false;
+  return el;
+};
+
+// Simulate the router re-pointing a reused editor element at another scene:
+// set the property, then invoke the lifecycle hook with the old value the
+// way Lit would after an update.
+const runUpdated = (el: any, changed: Record<string, unknown>) => {
+  el.updated(new Map(Object.entries(changed)));
+};
+
+describe("scene editor item switch", () => {
+  test("switching to another scene resets the editor state", async () => {
+    const el = createEditor();
+    el.sceneId = "scene_a";
+    runUpdated(el, { sceneId: undefined });
+    await flush();
+    expect(el._config?.name).toBe("scene_a name");
+
+    el._mode = "yaml";
+    el._yamlErrors = "unparseable";
+
+    el.sceneId = "scene_b";
+    runUpdated(el, { sceneId: "scene_a" });
+
+    expect(el._mode).toBe("review");
+    expect(el._yamlErrors).toBeUndefined();
+    await flush();
+    expect(el._config?.name).toBe("scene_b name");
+  });
+
+  test("leaving live mode restores stored states and unsubscribes", async () => {
+    const el = createEditor();
+    el.sceneId = "scene_a";
+    runUpdated(el, { sceneId: undefined });
+    await flush();
+
+    const unsubscribe = vi.fn();
+    const storedStates = { "light.kitchen": "on" };
+    el._mode = "live";
+    el._storedStates = storedStates;
+    el._unsubscribeEvents = unsubscribe;
+
+    el.sceneId = "scene_b";
+    runUpdated(el, { sceneId: "scene_a" });
+
+    expect(el.hass.callService).toHaveBeenCalledWith("scene", "apply", {
+      entities: storedStates,
+    });
+    expect(unsubscribe).toHaveBeenCalled();
+    expect(el._unsubscribeEvents).toBeUndefined();
+    expect(el._mode).toBe("review");
+  });
+
+  test("duplicating a scene opens the copy in review mode", async () => {
+    const el = createEditor();
+    el.sceneId = "scene_a";
+    runUpdated(el, { sceneId: undefined });
+    await flush();
+    el._mode = "yaml";
+
+    showSceneEditor({ name: "scene_a name (Duplicate)", entities: {} });
+    el.sceneId = null;
+    runUpdated(el, { sceneId: "scene_a" });
+
+    expect(el._mode).toBe("review");
+    expect(el._config?.name).toBe("scene_a name (Duplicate)");
+    expect(el.hass.connection.subscribeEvents).not.toHaveBeenCalled();
+    expect(el.isDirtyState).toBe(true);
+  });
+
+  test("keeps state when the id change comes from saving a new scene", async () => {
+    const el = createEditor();
+    el.sceneId = null;
+    runUpdated(el, { sceneId: undefined });
+    expect(el._config).toBeDefined();
+
+    el._mode = "yaml";
+    el._justSavedId = "123";
+    el.sceneId = "123";
+    runUpdated(el, { sceneId: null });
+
+    expect(el._mode).toBe("yaml");
+    expect(el._justSavedId).toBeUndefined();
+    await flush();
+    expect(el._config?.name).toBe("123 name");
+  });
+});

--- a/test/panels/config/scene/scene-editor-item-switch.test.ts
+++ b/test/panels/config/scene/scene-editor-item-switch.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import "../../../../src/panels/config/scene/ha-scene-editor";
 import type { HaSceneEditor } from "../../../../src/panels/config/scene/ha-scene-editor";
+import type { SceneConfig } from "../../../../src/data/scene";
 import { showSceneEditor } from "../../../../src/data/scene";
 import { createMockHass } from "../../../fixtures/hass";
 import { flush, runUpdated } from "../../../fixtures/lit";
@@ -78,6 +79,61 @@ describe("scene editor item switch", () => {
     expect(el._config?.name).toBe("scene_a name (Duplicate)");
     expect(el.hass.connection.subscribeEvents).not.toHaveBeenCalled();
     expect(el.isDirtyState).toBe(true);
+  });
+
+  test("ignores a scene fetch that resolves after switching scenes", async () => {
+    const el = createEditor();
+    let resolveA!: (value: SceneConfig) => void;
+    (el.hass.callApi as any).mockImplementation(
+      (_method: string, path: string) => {
+        if (path.endsWith("/scene_a")) {
+          return new Promise((resolve) => {
+            resolveA = resolve;
+          });
+        }
+        return Promise.resolve({
+          name: `${path.split("/").pop()} name`,
+          entities: {},
+        });
+      }
+    );
+    el.sceneId = "scene_a";
+    runUpdated(el, { sceneId: undefined });
+
+    el.sceneId = "scene_b";
+    runUpdated(el, { sceneId: "scene_a" });
+    await flush();
+    expect(el._config?.name).toBe("scene_b name");
+
+    resolveA({ name: "scene_a name", entities: {} });
+    await flush();
+    expect(el._config?.name).toBe("scene_b name");
+  });
+
+  test("discards a live subscription that resolves after switching scenes", async () => {
+    const el = createEditor();
+    el.sceneId = "scene_a";
+    runUpdated(el, { sceneId: undefined });
+    await flush();
+
+    let resolveSubscribe!: (value: () => void) => void;
+    el.hass.connection.subscribeEvents = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveSubscribe = resolve;
+        })
+    );
+    el._mode = "live";
+    el._subscribeEvents();
+
+    el.sceneId = "scene_b";
+    runUpdated(el, { sceneId: "scene_a" });
+
+    const unsubscribe = vi.fn();
+    resolveSubscribe(unsubscribe);
+    await flush();
+    expect(unsubscribe).toHaveBeenCalled();
+    expect(el._unsubscribeEvents).toBeUndefined();
   });
 
   test("keeps state when the id change comes from saving a new scene", async () => {

--- a/test/panels/config/script/script-editor-item-switch.test.ts
+++ b/test/panels/config/script/script-editor-item-switch.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test, vi } from "vitest";
+
+import "../../../../src/panels/config/script/ha-script-editor";
+import type { HaScriptEditor } from "../../../../src/panels/config/script/ha-script-editor";
+import type { ScriptConfig } from "../../../../src/data/script";
+import { createMockHass } from "../../../fixtures/hass";
+import { flush, runUpdated } from "../../../fixtures/lit";
+
+const configFor = (alias: string): ScriptConfig => ({
+  alias,
+  sequence: [],
+});
+
+const createEditor = (): any => {
+  const el = document.createElement("ha-script-editor") as HaScriptEditor;
+  const hass = createMockHass();
+  (hass as any).callApi = vi.fn(async (_method: string, path: string) =>
+    configFor(path.split("/").pop()!)
+  );
+  (hass as any).callWS = vi.fn(async () => ({ config: configFor("state") }));
+  el.hass = hass;
+  return el;
+};
+
+describe("script editor item switch", () => {
+  test("switching to another script resets the editor state", async () => {
+    const el = createEditor();
+    el.scriptId = "a";
+    runUpdated(el, { scriptId: undefined });
+    await flush();
+    expect(el.config?.alias).toBe("a");
+
+    el.mode = "yaml";
+    el.yamlErrors = "unparseable";
+    el._undoRedoController.commit(configFor("a-edited"));
+    expect(el._undoRedoController.canUndo).toBe(true);
+
+    el.scriptId = "b";
+    runUpdated(el, { scriptId: "a" });
+
+    expect(el.mode).toBe("gui");
+    expect(el.yamlErrors).toBeUndefined();
+    expect(el._undoRedoController.canUndo).toBe(false);
+    await flush();
+    expect(el.config?.alias).toBe("b");
+  });
+
+  test("keeps state when the id change comes from saving a new script", async () => {
+    const el = createEditor();
+    el.scriptId = null;
+    runUpdated(el, { scriptId: undefined });
+    expect(el.config).toBeDefined();
+
+    el.mode = "yaml";
+    el.justSavedId = "123";
+    el.scriptId = "123";
+    runUpdated(el, { scriptId: null });
+
+    expect(el.mode).toBe("yaml");
+    expect(el.justSavedId).toBeUndefined();
+    await flush();
+    expect(el.config?.alias).toBe("123");
+  });
+
+  test("switching to another entity in the read-only view resets the editor state", async () => {
+    const el = createEditor();
+    el.entityRegistry = [
+      { entity_id: "script.one", unique_id: "one", platform: "script" },
+      { entity_id: "script.two", unique_id: "two", platform: "script" },
+    ];
+    el.entityId = "script.one";
+    runUpdated(el, { entityId: undefined });
+    expect(el.scriptId).toBe("one");
+    await flush();
+
+    // the show route assigns scriptId internally; that must not reset
+    el.yamlErrors = "sentinel";
+    runUpdated(el, { scriptId: null });
+    expect(el.yamlErrors).toBe("sentinel");
+
+    el.mode = "yaml";
+    el.entityId = "script.two";
+    runUpdated(el, { entityId: "script.one" });
+
+    expect(el.mode).toBe("gui");
+    expect(el.readOnly).toBe(true);
+    expect(el.scriptId).toBe("two");
+    await flush();
+    expect(el.config?.alias).toBe("state");
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The config panel is cached and the router reuses the editor element when only the item id in the route changes, so opening another automation via more-info → Edit automation kept the previous automation's YAML on screen (along with its undo history and pending registry changes), and saving from there would overwrite the newly opened automation with the old content. Switching to a different automation, script, or scene now resets the editor to a freshly opened state; the reset is skipped when the id change comes from just saving a new item, so that flow keeps its mode and content. The scene editor also tears down its live-mode subscription and restores the stored entity states when it leaves live mode this way.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Editing automation A in YAML mode, then opening automation B ("Bravo evening blinds") via more-info → Edit automation:

| Before | After |
|--------|-------|
| ![before](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/before-9148f97f.png) | ![after](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/after-7a91ea7e.png) |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
