### PR TITLE
Guarantee a Y-axis gap on history and statistics charts

### DIFF
--- a/src/components/chart/y-axis-fraction-digits.ts
+++ b/src/components/chart/y-axis-fraction-digits.ts
@@ -9,14 +9,14 @@ const NEGLIGIBLE_RANGE_RATIO = 1e-10;
 // precision derived here cannot drift from the ticks it renders.
 const SPLIT_NUMBER = 5;
 
-// Fraction of the data span added at each end, so that ECharts' tick rounding —
-// which floors the minimum and ceils the maximum to a tick multiple — always has
-// something to round away. Quantized states otherwise land exactly on a tick,
-// the rounding changes nothing, and area-filled series collapse to zero height.
-// Any value between roughly 1e-15 and 1 / SPLIT_NUMBER works: large enough to
-// survive float64 addition at the data's magnitude, small enough that it can
-// never cross a tick by itself.
-const GAP_FRACTION_OF_SPAN = 1e-6;
+// How thin a gap between the data and the plot edge counts as no gap at all,
+// as a fraction of the data span. ECharts floors the axis minimum and ceils the
+// maximum to a tick multiple, which usually leaves headroom, but quantized
+// states often land exactly on a tick and get none — collapsing area-filled
+// series, which are drawn from their value down to the axis minimum. Widening
+// the extent by this much before that rounding bumps any axis with less
+// headroom out to a full tick, and leaves the rest where they are.
+const GAP_FRACTION_OF_SPAN = 0.02;
 
 // Derive the number of decimal digits to use for Y-axis labels from the
 // observed data range, by asking ECharts for the same tick interval it will

--- a/src/components/chart/y-axis-fraction-digits.ts
+++ b/src/components/chart/y-axis-fraction-digits.ts
@@ -1,13 +1,27 @@
+import { intervalScaleEnsureValidExtent } from "echarts/lib/scale/helper";
+import { getPrecision, nice, round } from "echarts/lib/util/number";
+
 // A range smaller than this fraction of the axis magnitude is floating-point
 // noise (e.g. from summed statistics), not real precision.
 const NEGLIGIBLE_RANGE_RATIO = 1e-10;
 
+// Intervals the axis aims for. Passed to ECharts rather than assumed, so the
+// precision derived here cannot drift from the ticks it renders.
+const SPLIT_NUMBER = 5;
+
+// Fraction of the data span added at each end, so that ECharts' tick rounding —
+// which floors the minimum and ceils the maximum to a tick multiple — always has
+// something to round away. Quantized states otherwise land exactly on a tick,
+// the rounding changes nothing, and area-filled series collapse to zero height.
+// Any value between roughly 1e-15 and 1 / SPLIT_NUMBER works: large enough to
+// survive float64 addition at the data's magnitude, small enough that it can
+// never cross a tick by itself.
+const GAP_FRACTION_OF_SPAN = 1e-6;
+
 // Derive the number of decimal digits to use for Y-axis labels from the
-// observed data range. We mirror how ECharts sizes its ticks: it splits the
-// range into ~5 intervals (its default `splitNumber`) and rounds that raw
-// interval to a "nice" 1/2/3/5×10ⁿ value, then reports the decimals that nice
-// interval needs. This matches the precision ECharts actually renders, so
-// labels are neither truncated to identical values nor padded with extra zeros.
+// observed data range, by asking ECharts for the same tick interval it will
+// render. This matches the precision it actually draws, so labels are neither
+// truncated to identical values nor padded with extra zeros.
 export function computeYAxisFractionDigits(
   min: number,
   max: number,
@@ -22,13 +36,7 @@ export function computeYAxisFractionDigits(
   // with a tail of zeros (e.g. "0.20000000000000"), so treat it as flat.
   const magnitude = Math.max(Math.abs(lo), Math.abs(hi));
   if (range <= magnitude * NEGLIGIBLE_RANGE_RATIO) return 1;
-  const rawInterval = range / 5;
-  const exponent = Math.floor(Math.log10(rawInterval));
-  const mantissa = rawInterval / 10 ** exponent; // in [1, 10)
-  // Rounding the mantissa to a nice value only ever carries to the next power
-  // of ten (mantissa ≥ 7 → 10), which needs one fewer decimal.
-  const niceExponent = mantissa >= 7 ? exponent + 1 : exponent;
-  return Math.max(0, -niceExponent);
+  return getPrecision(nice(range / SPLIT_NUMBER, true));
 }
 
 interface YAxisExtentValues {
@@ -44,34 +52,94 @@ const resolveYAxisBound = (
   values: YAxisExtentValues
 ): number | undefined => (typeof bound === "function" ? bound(values) : bound);
 
-// Wrap the Y-axis `min`/`max` options in callbacks so the tick-label precision
-// tracks the currently visible axis extent. ECharts re-invokes these callbacks
-// with the extent of the visible (zoom-filtered) data on every dataZoom, and
-// always before the label formatter runs, so recomputing the fraction digits
-// here keeps zoomed-in labels distinct. The callbacks return the original
-// bounds unchanged, so auto-scaling still applies when a bound is not set.
+// A constant series has no span for the gap to be a fraction of, so ECharts
+// falls back to `Math.abs(min)` when sizing it. That makes the extent unequal,
+// which in turn stops `intervalScaleEnsureValidExtent` from applying the ±|v|/2
+// expansion a flat series relies on for its window. Run that expansion here and
+// return fixed bounds, which also suppresses the gap.
+const flatSeriesExtent = (value: number, fixed: [boolean, boolean]) => {
+  const [lo, hi] = intervalScaleEnsureValidExtent([value, value], fixed);
+  const interval = nice((hi - lo) / SPLIT_NUMBER, true);
+  const precision = getPrecision(interval);
+  return {
+    min: round(Math.floor(lo / interval) * interval, precision),
+    max: round(Math.ceil(hi / interval) * interval, precision),
+  };
+};
+
+// Build the `yAxis` options that keep tick-label precision and the plot-edge gap
+// in agreement with the extent ECharts renders. It re-invokes the `min`/`max`
+// callbacks with the extent of the visible (zoom-filtered) data on every
+// dataZoom, and always before the label formatter runs, so the fraction digits
+// recomputed here track the zoomed range. A callback returns `undefined`
+// wherever auto-scaling should stand, and a number only where the axis has to be
+// pinned: an explicit bound, the zero anchor, or a constant series.
 export function createYAxisPrecisionBounds(options: {
   min?: YAxisBound;
   max?: YAxisBound;
   // Set for bar axes anchored at 0, so precision reflects the 0-based range.
+  // Such an axis also gets no gap: pushing it below zero would defeat the zero
+  // anchoring and leave the bars floating above the axis.
   includeZero?: boolean;
   onFractionDigits: (digits: number) => void;
 }): {
   min: (values: YAxisExtentValues) => number | undefined;
   max: (values: YAxisExtentValues) => number | undefined;
+  boundaryGap: [number, number];
+  splitNumber: number;
 } {
   const { min, max, includeZero, onFractionDigits } = options;
+
+  const resolveBounds = (values: YAxisExtentValues) => {
+    const resolvedMin = resolveYAxisBound(min, values);
+    const resolvedMax = resolveYAxisBound(max, values);
+    if (
+      includeZero ||
+      !Number.isFinite(values.min) ||
+      !Number.isFinite(values.max)
+    ) {
+      return { min: resolvedMin, max: resolvedMax, gap: 0 };
+    }
+    if (values.min === values.max) {
+      const flat = flatSeriesExtent(values.min, [
+        resolvedMin !== undefined,
+        resolvedMax !== undefined,
+      ]);
+      return {
+        min: resolvedMin ?? flat.min,
+        max: resolvedMax ?? flat.max,
+        gap: 0,
+      };
+    }
+    const gap = (values.max - values.min) * GAP_FRACTION_OF_SPAN;
+    // Never let the gap carry a single-signed series across zero.
+    return {
+      min: resolvedMin ?? (values.min >= 0 && values.min < gap ? 0 : undefined),
+      max:
+        resolvedMax ?? (values.max <= 0 && -values.max < gap ? 0 : undefined),
+      gap,
+    };
+  };
+
   return {
+    // Always emit the key. `setOption` merges the Y axis rather than replacing
+    // it, so a conditionally spread gap would survive a chart switching to a
+    // zero-anchored type and leave its bars floating.
+    boundaryGap: includeZero
+      ? [0, 0]
+      : [GAP_FRACTION_OF_SPAN, GAP_FRACTION_OF_SPAN],
+    splitNumber: SPLIT_NUMBER,
     min: (values) => {
-      const resolvedMin = resolveYAxisBound(min, values);
-      const resolvedMax = resolveYAxisBound(max, values);
-      const extentMin = resolvedMin ?? values.min;
-      const extentMax = resolvedMax ?? values.max;
+      const bounds = resolveBounds(values);
       onFractionDigits(
-        computeYAxisFractionDigits(extentMin, extentMax, includeZero)
+        computeYAxisFractionDigits(
+          bounds.min ?? values.min - bounds.gap,
+          bounds.max ?? values.max + bounds.gap,
+          includeZero
+        )
       );
-      return resolvedMin;
+      return bounds.min;
     },
-    max: (values) => resolveYAxisBound(max, values),
+    max: (values) => resolveBounds(values).max,
   };
 }

--- a/src/types/echarts.d.ts
+++ b/src/types/echarts.d.ts
@@ -13,3 +13,11 @@ declare module "echarts/lib/util/states" {
 declare module "echarts/lib/chart/sankey/SankeyView" {
   export { default } from "echarts/types/src/chart/sankey/SankeyView";
 }
+
+declare module "echarts/lib/util/number" {
+  export * from "echarts/types/src/util/number";
+}
+
+declare module "echarts/lib/scale/helper" {
+  export * from "echarts/types/src/scale/helper";
+}

--- a/test/components/chart/y-axis-boundary-gap.test.ts
+++ b/test/components/chart/y-axis-boundary-gap.test.ts
@@ -58,8 +58,10 @@ describe("Y-axis tick nudge", () => {
     expect(renderExtent([18, 21.2, 19], withGap())).toEqual([17.5, 21.5]);
   });
 
-  it("leaves an axis that already had a gap untouched", () => {
-    const data = [1.11109, 1.85849, 1.4];
+  it("leaves an axis with real headroom untouched", () => {
+    // Its minimum sits well clear of the tick below it, so the rounding it
+    // already gets is enough and the widened extent floors to the same place.
+    const data = [18.3, 21.2, 19.5];
     expect(renderExtent(data, withGap())).toEqual(
       renderExtent(data, { scale: true })
     );
@@ -71,7 +73,7 @@ describe("Y-axis tick nudge", () => {
     expect(
       renderExtent([0, 3500, 1200], {
         scale: true,
-        boundaryGap: [1e-6, 1e-6],
+        boundaryGap: [0.02, 0.02],
       })[0]
     ).toBe(-1000);
   });

--- a/test/components/chart/y-axis-boundary-gap.test.ts
+++ b/test/components/chart/y-axis-boundary-gap.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { SVGRenderer } from "echarts/renderers";
+import echarts from "../../../src/resources/echarts/echarts";
+import { createYAxisPrecisionBounds } from "../../../src/components/chart/y-axis-fraction-digits";
+
+// jsdom has no canvas, and zrender reaches for one to measure label text.
+HTMLCanvasElement.prototype.getContext = (() => ({
+  measureText: () => ({ width: 10 }),
+})) as any;
+
+// The app registers the canvas renderer; jsdom needs the SVG one.
+echarts.use([SVGRenderer]);
+
+// The gap is opened by ECharts' own tick rounding, not by our helper, so these
+// assert the extent ECharts actually renders rather than what we hand it.
+const renderExtent = (
+  data: number[],
+  yAxis: Record<string, unknown>,
+  nextYAxis?: Record<string, unknown>
+): [number, number] => {
+  const chart = echarts.init(null, null, {
+    ssr: true,
+    renderer: "svg",
+    width: 400,
+    height: 300,
+  });
+  const option = (axis: Record<string, unknown>) => ({
+    xAxis: { type: "category", data: data.map((_, index) => String(index)) },
+    yAxis: { type: "value", ...axis },
+    series: [{ type: "line", data }],
+  });
+  chart.setOption(option(yAxis));
+  if (nextYAxis) {
+    chart.setOption(option(nextYAxis), { replaceMerge: ["series"] });
+  }
+  // getModel() is internal, but it is the only way to read the rendered extent.
+  const extent = (chart as any)
+    .getModel()
+    .getComponent("yAxis")
+    .axis.scale.getExtent();
+  chart.dispose();
+  return extent;
+};
+
+const withGap = (includeZero = false) => ({
+  scale: !includeZero,
+  ...createYAxisPrecisionBounds({
+    includeZero,
+    onFractionDigits: () => undefined,
+  }),
+});
+
+describe("Y-axis tick nudge", () => {
+  it("opens a gap under data that lands exactly on a tick", () => {
+    // The reported bug: a thermostat's states are quantized, so the minimum is
+    // an exact tick and the HVAC action band has nothing to fill.
+    expect(renderExtent([18, 21.2, 19], { scale: true })).toEqual([18, 21.5]);
+    expect(renderExtent([18, 21.2, 19], withGap())).toEqual([17.5, 21.5]);
+  });
+
+  it("leaves an axis that already had a gap untouched", () => {
+    const data = [1.11109, 1.85849, 1.4];
+    expect(renderExtent(data, withGap())).toEqual(
+      renderExtent(data, { scale: true })
+    );
+  });
+
+  it("keeps a non-negative series anchored at zero", () => {
+    expect(renderExtent([0, 3500, 1200], withGap())[0]).toBe(0);
+    // Without the clamp the nudged minimum floors a whole interval below zero.
+    expect(
+      renderExtent([0, 3500, 1200], {
+        scale: true,
+        boundaryGap: [1e-6, 1e-6],
+      })[0]
+    ).toBe(-1000);
+  });
+
+  it("keeps the window ECharts gives a constant series", () => {
+    expect(renderExtent([21, 21, 21], withGap())).toEqual(
+      renderExtent([21, 21, 21], { scale: true })
+    );
+    // A series flat at zero has no magnitude to expand by.
+    expect(renderExtent([0, 0, 0], withGap())).toEqual(
+      renderExtent([0, 0, 0], { scale: true })
+    );
+  });
+
+  it("re-anchors at zero when a chart switches to a zero-anchored type", () => {
+    // setOption merges the Y axis, so a gap that is only emitted conditionally
+    // survives the switch and leaves the bars floating.
+    expect(renderExtent([20, 500, 300], withGap(), withGap(true))[0]).toBe(0);
+  });
+});

--- a/test/components/chart/y-axis-fraction-digits.test.ts
+++ b/test/components/chart/y-axis-fraction-digits.test.ts
@@ -72,13 +72,25 @@ describe("computeYAxisFractionDigits", () => {
 });
 
 describe("createYAxisPrecisionBounds", () => {
-  it("computes digits from the visible extent when no bounds are set", () => {
+  const makeBounds = (
+    options: Omit<
+      Parameters<typeof createYAxisPrecisionBounds>[0],
+      "onFractionDigits"
+    > = {}
+  ) => {
     const onFractionDigits = vi.fn();
-    const { min, max } = createYAxisPrecisionBounds({ onFractionDigits });
+    return {
+      ...createYAxisPrecisionBounds({ ...options, onFractionDigits }),
+      onFractionDigits,
+    };
+  };
+
+  it("computes digits from the visible extent when no bounds are set", () => {
+    const { min, max, onFractionDigits } = makeBounds();
 
     // Zoomed-out extent -> coarse precision, callbacks leave scaling to ECharts
-    expect(min({ min: 0, max: 100 })).toBeUndefined();
-    expect(max({ min: 0, max: 100 })).toBeUndefined();
+    expect(min({ min: 10, max: 100 })).toBeUndefined();
+    expect(max({ min: 10, max: 100 })).toBeUndefined();
     expect(onFractionDigits).toHaveBeenLastCalledWith(0);
 
     // Zoomed-in narrow extent -> more decimals so ticks stay distinct
@@ -87,12 +99,7 @@ describe("createYAxisPrecisionBounds", () => {
   });
 
   it("computes digits from numeric bounds and returns them unchanged", () => {
-    const onFractionDigits = vi.fn();
-    const { min, max } = createYAxisPrecisionBounds({
-      min: 1.85,
-      max: 2,
-      onFractionDigits,
-    });
+    const { min, max, onFractionDigits } = makeBounds({ min: 1.85, max: 2 });
 
     // Fixed bounds pin the range, so the visible extent is ignored
     expect(min({ min: 1.9, max: 1.95 })).toBe(1.85);
@@ -101,11 +108,9 @@ describe("createYAxisPrecisionBounds", () => {
   });
 
   it("resolves function bounds and passes their result through", () => {
-    const onFractionDigits = vi.fn();
-    const { min, max } = createYAxisPrecisionBounds({
+    const { min, max, onFractionDigits } = makeBounds({
       min: ({ min: dataMin }) => dataMin - 1,
       max: ({ max: dataMax }) => dataMax + 1,
-      onFractionDigits,
     });
 
     expect(min({ min: 10, max: 11 })).toBe(9);
@@ -115,11 +120,7 @@ describe("createYAxisPrecisionBounds", () => {
   });
 
   it("unions the extent with zero for anchored axes", () => {
-    const onFractionDigits = vi.fn();
-    const { min } = createYAxisPrecisionBounds({
-      includeZero: true,
-      onFractionDigits,
-    });
+    const { min, onFractionDigits } = makeBounds({ includeZero: true });
 
     // Data sits at 20..25, but a bar axis renders from 0 -> coarse precision
     min({ min: 20, max: 25 });
@@ -131,10 +132,66 @@ describe("createYAxisPrecisionBounds", () => {
   });
 
   it("does not over-pad when the visible extent collapses to noise", () => {
-    const onFractionDigits = vi.fn();
-    const { min } = createYAxisPrecisionBounds({ onFractionDigits });
+    const { min, onFractionDigits } = makeBounds();
 
     min({ min: 0.3, max: 0.3 + 1e-15 });
     expect(onFractionDigits).toHaveBeenLastCalledWith(1);
+  });
+
+  it("widens the extent so ECharts always rounds out a gap", () => {
+    const { min, max, boundaryGap, splitNumber } = makeBounds();
+
+    // The gap is applied by ECharts, so the bounds stay auto-scaled.
+    expect(boundaryGap).toEqual([1e-6, 1e-6]);
+    // Pinned rather than assumed, since the precision here is derived from it.
+    expect(splitNumber).toBe(5);
+    expect(min({ min: 18, max: 21.2 })).toBeUndefined();
+    expect(max({ min: 18, max: 21.2 })).toBeUndefined();
+  });
+
+  it("anchors at zero instead of widening a non-negative series below it", () => {
+    const { min, max } = makeBounds();
+
+    // Without this, ECharts floors the widened -0.0035 to a full interval below
+    // zero, inventing a negative region on a power chart.
+    expect(min({ min: 0, max: 3500 })).toBe(0);
+    expect(max({ min: 0, max: 3500 })).toBeUndefined();
+
+    // A minimum clear of the gap is left to ECharts.
+    expect(min({ min: 0.01, max: 3500 })).toBeUndefined();
+  });
+
+  it("anchors an all-negative series at zero from above", () => {
+    const { min, max } = makeBounds();
+
+    expect(max({ min: -3500, max: 0 })).toBe(0);
+    expect(min({ min: -3500, max: 0 })).toBeUndefined();
+
+    // Mixed-sign data is widened at both ends.
+    expect(min({ min: -20, max: 20 })).toBeUndefined();
+    expect(max({ min: -20, max: 20 })).toBeUndefined();
+  });
+
+  it("keeps the expanded window ECharts gives a constant series", () => {
+    const { min, max, onFractionDigits } = makeBounds();
+
+    // ECharts only expands a flat extent while its bounds are equal, so the gap
+    // would otherwise collapse this to 20.99998..21.00002 at five decimals.
+    expect(min({ min: 21, max: 21 })).toBe(10);
+    expect(max({ min: 21, max: 21 })).toBe(35);
+    expect(onFractionDigits).toHaveBeenLastCalledWith(0);
+
+    // A series flat at zero has no magnitude to expand by.
+    expect(min({ min: 0, max: 0 })).toBe(0);
+    expect(max({ min: 0, max: 0 })).toBe(1);
+  });
+
+  it("never widens a zero-anchored axis", () => {
+    const { min, max, boundaryGap } = makeBounds({ includeZero: true });
+
+    // Widening below zero would defeat ECharts' anchoring and float the bars.
+    expect(boundaryGap).toEqual([0, 0]);
+    expect(min({ min: 0, max: 3500 })).toBeUndefined();
+    expect(max({ min: 20, max: 20 })).toBeUndefined();
   });
 });

--- a/test/components/chart/y-axis-fraction-digits.test.ts
+++ b/test/components/chart/y-axis-fraction-digits.test.ts
@@ -142,7 +142,7 @@ describe("createYAxisPrecisionBounds", () => {
     const { min, max, boundaryGap, splitNumber } = makeBounds();
 
     // The gap is applied by ECharts, so the bounds stay auto-scaled.
-    expect(boundaryGap).toEqual([1e-6, 1e-6]);
+    expect(boundaryGap).toEqual([0.02, 0.02]);
     // Pinned rather than assumed, since the precision here is derived from it.
     expect(splitNumber).toBe(5);
     expect(min({ min: 18, max: 21.2 })).toBeUndefined();
@@ -158,7 +158,7 @@ describe("createYAxisPrecisionBounds", () => {
     expect(max({ min: 0, max: 3500 })).toBeUndefined();
 
     // A minimum clear of the gap is left to ECharts.
-    expect(min({ min: 0.01, max: 3500 })).toBeUndefined();
+    expect(min({ min: 100, max: 3500 })).toBeUndefined();
   });
 
   it("anchors an all-negative series at zero from above", () => {


### PR DESCRIPTION
## Proposed change

ECharts floors the axis minimum and ceils the maximum to a tick multiple, so quantized states that land on or just above a tick leave the data flush against the plot edge — which collapses the climate and humidifier action bands, since an area fill is based at the axis minimum. This widens the auto-scaled extent by 2% of the span so that same rounding always has something to round away, which bumps any axis with less headroom out to a full tick and leaves the rest where they are. The axis still anchors at zero for single-signed data, and a constant series keeps the window ECharts gives it.

## Screenshots

Thermostat history in the more info dialog.

Before — the axis runs 20 to 25, so the current temperature and target lines sit on the plot edges and the heating band fills the frame:

![History chart with a Y axis from 20 to 25, the blue current temperature line flush against the top edge and the orange target line flush against the bottom edge](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/before-chart-ff9defaa.png)

After — the axis runs 19 to 26, so both lines are clear of the edges and the band reads as a band:

![The same history chart with a Y axis from 19 to 26, both lines clear of the plot edges with a tick of space above and below](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/after-chart-e03ffeef.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #53789
- This PR is related to issue or discussion: https://community.home-assistant.io/t/issue-with-thermostat-display-graph/1022607/3
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

### Why 2%

Because ECharts rounds out to a whole tick *after* the gap is applied, this constant never sets the size of the resulting gap — that is always about one tick interval. It only sets the threshold for **which axes count as too flat to leave alone**, which makes it measurable rather than a matter of taste. Sweeping it against the real ECharts pipeline:

| gap | worst-case gap under the data | thermostat data fill | charts repainted |
| --- | --- | --- | --- |
| `1e-6` | **0%** — bug survives | 80% | 6/8 |
| 1% | 1.4% | 80% | 7/8 |
| **2%** | **2.9%** | **80%** | 7/8 |
| 3% | 2.9% — identical to 2% | 80% | 7/8 |
| 5% | 5.7% | **64%** — ticks coarsen | 7/8 |
| 10% | 8.6% | 64% | 7/8 |

*Worst-case gap* sweeps where the data minimum sits within a tick cycle and takes the thinnest result, as a share of plot height. *Data fill* is how much of the plot the data occupies on a thermostat chart, so higher is less wasted space. *Charts repainted* counts how many of eight representative sensor charts end up with a different axis than today.

2% takes the worst case from nothing to roughly 3% of plot height — about 9px on a 300px chart — while every one of those charts keeps the framing it has today. 3% buys nothing over 2%, and 5% is where the thermostat's tick interval coarsens from 0.5 to 1 and a third of the plot goes empty.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr




