### PR TITLE
Stop a percentage Y axis expanding past 100

### DIFF
--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -328,6 +328,7 @@ export class StateHistoryChartLine extends LitElement {
           ...createYAxisPrecisionBounds({
             min: this._clampYAxis(minYAxis),
             max: this._clampYAxis(maxYAxis),
+            unit: this.unit,
             onFractionDigits: (digits) => {
               if (digits !== this._yAxisFractionDigits) {
                 this._yAxisFractionDigits = digits;

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -446,6 +446,7 @@ export class StatisticsChart extends LitElement {
         ...createYAxisPrecisionBounds({
           min: this._clampYAxis(minYAxis),
           max: this._clampYAxis(maxYAxis),
+          unit: this.unit,
           // Bar charts stay anchored at 0, so precision must reflect the
           // 0-based range that is actually rendered.
           includeZero: !yAxisScale,

--- a/src/components/chart/y-axis-fraction-digits.ts
+++ b/src/components/chart/y-axis-fraction-digits.ts
@@ -18,6 +18,11 @@ const SPLIT_NUMBER = 5;
 // headroom out to a full tick, and leaves the rest where they are.
 const GAP_FRACTION_OF_SPAN = 0.02;
 
+// A percentage has a real ceiling the way zero is a real floor, so the gap must
+// not push the axis past it. Not every `%` sensor is bounded — power factor is
+// signed and can read over 100 — so this only applies while the data stays under.
+const PERCENT_MAX = 100;
+
 // Derive the number of decimal digits to use for Y-axis labels from the
 // observed data range, by asking ECharts for the same tick interval it will
 // render. This matches the precision it actually draws, so labels are neither
@@ -81,6 +86,9 @@ export function createYAxisPrecisionBounds(options: {
   // Such an axis also gets no gap: pushing it below zero would defeat the zero
   // anchoring and leave the bars floating above the axis.
   includeZero?: boolean;
+  // Used to recognise a bounded quantity, so the gap cannot widen the axis past
+  // a limit the data itself never crosses.
+  unit?: string;
   onFractionDigits: (digits: number) => void;
 }): {
   min: (values: YAxisExtentValues) => number | undefined;
@@ -88,7 +96,8 @@ export function createYAxisPrecisionBounds(options: {
   boundaryGap: [number, number];
   splitNumber: number;
 } {
-  const { min, max, includeZero, onFractionDigits } = options;
+  const { min, max, includeZero, unit, onFractionDigits } = options;
+  const naturalMax = unit === "%" ? PERCENT_MAX : undefined;
 
   const resolveBounds = (values: YAxisExtentValues) => {
     const resolvedMin = resolveYAxisBound(min, values);
@@ -105,18 +114,36 @@ export function createYAxisPrecisionBounds(options: {
         resolvedMin !== undefined,
         resolvedMax !== undefined,
       ]);
+      // The expansion is a fraction of the magnitude, so a constant series near
+      // the ceiling would otherwise overshoot it too.
+      const flatMax =
+        naturalMax !== undefined && values.max <= naturalMax
+          ? Math.min(flat.max, naturalMax)
+          : flat.max;
       return {
         min: resolvedMin ?? flat.min,
-        max: resolvedMax ?? flat.max,
+        max: resolvedMax ?? flatMax,
         gap: 0,
       };
     }
     const gap = (values.max - values.min) * GAP_FRACTION_OF_SPAN;
-    // Never let the gap carry a single-signed series across zero.
+    // Never let the gap carry a series past a boundary it does not itself cross.
+    const floor = values.min >= 0 ? 0 : undefined;
+    const ceiling =
+      naturalMax !== undefined && values.max <= naturalMax
+        ? naturalMax
+        : values.max <= 0
+          ? 0
+          : undefined;
     return {
-      min: resolvedMin ?? (values.min >= 0 && values.min < gap ? 0 : undefined),
+      min:
+        resolvedMin ??
+        (floor !== undefined && values.min - floor < gap ? floor : undefined),
       max:
-        resolvedMax ?? (values.max <= 0 && -values.max < gap ? 0 : undefined),
+        resolvedMax ??
+        (ceiling !== undefined && ceiling - values.max < gap
+          ? ceiling
+          : undefined),
       gap,
     };
   };

--- a/test/components/chart/y-axis-boundary-gap.test.ts
+++ b/test/components/chart/y-axis-boundary-gap.test.ts
@@ -42,10 +42,11 @@ const renderExtent = (
   return extent;
 };
 
-const withGap = (includeZero = false) => ({
+const withGap = (includeZero = false, unit?: string) => ({
   scale: !includeZero,
   ...createYAxisPrecisionBounds({
     includeZero,
+    unit,
     onFractionDigits: () => undefined,
   }),
 });
@@ -86,6 +87,12 @@ describe("Y-axis tick nudge", () => {
     expect(renderExtent([0, 0, 0], withGap())).toEqual(
       renderExtent([0, 0, 0], { scale: true })
     );
+  });
+
+  it("does not round a percentage axis past 100", () => {
+    const battery = [20, 100, 60, 20, 80];
+    expect(renderExtent(battery, withGap())).toEqual([0, 120]);
+    expect(renderExtent(battery, withGap(false, "%"))).toEqual([0, 100]);
   });
 
   it("re-anchors at zero when a chart switches to a zero-anchored type", () => {

--- a/test/components/chart/y-axis-fraction-digits.test.ts
+++ b/test/components/chart/y-axis-fraction-digits.test.ts
@@ -186,6 +186,42 @@ describe("createYAxisPrecisionBounds", () => {
     expect(max({ min: 0, max: 0 })).toBe(1);
   });
 
+  it("stops a percentage axis at 100 the way it stops at zero", () => {
+    const { max } = makeBounds({ unit: "%" });
+
+    // A battery that reaches full would otherwise round out to an axis
+    // labelled up to 120%.
+    expect(max({ min: 20, max: 100 })).toBe(100);
+    expect(max({ min: 20, max: 99 })).toBe(100);
+
+    // Well clear of the ceiling, so it still gets its gap.
+    expect(max({ min: 40, max: 60 })).toBeUndefined();
+
+    // Not every % sensor is bounded: power factor is signed and can read over
+    // 100, and a series already past the ceiling must be left alone.
+    expect(max({ min: -80, max: 140 })).toBeUndefined();
+  });
+
+  it("holds a constant percentage under the ceiling too", () => {
+    const { max } = makeBounds({ unit: "%" });
+
+    // A device left on the charger reads a flat 100%, and the expansion a flat
+    // series gets is a fraction of its magnitude, so it overshoots on its own.
+    expect(max({ min: 100, max: 100 })).toBe(100);
+    expect(max({ min: 80, max: 80 })).toBe(100);
+
+    // Far enough below that the expansion never reaches the ceiling.
+    expect(max({ min: 54, max: 54 })).toBe(90);
+  });
+
+  it("only treats a percentage as bounded", () => {
+    // The same extent without the unit is widened as usual.
+    expect(makeBounds().max({ min: 20, max: 100 })).toBeUndefined();
+    expect(
+      makeBounds({ unit: "W" }).max({ min: 20, max: 100 })
+    ).toBeUndefined();
+  });
+
   it("never widens a zero-anchored axis", () => {
     const { min, max, boundaryGap } = makeBounds({ includeZero: true });
 


### PR DESCRIPTION
## Proposed change

A percentage has a real ceiling the way zero is a real floor, but the gap that keeps series off the plot edges did not know that — so a battery reading 20–100% rounded out to an axis labelled up to 120%, and one sitting flat at 100% reached 160%. This recognises the unit at the two line-chart call sites and holds the axis at 100, mirroring the zero clamp already there. It applies only while the data stays under the ceiling, since power factor is also reported in `%` and is signed.

Stacked on #53821, which introduced the gap and the zero clamp — review that one first.

## Screenshots

A battery sitting at 99%.

Before — the axis runs to 160% and roughly 40% of the plot is values a battery cannot report:

![Battery history chart with a Y axis from 40 to 160 percent, the flat 99% line sitting around two thirds up the plot](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pct-before-chart-a50a4b39.png)

After — the axis stops at 100:

![The same chart with a Y axis from 40 to 100 percent, the flat 99% line just below the top gridline](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pct-after-chart-704ab14a.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53821
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

### Why the unit rather than the device class

`device_class` would be the more precise signal, but it is not available at either call site. `LineChartUnit` carries it, yet `state-history-charts` never forwards it, and it is only populated when `split_device_classes` is on — which the more info dialog and the history graph card both leave off. `StatisticsMetaData` has no `device_class` field at all. The unit string is the only signal both callers already hold, and every existing percentage check in the frontend compares the bare `"%"` literal.

### Why the clamp is conditional

`%` is not a 0–100 unit in general: `power_factor` is reported in `%` and core allows it to be signed. The clamp therefore fires only when the widened maximum would actually cross 100, exactly like the zero clamp only fires when the widened minimum would cross zero. A series that genuinely reads 140% is left alone.

A battery that reaches 100% then sits flush against the top edge, as the second screenshot shows. That is the intended symmetry with `0` rather than a regression — an area fill is anchored at the axis minimum, so nothing collapses at the top, and labelling an axis to 160% is the worse of the two.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
