### PR TITLE
Expand tree nodes on double-click in the automation editor

### DIFF
--- a/src/panels/config/automation/add-automation-element/ha-automation-add-from-target.ts
+++ b/src/panels/config/automation/add-automation-element/ha-automation-add-from-target.ts
@@ -1,4 +1,5 @@
 import "@home-assistant/webawesome/dist/components/tree-item/tree-item";
+import type WaTreeItem from "@home-assistant/webawesome/dist/components/tree-item/tree-item";
 import "@home-assistant/webawesome/dist/components/tree/tree";
 import type { WaSelectionChangeEvent } from "@home-assistant/webawesome/dist/events/selection-change";
 import { consume, type ContextType } from "@lit/context";
@@ -360,6 +361,7 @@ export default class HaAutomationAddFromTarget extends LitElement {
                   ? html`<ha-list-base>${floorAreas}</ha-list-base>`
                   : html`<wa-tree
                       @wa-selection-change=${this._handleSelectionChange}
+                      @dblclick=${this._handleDoubleClick}
                       >${floorAreas}</wa-tree
                     >`
               }`
@@ -1442,6 +1444,26 @@ export default class HaAutomationAddFromTarget extends LitElement {
   private _collapseItem(ev) {
     const targetId = ev.target.target;
     this._toggleItem(targetId, false);
+  }
+
+  private _handleDoubleClick(ev: MouseEvent) {
+    // the expand button and non-selectable items already toggle on single click
+    if (
+      ev
+        .composedPath()
+        .some((el) => (el as HTMLElement).classList?.contains("expand-button"))
+    ) {
+      return;
+    }
+    const item = (ev.target as HTMLElement).closest<
+      WaTreeItem & { target: string }
+    >("wa-tree-item");
+    if (!item || item.isLeaf || item.preventSelection) {
+      return;
+    }
+    // avoid leaving the label text selected by the double click
+    window.getSelection()?.removeAllRanges();
+    this._toggleItem(item.target, !item.expanded);
   }
 
   private async _loadConfigEntries() {


### PR DESCRIPTION
## Proposed change

In the add trigger/condition/action dialog, the desktop target picker tree can only be
expanded by hitting the small chevron — clicking the row itself just selects the node.
This adds double-click on the row as a shortcut to expand/collapse in the "Home" tree.

It is a shortcut, not a replacement: the chevron still toggles on a single click, and a
single click on the row still just selects. Making single click expand too was considered,
but browsing a level would then leave a trail of branches open that nobody asked for.
Double-click to open is the long-standing tree convention on desktop, so it costs nothing
to users who never try it.

The uncategorized tree is unchanged, as are touch and narrow layouts — the narrow layout
renders no tree at all.

> [!NOTE]
> A note for the dashboard side: the dashboard tree selector (and the "by entity" tab)
> currently accepts no floor, area, or device as a valid target, so the same
> expand-vs-select distinction has nothing to act on there yet. That may well change —
> a template view for a floor, a template view for an area, or a device card — and when it
> does, the two pickers will behave the same way instead of diverging.

## Screenshots


https://github.com/user-attachments/assets/ec62854c-1423-4b4a-8140-fa8a0ec7a28c



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52000
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
