### PR TITLE
Keep the automation config when replacing a device in device automations

### DIFF
--- a/src/components/device/ha-device-automation-picker.ts
+++ b/src/components/device/ha-device-automation-picker.ts
@@ -11,9 +11,7 @@ import type { LocalizeFunc } from "../../common/translations/localize";
 import { fullEntitiesContext } from "../../data/context";
 import type { DeviceAutomation } from "../../data/device/device_automation";
 import {
-  deviceAutomationExtraConfig,
   deviceAutomationsEqual,
-  findEquivalentDeviceAutomation,
   sortDeviceAutomations,
 } from "../../data/device/device_automation";
 import type { EntityRegistryEntry } from "../../data/entity/entity_registry";
@@ -181,12 +179,15 @@ export abstract class HaDeviceAutomationPicker<
       (a, idx) => value === `${a.device_id}_${idx}`
     );
 
-    const text = automation
+    const described =
+      automation ?? (this.value?.domain ? this.value : undefined);
+
+    const text = described
       ? this._localizeDeviceAutomation(
           this.hass.localize,
           this.hass.states,
           this._entityReg,
-          automation
+          described
         )
       : value === NO_AUTOMATION_KEY
         ? this.NO_AUTOMATION_TEXT
@@ -196,45 +197,29 @@ export abstract class HaDeviceAutomationPicker<
   };
 
   private async _updateDeviceInfo() {
+    // Asking a removed device for its automations fails rather than returning
+    // an empty list.
     this._automations = this.deviceId
       ? (
-          await this._fetchDeviceAutomations(this.hass.callWS, this.deviceId)
+          await this._fetchDeviceAutomations(
+            this.hass.callWS,
+            this.deviceId
+          ).catch(() => [] as T[])
         ).sort(sortDeviceAutomations)
       : // No device, clear the list of automations
         [];
 
+    // If there is no value, or if we have changed the device ID, reset the value.
     if (!this.value || this.value.device_id !== this.deviceId) {
-      this._updateValueForDevice();
+      this._setValue(
+        this._automations.length
+          ? this._automations[0]
+          : this._createNoAutomation(this.deviceId)
+      );
     }
     this._renderEmpty = true;
     await this.updateComplete;
     this._renderEmpty = false;
-  }
-
-  // The current value belongs to another device, either because there is no
-  // value yet or because the device was just changed. Move it to the same
-  // automation on the new device when there is one, otherwise start over.
-  private _updateValueForDevice() {
-    if (this.deviceId && this.value) {
-      const equivalent = findEquivalentDeviceAutomation(
-        this._entityReg,
-        this._automations!,
-        this.value
-      );
-      if (equivalent) {
-        this._setValue({
-          ...equivalent,
-          ...deviceAutomationExtraConfig(this.value),
-        });
-        return;
-      }
-    }
-
-    this._setValue(
-      this._automations!.length
-        ? this._automations![0]
-        : this._createNoAutomation(this.deviceId)
-    );
   }
 
   private _automationChanged(ev: ValueChangedEvent<string>) {

--- a/src/components/device/ha-device-automation-picker.ts
+++ b/src/components/device/ha-device-automation-picker.ts
@@ -11,8 +11,9 @@ import type { LocalizeFunc } from "../../common/translations/localize";
 import { fullEntitiesContext } from "../../data/context";
 import type { DeviceAutomation } from "../../data/device/device_automation";
 import {
+  deviceAutomationExtraConfig,
   deviceAutomationsEqual,
-  deviceAutomationsSimilar,
+  findEquivalentDeviceAutomation,
   sortDeviceAutomations,
 } from "../../data/device/device_automation";
 import type { EntityRegistryEntry } from "../../data/entity/entity_registry";
@@ -202,27 +203,38 @@ export abstract class HaDeviceAutomationPicker<
       : // No device, clear the list of automations
         [];
 
-    // If there is no value, or if we have changed the device ID, reset the
-    // value. When the device changed (for example after replacing a removed
-    // device), try to keep the same automation type/subtype on the new device
-    // before falling back to the first available automation.
     if (!this.value || this.value.device_id !== this.deviceId) {
-      const equivalent =
-        this.value && this.deviceId
-          ? this._automations.find((automation) =>
-              deviceAutomationsSimilar(automation, this.value!)
-            )
-          : undefined;
-      this._setValue(
-        equivalent ||
-          (this._automations.length
-            ? this._automations[0]
-            : this._createNoAutomation(this.deviceId))
-      );
+      this._updateValueForDevice();
     }
     this._renderEmpty = true;
     await this.updateComplete;
     this._renderEmpty = false;
+  }
+
+  // The current value belongs to another device, either because there is no
+  // value yet or because the device was just changed. Move it to the same
+  // automation on the new device when there is one, otherwise start over.
+  private _updateValueForDevice() {
+    if (this.deviceId && this.value) {
+      const equivalent = findEquivalentDeviceAutomation(
+        this._entityReg,
+        this._automations!,
+        this.value
+      );
+      if (equivalent) {
+        this._setValue({
+          ...equivalent,
+          ...deviceAutomationExtraConfig(this.value),
+        });
+        return;
+      }
+    }
+
+    this._setValue(
+      this._automations!.length
+        ? this._automations![0]
+        : this._createNoAutomation(this.deviceId)
+    );
   }
 
   private _automationChanged(ev: ValueChangedEvent<string>) {

--- a/src/components/device/ha-device-picker.ts
+++ b/src/components/device/ha-device-picker.ts
@@ -105,6 +105,14 @@ export class HaDevicePicker extends LitElement {
   @property({ attribute: "hide-clear-icon", type: Boolean })
   public hideClearIcon = false;
 
+  /**
+   * The split devices that can actually replace the current value, when the
+   * caller knows better than this picker. Narrows the replacement candidates,
+   * so the user is only asked to choose when there is a real choice.
+   */
+  @property({ attribute: false })
+  public replacementDeviceIds?: string[];
+
   @query("ha-generic-picker") private _picker?: HaGenericPicker;
 
   @state() private _configEntryLookup: Record<string, ConfigEntry> = {};
@@ -188,7 +196,8 @@ export class HaDevicePicker extends LitElement {
       value: string | undefined,
       _devices: HomeAssistant["devices"],
       compositeSplits: DeviceCompositeSplits | undefined,
-      items: (DevicePickerItem | string)[]
+      items: (DevicePickerItem | string)[],
+      replacementDeviceIds: string[] | undefined
     ) => {
       if (!value || !compositeSplits || this.hass.devices[value]) {
         return undefined;
@@ -204,7 +213,11 @@ export class HaDevicePicker extends LitElement {
           .filter((item): item is DevicePickerItem => typeof item !== "string")
           .map((item) => item.id)
       );
-      const candidates = split.split_ids.filter((id) => selectableIds.has(id));
+      const candidates = split.split_ids.filter(
+        (id) =>
+          selectableIds.has(id) &&
+          (!replacementDeviceIds || replacementDeviceIds.includes(id))
+      );
       return { candidates, primaryId: split.primary_id };
     }
   );
@@ -400,7 +413,8 @@ export class HaDevicePicker extends LitElement {
             this.value,
             this.hass.devices,
             this._compositeSplits,
-            this._getItems()
+            this._getItems(),
+            this.replacementDeviceIds
           )
         : undefined;
 
@@ -507,7 +521,8 @@ export class HaDevicePicker extends LitElement {
       this.value,
       this.hass.devices,
       this._compositeSplits,
-      this._getItems()
+      this._getItems(),
+      this.replacementDeviceIds
     );
     if (!replacement?.candidates.length) {
       return;

--- a/src/data/device/device_automation.ts
+++ b/src/data/device/device_automation.ts
@@ -182,26 +182,70 @@ export const deviceAutomationEditorMode = (
     : "unknown-device";
 };
 
-// Like deviceAutomationsEqual, but ignores device_id and entity_id so an
-// automation can be matched to the equivalent one on a different device (for
-// example when a referenced device was replaced by a split device).
-export const deviceAutomationsSimilar = (
+// Whether two device automations describe the same kind of automation, meaning
+// the same domain, type, subtype and event. Which device and which entity they
+// apply to is ignored, so an automation can be matched against the ones another
+// device offers.
+const deviceAutomationsSameType = (a: DeviceAutomation, b: DeviceAutomation) =>
+  deviceAutomationIdentifiers
+    .filter((property) => property !== "device_id" && property !== "entity_id")
+    .every((property) => Object.is(a[property], b[property]));
+
+// Whether two device automations point at the same entity. Both the entity
+// registry id and the entity id are accepted as reference, on either side.
+const deviceAutomationsSameEntity = (
+  entityRegistry: EntityRegistryEntry[],
   a: DeviceAutomation,
   b: DeviceAutomation
 ) => {
-  if (typeof a !== typeof b) {
+  if (!a.entity_id && !b.entity_id) {
+    return true;
+  }
+  if (!a.entity_id || !b.entity_id) {
     return false;
   }
-  return deviceAutomationIdentifiers
-    .filter((property) => property !== "device_id" && property !== "entity_id")
-    .every((property) => {
-      const inA = property in a;
-      const inB = property in b;
-      if (!inA && !inB) {
-        return true;
-      }
-      return Object.is(a[property], b[property]);
-    });
+  return (
+    a.entity_id === b.entity_id ||
+    compareEntityIdWithEntityRegId(entityRegistry, a.entity_id, b.entity_id)
+  );
+};
+
+// Finds, among the automations a device offers, the one matching the given
+// automation, so a device automation can follow its device after the device was
+// replaced. A device exposes the same automation type once per entity, so
+// matching on the type alone picks an arbitrary entity. Splitting a device
+// leaves the entity registry ids untouched, which makes the entity the reliable
+// match, the type only serving as a fallback for entity-less automations.
+export const findEquivalentDeviceAutomation = <T extends DeviceAutomation>(
+  entityRegistry: EntityRegistryEntry[],
+  automations: T[],
+  automation: DeviceAutomation
+): T | undefined => {
+  const sameType = automations.filter((candidate) =>
+    deviceAutomationsSameType(candidate, automation)
+  );
+  const sameEntity = sameType.find((candidate) =>
+    deviceAutomationsSameEntity(entityRegistry, candidate, automation)
+  );
+  return sameEntity || sameType[0];
+};
+
+// Everything the automation list does not return: the extra fields of the
+// capabilities schema (`for`, `above`, ...) and the config of the row holding
+// the automation (`enabled`, `id`, `alias`, ...).
+export const deviceAutomationExtraConfig = <T extends DeviceAutomation>(
+  automation: T
+): Partial<T> => {
+  const extraConfig: Partial<T> = {};
+  for (const property in automation) {
+    if (
+      property !== "metadata" &&
+      !deviceAutomationIdentifiers.includes(property)
+    ) {
+      extraConfig[property] = automation[property];
+    }
+  }
+  return extraConfig;
 };
 
 const compareEntityIdWithEntityRegId = (

--- a/src/data/device/device_automation.ts
+++ b/src/data/device/device_automation.ts
@@ -182,17 +182,13 @@ export const deviceAutomationEditorMode = (
     : "unknown-device";
 };
 
-// Whether two device automations describe the same kind of automation, meaning
-// the same domain, type, subtype and event. Which device and which entity they
-// apply to is ignored, so an automation can be matched against the ones another
-// device offers.
 const deviceAutomationsSameType = (a: DeviceAutomation, b: DeviceAutomation) =>
   deviceAutomationIdentifiers
     .filter((property) => property !== "device_id" && property !== "entity_id")
     .every((property) => Object.is(a[property], b[property]));
 
-// Whether two device automations point at the same entity. Both the entity
-// registry id and the entity id are accepted as reference, on either side.
+// An entity can be referenced by its registry id or by its entity id, and the
+// two sides do not have to agree.
 const deviceAutomationsSameEntity = (
   entityRegistry: EntityRegistryEntry[],
   a: DeviceAutomation,
@@ -210,42 +206,45 @@ const deviceAutomationsSameEntity = (
   );
 };
 
-// Finds, among the automations a device offers, the one matching the given
-// automation, so a device automation can follow its device after the device was
-// replaced. A device exposes the same automation type once per entity, so
-// matching on the type alone picks an arbitrary entity. Splitting a device
-// leaves the entity registry ids untouched, which makes the entity the reliable
-// match, the type only serving as a fallback for entity-less automations.
+// A device exposes the same automation type once per entity, so the same type
+// on another entity is a different automation, not an equivalent one.
 export const findEquivalentDeviceAutomation = <T extends DeviceAutomation>(
   entityRegistry: EntityRegistryEntry[],
   automations: T[],
   automation: DeviceAutomation
-): T | undefined => {
-  const sameType = automations.filter((candidate) =>
-    deviceAutomationsSameType(candidate, automation)
+): T | undefined =>
+  automations.find(
+    (candidate) =>
+      deviceAutomationsSameType(candidate, automation) &&
+      deviceAutomationsSameEntity(entityRegistry, candidate, automation)
   );
-  const sameEntity = sameType.find((candidate) =>
-    deviceAutomationsSameEntity(entityRegistry, candidate, automation)
-  );
-  return sameEntity || sameType[0];
-};
 
-// Everything the automation list does not return: the extra fields of the
-// capabilities schema (`for`, `above`, ...) and the config of the row holding
-// the automation (`enabled`, `id`, `alias`, ...).
-export const deviceAutomationExtraConfig = <T extends DeviceAutomation>(
-  automation: T
-): Partial<T> => {
-  const extraConfig: Partial<T> = {};
-  for (const property in automation) {
-    if (
-      property !== "metadata" &&
-      !deviceAutomationIdentifiers.includes(property)
-    ) {
-      extraConfig[property] = automation[property];
-    }
-  }
-  return extraConfig;
+// Among the split devices that replaced a removed device, the ones that offer
+// the given automation. Nothing in the registry says which of them took it over,
+// so each candidate has to be asked.
+export const fetchReplacementDevices = async <T extends DeviceAutomation>(
+  hass: HomeAssistant,
+  entityRegistry: EntityRegistryEntry[],
+  automation: DeviceAutomation,
+  compositeSplits: DeviceCompositeSplits,
+  fetchDeviceAutomations: (callWS: CallWS, deviceId: string) => Promise<T[]>
+): Promise<string[]> => {
+  const candidates =
+    compositeSplits[automation.device_id]?.split_ids.filter(
+      (id) => id in hass.devices
+    ) ?? [];
+  const automationsPerCandidate = await Promise.all(
+    candidates.map((id) =>
+      fetchDeviceAutomations(hass.callWS, id).catch(() => [] as T[])
+    )
+  );
+  return candidates.filter((_id, index) =>
+    findEquivalentDeviceAutomation(
+      entityRegistry,
+      automationsPerCandidate[index],
+      automation
+    )
+  );
 };
 
 const compareEntityIdWithEntityRegId = (

--- a/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
@@ -14,6 +14,8 @@ import type {
 } from "../../../../../data/device/device_automation";
 import {
   deviceAutomationEditorMode,
+  fetchReplacementDevices,
+  fetchDeviceActions,
   deviceAutomationsEqual,
   fetchDeviceActionCapabilities,
   localizeExtraFieldsComputeHelperCallback,
@@ -39,6 +41,8 @@ export class HaDeviceAction extends LitElement {
   @state() private _capabilities?: DeviceCapabilities;
 
   @state() private _compositeSplits?: DeviceCompositeSplits;
+
+  @state() private _replacementDeviceIds?: string[];
 
   private _loadingCompositeSplits = false;
 
@@ -101,7 +105,17 @@ export class HaDeviceAction extends LitElement {
     }
     this._loadingCompositeSplits = true;
     try {
-      this._compositeSplits = await fetchDeviceCompositeSplits(this.hass);
+      // Resolve the candidates before exposing the split map, so the picker
+      // never offers one that cannot host the automation.
+      const compositeSplits = await fetchDeviceCompositeSplits(this.hass);
+      this._replacementDeviceIds = await fetchReplacementDevices(
+        this.hass,
+        this._entityReg,
+        this.action,
+        compositeSplits,
+        fetchDeviceActions
+      );
+      this._compositeSplits = compositeSplits;
     } catch (_err) {
       this._compositeSplits = {};
     } finally {
@@ -115,6 +129,7 @@ export class HaDeviceAction extends LitElement {
     return html`
       <ha-device-picker
         .value=${deviceId}
+        .replacementDeviceIds=${this._replacementDeviceIds}
         .disabled=${this.disabled}
         @value-changed=${this._devicePicked}
         .hass=${this.hass}
@@ -185,6 +200,15 @@ export class HaDeviceAction extends LitElement {
 
   private _devicePicked(ev) {
     ev.stopPropagation();
+    // The automation exists as is on the replacement, so only the reference
+    // changes and the rest of the configuration is left untouched.
+    if (this._replacementDeviceIds?.includes(ev.target.value)) {
+      this._deviceId = undefined;
+      fireEvent(this, "value-changed", {
+        value: { ...this.action, device_id: ev.target.value },
+      });
+      return;
+    }
     this._deviceId = ev.target.value;
     if (this._deviceId === undefined) {
       fireEvent(this, "value-changed", {

--- a/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
@@ -99,6 +99,16 @@ export class HaDeviceAction extends LitElement {
     return true;
   }
 
+  private async _resolveReplacements(compositeSplits: DeviceCompositeSplits) {
+    this._replacementDeviceIds = await fetchReplacementDevices(
+      this.hass,
+      this._entityReg,
+      this.action,
+      compositeSplits,
+      fetchDeviceActions
+    );
+  }
+
   private async _loadCompositeSplits() {
     if (this._loadingCompositeSplits) {
       return;
@@ -108,13 +118,7 @@ export class HaDeviceAction extends LitElement {
       // Resolve the candidates before exposing the split map, so the picker
       // never offers one that cannot host the automation.
       const compositeSplits = await fetchDeviceCompositeSplits(this.hass);
-      this._replacementDeviceIds = await fetchReplacementDevices(
-        this.hass,
-        this._entityReg,
-        this.action,
-        compositeSplits,
-        fetchDeviceActions
-      );
+      await this._resolveReplacements(compositeSplits);
       this._compositeSplits = compositeSplits;
     } catch (_err) {
       this._compositeSplits = {};
@@ -169,6 +173,19 @@ export class HaDeviceAction extends LitElement {
           : ""
       }
     `;
+  }
+
+  protected willUpdate(changedProps: PropertyValues<this>) {
+    // The picked device only lives here until the configuration catches up.
+    // Once it points somewhere else, undo and redo included, it is stale.
+    const previous = changedProps.get("action");
+    if (previous && previous.device_id !== this.action.device_id) {
+      this._deviceId = undefined;
+      this._replacementDeviceIds = undefined;
+      if (this._compositeSplits) {
+        this._resolveReplacements(this._compositeSplits);
+      }
+    }
   }
 
   protected firstUpdated() {

--- a/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
@@ -100,6 +100,16 @@ export class HaDeviceCondition extends LitElement {
     return true;
   }
 
+  private async _resolveReplacements(compositeSplits: DeviceCompositeSplits) {
+    this._replacementDeviceIds = await fetchReplacementDevices(
+      this.hass,
+      this._entityReg,
+      this.condition,
+      compositeSplits,
+      fetchDeviceConditions
+    );
+  }
+
   private async _loadCompositeSplits() {
     if (this._loadingCompositeSplits) {
       return;
@@ -109,13 +119,7 @@ export class HaDeviceCondition extends LitElement {
       // Resolve the candidates before exposing the split map, so the picker
       // never offers one that cannot host the automation.
       const compositeSplits = await fetchDeviceCompositeSplits(this.hass);
-      this._replacementDeviceIds = await fetchReplacementDevices(
-        this.hass,
-        this._entityReg,
-        this.condition,
-        compositeSplits,
-        fetchDeviceConditions
-      );
+      await this._resolveReplacements(compositeSplits);
       this._compositeSplits = compositeSplits;
     } catch (_err) {
       this._compositeSplits = {};
@@ -170,6 +174,19 @@ export class HaDeviceCondition extends LitElement {
           : ""
       }
     `;
+  }
+
+  protected willUpdate(changedProps: PropertyValues<this>) {
+    // The picked device only lives here until the configuration catches up.
+    // Once it points somewhere else, undo and redo included, it is stale.
+    const previous = changedProps.get("condition");
+    if (previous && previous.device_id !== this.condition.device_id) {
+      this._deviceId = undefined;
+      this._replacementDeviceIds = undefined;
+      if (this._compositeSplits) {
+        this._resolveReplacements(this._compositeSplits);
+      }
+    }
   }
 
   protected firstUpdated() {

--- a/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
@@ -14,6 +14,8 @@ import type {
 } from "../../../../../data/device/device_automation";
 import {
   deviceAutomationEditorMode,
+  fetchReplacementDevices,
+  fetchDeviceConditions,
   deviceAutomationsEqual,
   fetchDeviceConditionCapabilities,
   localizeExtraFieldsComputeHelperCallback,
@@ -39,6 +41,8 @@ export class HaDeviceCondition extends LitElement {
   @state() private _capabilities?: DeviceCapabilities;
 
   @state() private _compositeSplits?: DeviceCompositeSplits;
+
+  @state() private _replacementDeviceIds?: string[];
 
   private _loadingCompositeSplits = false;
 
@@ -102,7 +106,17 @@ export class HaDeviceCondition extends LitElement {
     }
     this._loadingCompositeSplits = true;
     try {
-      this._compositeSplits = await fetchDeviceCompositeSplits(this.hass);
+      // Resolve the candidates before exposing the split map, so the picker
+      // never offers one that cannot host the automation.
+      const compositeSplits = await fetchDeviceCompositeSplits(this.hass);
+      this._replacementDeviceIds = await fetchReplacementDevices(
+        this.hass,
+        this._entityReg,
+        this.condition,
+        compositeSplits,
+        fetchDeviceConditions
+      );
+      this._compositeSplits = compositeSplits;
     } catch (_err) {
       this._compositeSplits = {};
     } finally {
@@ -116,6 +130,7 @@ export class HaDeviceCondition extends LitElement {
     return html`
       <ha-device-picker
         .value=${deviceId}
+        .replacementDeviceIds=${this._replacementDeviceIds}
         @value-changed=${this._devicePicked}
         .hass=${this.hass}
         .disabled=${this.disabled}
@@ -187,6 +202,15 @@ export class HaDeviceCondition extends LitElement {
 
   private _devicePicked(ev) {
     ev.stopPropagation();
+    // The automation exists as is on the replacement, so only the reference
+    // changes and the rest of the configuration is left untouched.
+    if (this._replacementDeviceIds?.includes(ev.target.value)) {
+      this._deviceId = undefined;
+      fireEvent(this, "value-changed", {
+        value: { ...this.condition, device_id: ev.target.value },
+      });
+      return;
+    }
     this._deviceId = ev.target.value;
     if (this._deviceId === undefined) {
       fireEvent(this, "value-changed", {

--- a/src/panels/config/automation/target/ha-automation-row-targets.ts
+++ b/src/panels/config/automation/target/ha-automation-row-targets.ts
@@ -479,7 +479,12 @@ export class HaAutomationRowTargets extends LitElement {
         warning = true;
         badgeTargetId = undefined;
         badgeTargetType = undefined;
-        if (targetType === "device" && this._compositeSplits?.[targetId]) {
+        if (
+          targetType === "device" &&
+          this._compositeSplits?.[targetId]?.split_ids.some(
+            (id) => id in this._registries.devices
+          )
+        ) {
           // The device was replaced by one or more split devices; make clear
           // this reference needs to be updated, distinct from "unknown device".
           icon = mdiSwapHorizontal;

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -104,6 +104,16 @@ export class HaDeviceTrigger extends LitElement {
     return true;
   }
 
+  private async _resolveReplacements(compositeSplits: DeviceCompositeSplits) {
+    this._replacementDeviceIds = await fetchReplacementDevices(
+      this.hass,
+      this._entityReg,
+      this.trigger,
+      compositeSplits,
+      fetchDeviceTriggers
+    );
+  }
+
   private async _loadCompositeSplits() {
     if (this._loadingCompositeSplits) {
       return;
@@ -113,13 +123,7 @@ export class HaDeviceTrigger extends LitElement {
       // Resolve the candidates before exposing the split map, so the picker
       // never offers one that cannot host the automation.
       const compositeSplits = await fetchDeviceCompositeSplits(this.hass);
-      this._replacementDeviceIds = await fetchReplacementDevices(
-        this.hass,
-        this._entityReg,
-        this.trigger,
-        compositeSplits,
-        fetchDeviceTriggers
-      );
+      await this._resolveReplacements(compositeSplits);
       this._compositeSplits = compositeSplits;
     } catch (_err) {
       this._compositeSplits = {};
@@ -174,6 +178,19 @@ export class HaDeviceTrigger extends LitElement {
           : ""
       }
     `;
+  }
+
+  protected willUpdate(changedProps: PropertyValues<this>) {
+    // The picked device only lives here until the configuration catches up.
+    // Once it points somewhere else, undo and redo included, it is stale.
+    const previous = changedProps.get("trigger");
+    if (previous && previous.device_id !== this.trigger.device_id) {
+      this._deviceId = undefined;
+      this._replacementDeviceIds = undefined;
+      if (this._compositeSplits) {
+        this._resolveReplacements(this._compositeSplits);
+      }
+    }
   }
 
   protected firstUpdated() {

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -16,6 +16,8 @@ import type {
 } from "../../../../../data/device/device_automation";
 import {
   deviceAutomationEditorMode,
+  fetchReplacementDevices,
+  fetchDeviceTriggers,
   deviceAutomationsEqual,
   fetchDeviceTriggerCapabilities,
   localizeExtraFieldsComputeHelperCallback,
@@ -41,6 +43,8 @@ export class HaDeviceTrigger extends LitElement {
   @state() private _capabilities?: DeviceCapabilities;
 
   @state() private _compositeSplits?: DeviceCompositeSplits;
+
+  @state() private _replacementDeviceIds?: string[];
 
   private _loadingCompositeSplits = false;
 
@@ -106,7 +110,17 @@ export class HaDeviceTrigger extends LitElement {
     }
     this._loadingCompositeSplits = true;
     try {
-      this._compositeSplits = await fetchDeviceCompositeSplits(this.hass);
+      // Resolve the candidates before exposing the split map, so the picker
+      // never offers one that cannot host the automation.
+      const compositeSplits = await fetchDeviceCompositeSplits(this.hass);
+      this._replacementDeviceIds = await fetchReplacementDevices(
+        this.hass,
+        this._entityReg,
+        this.trigger,
+        compositeSplits,
+        fetchDeviceTriggers
+      );
+      this._compositeSplits = compositeSplits;
     } catch (_err) {
       this._compositeSplits = {};
     } finally {
@@ -120,6 +134,7 @@ export class HaDeviceTrigger extends LitElement {
     return html`
       <ha-device-picker
         .value=${deviceId}
+        .replacementDeviceIds=${this._replacementDeviceIds}
         @value-changed=${this._devicePicked}
         .hass=${this.hass}
         .disabled=${this.disabled}
@@ -208,6 +223,15 @@ export class HaDeviceTrigger extends LitElement {
 
   private _devicePicked(ev) {
     ev.stopPropagation();
+    // The automation exists as is on the replacement, so only the reference
+    // changes and the rest of the configuration is left untouched.
+    if (this._replacementDeviceIds?.includes(ev.target.value)) {
+      this._deviceId = undefined;
+      fireEvent(this, "value-changed", {
+        value: { ...this.trigger, device_id: ev.target.value },
+      });
+      return;
+    }
     this._deviceId = ev.target.value;
     if (this._deviceId === undefined) {
       fireEvent(this, "value-changed", {

--- a/test/data/device_automation.test.ts
+++ b/test/data/device_automation.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import type { DeviceTrigger } from "../../src/data/device/device_automation";
+import { findEquivalentDeviceAutomation } from "../../src/data/device/device_automation";
+import type { EntityRegistryEntry } from "../../src/data/entity/entity_registry";
+
+const entityRegistry = [
+  { id: "regid1", entity_id: "binary_sensor.one" },
+  { id: "regid2", entity_id: "binary_sensor.two" },
+] as EntityRegistryEntry[];
+
+const trigger = (partial: Partial<DeviceTrigger>): DeviceTrigger =>
+  ({
+    trigger: "device",
+    domain: "binary_sensor",
+    device_id: "device1",
+    ...partial,
+  }) as DeviceTrigger;
+
+describe("findEquivalentDeviceAutomation", () => {
+  it("picks the automation on the same entity among several of the same type", () => {
+    const automations = [
+      trigger({ device_id: "device2", type: "turned_on", entity_id: "regid1" }),
+      trigger({ device_id: "device2", type: "turned_on", entity_id: "regid2" }),
+    ];
+
+    expect(
+      findEquivalentDeviceAutomation(
+        entityRegistry,
+        automations,
+        trigger({ type: "turned_on", entity_id: "regid2" })
+      )
+    ).toBe(automations[1]);
+  });
+
+  it("matches an entity referenced by entity id against one referenced by registry id", () => {
+    const automations = [
+      trigger({ device_id: "device2", type: "turned_on", entity_id: "regid1" }),
+      trigger({ device_id: "device2", type: "turned_on", entity_id: "regid2" }),
+    ];
+
+    expect(
+      findEquivalentDeviceAutomation(
+        entityRegistry,
+        automations,
+        trigger({ type: "turned_on", entity_id: "binary_sensor.two" })
+      )
+    ).toBe(automations[1]);
+  });
+
+  it("falls back to the first automation of the same type when the entity is elsewhere", () => {
+    const automations = [
+      trigger({ device_id: "device2", type: "turned_on", entity_id: "regid1" }),
+      trigger({
+        device_id: "device2",
+        type: "turned_off",
+        entity_id: "regid1",
+      }),
+    ];
+
+    expect(
+      findEquivalentDeviceAutomation(
+        entityRegistry,
+        automations,
+        trigger({ type: "turned_on", entity_id: "regid2" })
+      )
+    ).toBe(automations[0]);
+  });
+
+  it("matches entity-less automations on their subtype", () => {
+    const automations = [
+      trigger({
+        device_id: "device2",
+        domain: "zha",
+        type: "remote_button_short_press",
+        subtype: "button_1",
+      }),
+      trigger({
+        device_id: "device2",
+        domain: "zha",
+        type: "remote_button_short_press",
+        subtype: "button_2",
+      }),
+    ];
+
+    expect(
+      findEquivalentDeviceAutomation(
+        entityRegistry,
+        automations,
+        trigger({
+          domain: "zha",
+          type: "remote_button_short_press",
+          subtype: "button_2",
+        })
+      )
+    ).toBe(automations[1]);
+  });
+
+  it("returns undefined when the device offers no automation of that type", () => {
+    const automations = [
+      trigger({
+        device_id: "device2",
+        type: "turned_off",
+        entity_id: "regid1",
+      }),
+    ];
+
+    expect(
+      findEquivalentDeviceAutomation(
+        entityRegistry,
+        automations,
+        trigger({ type: "turned_on", entity_id: "regid1" })
+      )
+    ).toBeUndefined();
+  });
+});

--- a/test/data/device_automation.test.ts
+++ b/test/data/device_automation.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { DeviceTrigger } from "../../src/data/device/device_automation";
-import { findEquivalentDeviceAutomation } from "../../src/data/device/device_automation";
+import {
+  fetchReplacementDevices,
+  findEquivalentDeviceAutomation,
+} from "../../src/data/device/device_automation";
+import type { DeviceCompositeSplits } from "../../src/data/device/device_registry";
 import type { EntityRegistryEntry } from "../../src/data/entity/entity_registry";
+import type { HomeAssistant } from "../../src/types";
 
 const entityRegistry = [
   { id: "regid1", entity_id: "binary_sensor.one" },
@@ -47,7 +52,7 @@ describe("findEquivalentDeviceAutomation", () => {
     ).toBe(automations[1]);
   });
 
-  it("falls back to the first automation of the same type when the entity is elsewhere", () => {
+  it("returns undefined when the same type is only offered for another entity", () => {
     const automations = [
       trigger({ device_id: "device2", type: "turned_on", entity_id: "regid1" }),
       trigger({
@@ -63,7 +68,7 @@ describe("findEquivalentDeviceAutomation", () => {
         automations,
         trigger({ type: "turned_on", entity_id: "regid2" })
       )
-    ).toBe(automations[0]);
+    ).toBeUndefined();
   });
 
   it("matches entity-less automations on their subtype", () => {
@@ -111,5 +116,72 @@ describe("findEquivalentDeviceAutomation", () => {
         trigger({ type: "turned_on", entity_id: "regid1" })
       )
     ).toBeUndefined();
+  });
+});
+
+describe("fetchReplacementDevices", () => {
+  const hass = {
+    callWS: () => Promise.resolve([]),
+    devices: { device2: {}, device3: {} },
+  } as unknown as HomeAssistant;
+
+  const compositeSplits = {
+    removed: { split_ids: ["device2", "device3"], primary_id: "device2" },
+  } as unknown as DeviceCompositeSplits;
+
+  const value = trigger({
+    device_id: "removed",
+    type: "turned_on",
+    entity_id: "regid1",
+  });
+
+  it("keeps only the devices that offer the automation", async () => {
+    const offers = {
+      device2: [
+        trigger({
+          device_id: "device2",
+          type: "turned_on",
+          entity_id: "regid1",
+        }),
+      ],
+      device3: [
+        trigger({
+          device_id: "device3",
+          type: "turned_on",
+          entity_id: "regid2",
+        }),
+      ],
+    };
+
+    expect(
+      await fetchReplacementDevices(
+        hass,
+        entityRegistry,
+        value,
+        compositeSplits,
+        (_callWS, deviceId) => Promise.resolve(offers[deviceId])
+      )
+    ).toEqual(["device2"]);
+  });
+
+  it("drops a device whose automations cannot be listed", async () => {
+    expect(
+      await fetchReplacementDevices(
+        hass,
+        entityRegistry,
+        value,
+        compositeSplits,
+        (_callWS, deviceId) =>
+          deviceId === "device2"
+            ? Promise.reject(new Error("unknown device"))
+            : Promise.resolve([
+                trigger({
+                  device_id: "device3",
+                  type: "turned_on",
+                  entity_id: "regid1",
+                }),
+              ])
+      )
+    ).toEqual(["device3"]);
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Replacing the device of a device trigger, condition or action reset the rest of it. The equivalent automation on the new device was matched on its type alone, so a device exposing that type for several entities got an arbitrary one, and everything the automation list does not return was dropped, including `above`, `below`, `for` and `enabled`. An automation could end up invalid and refuse to save.

The editors now ask each split device what it offers and keep only those that can host the automation, matching on the entity when there is one and on the type and subtype otherwise. Replacing then rewrites the device reference and leaves the rest of the configuration untouched.

An entity lives on a single device, and an automation without one still names the integration it belongs to, so a single device is usually left and replacing is applied straight away. The dialog asking which device to use is now only reached when the same integration ended up on both sides of the split.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/core#179627
- This PR is related to issue or discussion: home-assistant/core#178332
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
