### PR TITLE
Prompt for unsaved changes on programmatic navigation

### DIFF
--- a/src/common/navigate.ts
+++ b/src/common/navigate.ts
@@ -103,6 +103,13 @@ export const unregisterUnsavedChangesGuard = (guard: UnsavedChangesGuard) => {
 let pendingUnsavedPrompt: Promise<boolean> | undefined;
 
 /**
+ * Counts navigations that changed the history entry, so a navigation held up
+ * by an unsaved-changes prompt can tell whether a newer one has moved the app
+ * on in the meantime.
+ */
+let committedNavigations = 0;
+
+/**
  * Asks each dirty guard whether navigation may proceed. Returns true when
  * nothing is dirty or every prompt was confirmed. Concurrent navigations
  * share one pending prompt instead of stacking dialogs; the dirty check runs
@@ -181,14 +188,24 @@ const performNavigation = async (path: string, options?: NavigateOptions) => {
   fireEvent(mainWindow, "location-changed", {
     replace,
   });
+  committedNavigations += 1;
   return true;
 };
 
 export const navigate = async (path: string, options?: NavigateOptions) => {
   // Only guard actual departures: navigating to the current path keeps the
   // page, and any unsaved state on it, mounted.
-  if (path !== currentPath() && !(await ensureUnsavedChangesConfirmed())) {
-    return false;
+  if (path !== currentPath()) {
+    const navigationsBeforePrompt = committedNavigations;
+    if (!(await ensureUnsavedChangesConfirmed())) {
+      return false;
+    }
+    if (committedNavigations !== navigationsBeforePrompt) {
+      // Another navigation landed while the prompt was waiting for an answer,
+      // so this destination is stale. Dropping it keeps a late answer from
+      // pulling the user back off the page they are on now.
+      return false;
+    }
   }
   return performNavigation(path, options);
 };

--- a/src/common/navigate.ts
+++ b/src/common/navigate.ts
@@ -80,6 +80,60 @@ const ensureDialogsClosed = async (timestamp: number): Promise<boolean> => {
   return ensureDialogsClosed(timestamp);
 };
 
+/**
+ * Lets a page with unsaved changes (e.g. the automation editor) veto
+ * navigation. `isDirty` is read live at navigation time; `prompt` resolves
+ * true when navigation may proceed.
+ */
+export interface UnsavedChangesGuard {
+  isDirty(): boolean;
+  prompt(): Promise<boolean>;
+}
+
+const unsavedChangesGuards = new Set<UnsavedChangesGuard>();
+
+export const registerUnsavedChangesGuard = (guard: UnsavedChangesGuard) => {
+  unsavedChangesGuards.add(guard);
+};
+
+export const unregisterUnsavedChangesGuard = (guard: UnsavedChangesGuard) => {
+  unsavedChangesGuards.delete(guard);
+};
+
+let pendingUnsavedPrompt: Promise<boolean> | undefined;
+
+/**
+ * Asks each dirty guard whether navigation may proceed. Returns true when
+ * nothing is dirty or every prompt was confirmed. Concurrent navigations
+ * share one pending prompt instead of stacking dialogs; the dirty check runs
+ * before joining it, so a navigation triggered from inside a prompt (e.g. by
+ * its save action) cannot deadlock on its own promise.
+ */
+const ensureUnsavedChangesConfirmed = (): Promise<boolean> => {
+  const dirtyGuards = [...unsavedChangesGuards].filter((guard) =>
+    guard.isDirty()
+  );
+  if (!dirtyGuards.length) {
+    return Promise.resolve(true);
+  }
+  if (!pendingUnsavedPrompt) {
+    pendingUnsavedPrompt = (async () => {
+      try {
+        for (const guard of dirtyGuards) {
+          // eslint-disable-next-line no-await-in-loop
+          if (!(await guard.prompt())) {
+            return false;
+          }
+        }
+        return true;
+      } finally {
+        pendingUnsavedPrompt = undefined;
+      }
+    })();
+  }
+  return pendingUnsavedPrompt;
+};
+
 const buildHistoryState = (
   data: Record<string, unknown> | undefined,
   from?: string
@@ -91,7 +145,7 @@ const buildHistoryState = (
   return { ...state, from };
 };
 
-export const navigate = async (path: string, options?: NavigateOptions) => {
+const performNavigation = async (path: string, options?: NavigateOptions) => {
   const canProceed = await ensureDialogsClosed(Date.now());
   if (!canProceed) {
     return false;
@@ -130,6 +184,15 @@ export const navigate = async (path: string, options?: NavigateOptions) => {
   return true;
 };
 
+export const navigate = async (path: string, options?: NavigateOptions) => {
+  // Only guard actual departures: navigating to the current path keeps the
+  // page, and any unsaved state on it, mounted.
+  if (path !== currentPath() && !(await ensureUnsavedChangesConfirmed())) {
+    return false;
+  }
+  return performNavigation(path, options);
+};
+
 /**
  * Whether the previous history entry is a page this app navigated away from.
  * `history.length` cannot answer this: a login redirect goes through
@@ -142,6 +205,9 @@ export const canGoBack = (): boolean =>
 /**
  * Navigate back to the page we came from, falling back to a path when the
  * previous entry is not ours (deep link, login redirect, fresh tab).
+ * Deliberately not guarded against unsaved changes: pages with such a guard
+ * confirm in their own back handlers, and delete flows leave through here
+ * after the edited item is already gone.
  */
 export const goBack = async (fallbackPath?: string): Promise<void> => {
   const canProceed = await ensureDialogsClosed(Date.now());
@@ -156,5 +222,5 @@ export const goBack = async (fallbackPath?: string): Promise<void> => {
     return;
   }
 
-  await navigate(fallbackPath || "/", { replace: true });
+  await performNavigation(fallbackPath || "/", { replace: true });
 };

--- a/src/mixins/prevent-unsaved-mixin.ts
+++ b/src/mixins/prevent-unsaved-mixin.ts
@@ -1,5 +1,9 @@
 import type { LitElement, PropertyValues } from "lit";
-import { isNavigationClick } from "../common/dom/is-navigation-click";
+import type { UnsavedChangesGuard } from "../common/navigate";
+import {
+  registerUnsavedChangesGuard,
+  unregisterUnsavedChangesGuard,
+} from "../common/navigate";
 import type { Constructor } from "../types";
 
 export const PreventUnsavedMixin = <T extends Constructor<LitElement>>(
@@ -9,45 +13,34 @@ export const PreventUnsavedMixin = <T extends Constructor<LitElement>>(
     /** Provided by `DirtyStateProviderMixin`. */
     declare isDirtyState: boolean;
 
-    private _handleClick = async (e: MouseEvent) => {
-      // get the right target, otherwise the composedPath would return <home-assistant> in the new event
-      const target = e.composedPath()[0];
-      if (!isNavigationClick(e)) {
-        return;
-      }
-
-      const result = await this.promptDiscardChanges();
-      if (result) {
-        this._removeListeners();
-        if (target) {
-          const newEvent = new MouseEvent(e.type, e);
-          target.dispatchEvent(newEvent);
-        }
-      }
-    };
-
     private _handleUnload = (e: BeforeUnloadEvent) => e.preventDefault();
 
-    private _removeListeners() {
-      window.removeEventListener("click", this._handleClick, true);
-      window.removeEventListener("beforeunload", this._handleUnload);
+    private _unsavedChangesGuard: UnsavedChangesGuard = {
+      isDirty: () => this.isDirtyState,
+      prompt: () => this.promptDiscardChanges(),
+    };
+
+    public connectedCallback(): void {
+      super.connectedCallback();
+
+      registerUnsavedChangesGuard(this._unsavedChangesGuard);
     }
 
     protected willUpdate(changedProperties: PropertyValues<this>): void {
       super.willUpdate(changedProperties);
 
       if (this.isDirtyState && this.isConnected) {
-        window.addEventListener("click", this._handleClick, true);
         window.addEventListener("beforeunload", this._handleUnload);
       } else {
-        this._removeListeners();
+        window.removeEventListener("beforeunload", this._handleUnload);
       }
     }
 
     public disconnectedCallback(): void {
       super.disconnectedCallback();
 
-      this._removeListeners();
+      unregisterUnsavedChangesGuard(this._unsavedChangesGuard);
+      window.removeEventListener("beforeunload", this._handleUnload);
     }
 
     protected async promptDiscardChanges(): Promise<boolean> {

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -896,10 +896,15 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
             return;
           }
 
+          this.yamlErrors = undefined;
           resolve(true);
         },
         onClose: () => resolve(false),
-        onDiscard: () => resolve(true),
+        onDiscard: () => {
+          this.yamlErrors = undefined;
+          this._markDirtyStateClean();
+          resolve(true);
+        },
         entityRegistryUpdate: this.entityRegistryUpdate,
         entityRegistryEntry: this.registryEntry,
         title: this.hass.localize(

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -1115,20 +1115,24 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
   }
 
   private async _confirmUnsavedChanged(): Promise<boolean> {
-    if (this.isDirtyState) {
-      return showConfirmationDialog(this, {
-        title: this.hass!.localize(
-          "ui.panel.config.scene.editor.unsaved_confirm_title"
-        ),
-        text: this.hass!.localize(
-          "ui.panel.config.scene.editor.unsaved_confirm_text"
-        ),
-        confirmText: this.hass!.localize("ui.common.leave"),
-        dismissText: this.hass!.localize("ui.common.stay"),
-        destructive: true,
-      });
+    if (!this.isDirtyState) {
+      return true;
     }
-    return true;
+    const confirmed = await showConfirmationDialog(this, {
+      title: this.hass!.localize(
+        "ui.panel.config.scene.editor.unsaved_confirm_title"
+      ),
+      text: this.hass!.localize(
+        "ui.panel.config.scene.editor.unsaved_confirm_text"
+      ),
+      confirmText: this.hass!.localize("ui.common.leave"),
+      dismissText: this.hass!.localize("ui.common.stay"),
+      destructive: true,
+    });
+    if (confirmed) {
+      this._markDirtyStateClean();
+    }
+    return confirmed;
   }
 
   private async _duplicate() {

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -804,10 +804,15 @@ export class HaScriptEditor extends SubscribeMixin(
             return;
           }
 
+          this.yamlErrors = undefined;
           resolve(true);
         },
         onClose: () => resolve(false),
-        onDiscard: () => resolve(true),
+        onDiscard: () => {
+          this.yamlErrors = undefined;
+          this._markDirtyStateClean();
+          resolve(true);
+        },
         entityRegistryUpdate: this.entityRegistryUpdate,
         entityRegistryEntry: this.registryEntry,
         title: this.hass.localize(

--- a/test/common/navigate.test.ts
+++ b/test/common/navigate.test.ts
@@ -1,7 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { NavigateOptions } from "../../src/common/navigate";
-import { canGoBack, goBack, navigate } from "../../src/common/navigate";
+import type {
+  NavigateOptions,
+  UnsavedChangesGuard,
+} from "../../src/common/navigate";
+import {
+  canGoBack,
+  goBack,
+  navigate,
+  registerUnsavedChangesGuard,
+  unregisterUnsavedChangesGuard,
+} from "../../src/common/navigate";
 
 // navigate() closes open dialogs before touching history.
 vi.mock("../../src/dialogs/make-dialog-manager", () => ({
@@ -51,6 +60,133 @@ describe("navigate", () => {
   it("does not stamp an entry the app did not push", () => {
     expect(window.history.state).toBeNull();
     expect(canGoBack()).toBe(false);
+  });
+});
+
+describe("unsaved changes guard", () => {
+  const registeredGuards: UnsavedChangesGuard[] = [];
+
+  const registerGuard = (isDirty: boolean, promptResult = true) => {
+    const guard = {
+      isDirty: vi.fn(() => isDirty),
+      prompt: vi.fn(async () => promptResult),
+    };
+    registerUnsavedChangesGuard(guard);
+    registeredGuards.push(guard);
+    return guard;
+  };
+
+  beforeEach(() => {
+    setEntry("/config");
+  });
+
+  afterEach(() => {
+    registeredGuards.splice(0).forEach(unregisterUnsavedChangesGuard);
+  });
+
+  it("navigates without prompting when no guard is dirty", async () => {
+    const guard = registerGuard(false);
+
+    expect(await navigate("/config/areas")).toBe(true);
+
+    expect(window.location.pathname).toEqual("/config/areas");
+    expect(guard.prompt).not.toHaveBeenCalled();
+  });
+
+  it("prompts a dirty guard and navigates when confirmed", async () => {
+    const guard = registerGuard(true, true);
+
+    expect(await navigate("/config/areas")).toBe(true);
+
+    expect(guard.prompt).toHaveBeenCalledOnce();
+    expect(window.location.pathname).toEqual("/config/areas");
+  });
+
+  it("leaves history untouched when the prompt is declined", async () => {
+    const guard = registerGuard(true, false);
+    const listener = vi.fn();
+    window.addEventListener("location-changed", listener);
+
+    expect(await navigate("/config/areas")).toBe(false);
+
+    window.removeEventListener("location-changed", listener);
+    expect(guard.prompt).toHaveBeenCalledOnce();
+    expect(window.location.pathname).toEqual("/config");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("does not prompt when navigating to the current path", async () => {
+    const guard = registerGuard(true, false);
+
+    expect(await navigate("/config")).toBe(true);
+
+    expect(guard.prompt).not.toHaveBeenCalled();
+  });
+
+  it("skips a pending prompt once no guard is dirty anymore", async () => {
+    let dirty = true;
+    let resolvePrompt!: (value: boolean) => void;
+    const guard: UnsavedChangesGuard = {
+      isDirty: () => dirty,
+      prompt: vi.fn(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolvePrompt = resolve;
+          })
+      ),
+    };
+    registerUnsavedChangesGuard(guard);
+    registeredGuards.push(guard);
+
+    const first = navigate("/config/areas");
+    dirty = false;
+
+    expect(await navigate("/config/devices/dashboard")).toBe(true);
+    expect(window.location.pathname).toEqual("/config/devices/dashboard");
+
+    resolvePrompt(true);
+    expect(await first).toBe(true);
+    expect(guard.prompt).toHaveBeenCalledOnce();
+  });
+
+  it("shares one pending prompt between concurrent navigations", async () => {
+    let resolvePrompt!: (value: boolean) => void;
+    const guard: UnsavedChangesGuard = {
+      isDirty: () => true,
+      prompt: vi.fn(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolvePrompt = resolve;
+          })
+      ),
+    };
+    registerUnsavedChangesGuard(guard);
+    registeredGuards.push(guard);
+
+    const first = navigate("/config/areas");
+    const second = navigate("/config/devices/dashboard");
+    resolvePrompt(true);
+
+    expect(await Promise.all([first, second])).toEqual([true, true]);
+    expect(guard.prompt).toHaveBeenCalledOnce();
+  });
+
+  it("stops prompting once the guard is unregistered", async () => {
+    const guard = registerGuard(true, false);
+    unregisterUnsavedChangesGuard(guard);
+
+    expect(await navigate("/config/areas")).toBe(true);
+
+    expect(guard.prompt).not.toHaveBeenCalled();
+  });
+
+  it("does not prompt for goBack's fallback navigation", async () => {
+    const guard = registerGuard(true, false);
+
+    await goBack("/config/cloud/account");
+
+    expect(window.location.pathname).toEqual("/config/cloud/account");
+    expect(guard.prompt).not.toHaveBeenCalled();
   });
 });
 

--- a/test/common/navigate.test.ts
+++ b/test/common/navigate.test.ts
@@ -66,15 +66,19 @@ describe("navigate", () => {
 describe("unsaved changes guard", () => {
   const registeredGuards: UnsavedChangesGuard[] = [];
 
-  const registerGuard = (isDirty: boolean, promptResult = true) => {
-    const guard = {
-      isDirty: vi.fn(() => isDirty),
-      prompt: vi.fn(async () => promptResult),
-    };
+  // Registering through this keeps afterEach able to clean up the module-level
+  // registry, which outlives the test that filled it.
+  const trackGuard = <T extends UnsavedChangesGuard>(guard: T): T => {
     registerUnsavedChangesGuard(guard);
     registeredGuards.push(guard);
     return guard;
   };
+
+  const registerGuard = (isDirty: boolean, promptResult = true) =>
+    trackGuard({
+      isDirty: vi.fn(() => isDirty),
+      prompt: vi.fn(async () => promptResult),
+    });
 
   beforeEach(() => {
     setEntry("/config");
@@ -126,7 +130,7 @@ describe("unsaved changes guard", () => {
   it("skips a pending prompt once no guard is dirty anymore", async () => {
     let dirty = true;
     let resolvePrompt!: (value: boolean) => void;
-    const guard: UnsavedChangesGuard = {
+    const guard = trackGuard({
       isDirty: () => dirty,
       prompt: vi.fn(
         () =>
@@ -134,9 +138,7 @@ describe("unsaved changes guard", () => {
             resolvePrompt = resolve;
           })
       ),
-    };
-    registerUnsavedChangesGuard(guard);
-    registeredGuards.push(guard);
+    });
 
     const first = navigate("/config/areas");
     dirty = false;
@@ -151,7 +153,7 @@ describe("unsaved changes guard", () => {
 
   it("shares one pending prompt between concurrent navigations", async () => {
     let resolvePrompt!: (value: boolean) => void;
-    const guard: UnsavedChangesGuard = {
+    const guard = trackGuard({
       isDirty: () => true,
       prompt: vi.fn(
         () =>
@@ -159,9 +161,7 @@ describe("unsaved changes guard", () => {
             resolvePrompt = resolve;
           })
       ),
-    };
-    registerUnsavedChangesGuard(guard);
-    registeredGuards.push(guard);
+    });
 
     const first = navigate("/config/areas");
     const second = navigate("/config/devices/dashboard");

--- a/test/common/navigate.test.ts
+++ b/test/common/navigate.test.ts
@@ -80,6 +80,21 @@ describe("unsaved changes guard", () => {
       prompt: vi.fn(async () => promptResult),
     });
 
+  // A guard whose prompt stays open until the test answers it.
+  const trackDeferredGuard = (isDirty: () => boolean) => {
+    let answer!: (value: boolean) => void;
+    const guard = trackGuard({
+      isDirty,
+      prompt: vi.fn(
+        () =>
+          new Promise<boolean>((resolve) => {
+            answer = resolve;
+          })
+      ),
+    });
+    return { guard, answerPrompt: (value: boolean) => answer(value) };
+  };
+
   beforeEach(() => {
     setEntry("/config");
   });
@@ -129,45 +144,42 @@ describe("unsaved changes guard", () => {
 
   it("skips a pending prompt once no guard is dirty anymore", async () => {
     let dirty = true;
-    let resolvePrompt!: (value: boolean) => void;
-    const guard = trackGuard({
-      isDirty: () => dirty,
-      prompt: vi.fn(
-        () =>
-          new Promise<boolean>((resolve) => {
-            resolvePrompt = resolve;
-          })
-      ),
-    });
+    const { guard, answerPrompt } = trackDeferredGuard(() => dirty);
 
     const first = navigate("/config/areas");
     dirty = false;
 
     expect(await navigate("/config/devices/dashboard")).toBe(true);
     expect(window.location.pathname).toEqual("/config/devices/dashboard");
-
-    resolvePrompt(true);
-    expect(await first).toBe(true);
     expect(guard.prompt).toHaveBeenCalledOnce();
+
+    answerPrompt(true);
+    await first;
+  });
+
+  it("drops a navigation superseded while its prompt was open", async () => {
+    let dirty = true;
+    const { answerPrompt } = trackDeferredGuard(() => dirty);
+
+    const superseded = navigate("/config/areas");
+    dirty = false;
+    await navigate("/config/devices/dashboard");
+
+    answerPrompt(true);
+
+    expect(await superseded).toBe(false);
+    expect(window.location.pathname).toEqual("/config/devices/dashboard");
   });
 
   it("shares one pending prompt between concurrent navigations", async () => {
-    let resolvePrompt!: (value: boolean) => void;
-    const guard = trackGuard({
-      isDirty: () => true,
-      prompt: vi.fn(
-        () =>
-          new Promise<boolean>((resolve) => {
-            resolvePrompt = resolve;
-          })
-      ),
-    });
+    const { guard, answerPrompt } = trackDeferredGuard(() => true);
 
     const first = navigate("/config/areas");
     const second = navigate("/config/devices/dashboard");
-    resolvePrompt(true);
+    answerPrompt(true);
 
-    expect(await Promise.all([first, second])).toEqual([true, true]);
+    await Promise.all([first, second]);
+
     expect(guard.prompt).toHaveBeenCalledOnce();
   });
 

--- a/test/mixins/prevent-unsaved-mixin.test.ts
+++ b/test/mixins/prevent-unsaved-mixin.test.ts
@@ -52,9 +52,7 @@ const setEntry = (path: string) => {
 };
 
 const mountClean = async () => {
-  const element = document.createElement(
-    "test-prevent-unsaved"
-  ) as TestPreventUnsaved;
+  const element = document.createElement("test-prevent-unsaved");
   document.body.append(element);
   element.initialize({ name: "Kitchen" });
   await element.updateComplete;
@@ -77,7 +75,6 @@ describe("PreventUnsavedMixin", () => {
     document.querySelectorAll("test-prevent-unsaved").forEach((element) => {
       element.remove();
     });
-    window.isDirtyState = false;
   });
 
   it("blocks navigation while dirty when the prompt is declined", async () => {

--- a/test/mixins/prevent-unsaved-mixin.test.ts
+++ b/test/mixins/prevent-unsaved-mixin.test.ts
@@ -1,0 +1,146 @@
+import { LitElement } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { navigate } from "../../src/common/navigate";
+import { DirtyStateProviderMixin } from "../../src/mixins/dirty-state-provider-mixin";
+import { PreventUnsavedMixin } from "../../src/mixins/prevent-unsaved-mixin";
+
+// navigate() closes open dialogs before touching history.
+vi.mock("../../src/dialogs/make-dialog-manager", () => ({
+  closeAllDialogs: vi.fn(async () => true),
+}));
+
+interface TestState {
+  name: string;
+}
+
+// Mirrors the editors: DirtyStateProviderMixin wraps PreventUnsavedMixin.
+class TestPreventUnsaved extends DirtyStateProviderMixin<TestState>()(
+  PreventUnsavedMixin(LitElement)
+) {
+  public promptResponse = true;
+
+  public promptCalls = 0;
+
+  public initialize(value: TestState) {
+    this._initDirtyTracking({ type: "shallow" }, value);
+  }
+
+  public setValue(value: TestState) {
+    this._updateDirtyState(value);
+  }
+
+  public markClean() {
+    this._markDirtyStateClean();
+  }
+
+  protected async promptDiscardChanges(): Promise<boolean> {
+    this.promptCalls++;
+    return this.promptResponse;
+  }
+}
+
+customElements.define("test-prevent-unsaved", TestPreventUnsaved);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "test-prevent-unsaved": TestPreventUnsaved;
+  }
+}
+
+const setEntry = (path: string) => {
+  window.history.replaceState(null, "", path);
+};
+
+const mountClean = async () => {
+  const element = document.createElement(
+    "test-prevent-unsaved"
+  ) as TestPreventUnsaved;
+  document.body.append(element);
+  element.initialize({ name: "Kitchen" });
+  await element.updateComplete;
+  return element;
+};
+
+const mountDirty = async () => {
+  const element = await mountClean();
+  element.setValue({ name: "Bedroom" });
+  await element.updateComplete;
+  return element;
+};
+
+describe("PreventUnsavedMixin", () => {
+  beforeEach(() => {
+    setEntry("/config/automation/edit/1234");
+  });
+
+  afterEach(() => {
+    document.querySelectorAll("test-prevent-unsaved").forEach((element) => {
+      element.remove();
+    });
+    window.isDirtyState = false;
+  });
+
+  it("blocks navigation while dirty when the prompt is declined", async () => {
+    const element = await mountDirty();
+    element.promptResponse = false;
+
+    expect(await navigate("/config/scene/dashboard")).toBe(false);
+
+    expect(element.promptCalls).toBe(1);
+    expect(window.location.pathname).toEqual("/config/automation/edit/1234");
+  });
+
+  it("navigates while dirty when the prompt is confirmed", async () => {
+    const element = await mountDirty();
+
+    expect(await navigate("/config/scene/dashboard")).toBe(true);
+
+    expect(element.promptCalls).toBe(1);
+    expect(window.location.pathname).toEqual("/config/scene/dashboard");
+  });
+
+  it("does not prompt while clean", async () => {
+    const element = await mountClean();
+
+    expect(await navigate("/config/scene/dashboard")).toBe(true);
+
+    expect(element.promptCalls).toBe(0);
+    expect(window.location.pathname).toEqual("/config/scene/dashboard");
+  });
+
+  it("does not prompt after changes are marked clean, before the next render", async () => {
+    const element = await mountDirty();
+    element.markClean();
+
+    expect(await navigate("/config/scene/dashboard")).toBe(true);
+
+    expect(element.promptCalls).toBe(0);
+    expect(window.location.pathname).toEqual("/config/scene/dashboard");
+  });
+
+  it("stops guarding after being disconnected", async () => {
+    const element = await mountDirty();
+    element.promptResponse = false;
+    element.remove();
+
+    expect(await navigate("/config/scene/dashboard")).toBe(true);
+
+    expect(element.promptCalls).toBe(0);
+    expect(window.location.pathname).toEqual("/config/scene/dashboard");
+  });
+
+  it("arms beforeunload only while dirty", async () => {
+    const element = await mountDirty();
+
+    let event = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+
+    element.setValue({ name: "Kitchen" });
+    await element.updateComplete;
+
+    event = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Programmatic navigation — quick bar items and commands, the more-info dialog's "Edit automation" action, companion app navigate commands — bypassed the unsaved-changes prompt of the automation, script, and scene editors and silently dropped edits. The prompt only covered anchor clicks and page unloads.

`navigate()` now consults an unsaved-changes guard registry before navigating, mirroring the existing `ensureDialogsClosed` gate that already protects dirty dialogs. `PreventUnsavedMixin` registers the editors there, with live dirty-state reads and prompting through each editor's existing dialog. Its click-interception/re-dispatch hack is removed: in-app anchor clicks already funnel into `navigate()`, and `beforeunload` still covers real page unloads. This also fixes the back arrow of a dirty editor prompting twice.

Discarding changes in the leave prompt now marks the editor clean (and clears YAML errors on save/discard), so flows that already confirm before navigating — traces, duplicate, back — show exactly one prompt. `goBack()` stays unguarded on purpose: its reachable callers either confirm themselves or leave after the edited item was deleted. Navigating to the current path never prompts.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53794
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
