### PR TITLE
Improve low battery entity lookup

### DIFF
--- a/src/panels/maintenance/strategies/maintenance-view-strategy.ts
+++ b/src/panels/maintenance/strategies/maintenance-view-strategy.ts
@@ -16,9 +16,10 @@ import type { TileCardConfig } from "../../lovelace/cards/types";
 import { BINARY_STATE_ON } from "../../../common/const";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import {
-  type EntityRegistryDisplayEntry,
-  findBatteryChargingEntity,
-} from "../../../data/entity/entity_registry";
+  type DeviceEntityDisplayLookup,
+  getDeviceEntityDisplayLookup,
+} from "../../../data/device/device_registry";
+import { findBatteryChargingEntity } from "../../../data/entity/entity_registry";
 
 export interface MaintenanceViewStrategyConfig {
   type: "maintenance";
@@ -37,44 +38,48 @@ export const maintenanceEntityFilters: EntityFilter[] = [
 
 const LOW_BATTERY_THRESHOLD = 20;
 
-const _deviceEntities = memoizeOne(
-  (
-    deviceId: string,
-    entities: HomeAssistant["entities"]
-  ): EntityRegistryDisplayEntry[] => {
-    const entries = Object.values(entities);
-    return entries.filter((entity) => entity.device_id === deviceId);
-  }
+const _deviceEntityLookup = memoizeOne((entities: HomeAssistant["entities"]) =>
+  getDeviceEntityDisplayLookup(Object.values(entities))
 );
 
 export const filterLowBatteryEntities = (
   hass: HomeAssistant,
   entityIds: string[]
-): string[] =>
-  entityIds.filter((entityId) => {
+): string[] => {
+  let deviceEntityLookup: DeviceEntityDisplayLookup | undefined;
+
+  return entityIds.filter((entityId) => {
     const state = hass.states[entityId]?.state ?? "";
+
     if (computeDomain(entityId) === "binary_sensor") {
       return state === BINARY_STATE_ON;
     }
 
-    const deviceId = hass.entities[entityId]?.device_id;
-    const entities = deviceId ? _deviceEntities(deviceId, hass.entities) : [];
-
-    const batteryChargingEntity = findBatteryChargingEntity(
-      hass.states,
-      entities
-    );
-    const batteryCharging = batteryChargingEntity
-      ? hass.states[batteryChargingEntity?.entity_id]
-      : undefined;
-
-    if (batteryCharging && batteryCharging.state === "on") {
+    const stateValue = parseFloat(state);
+    if (isNaN(stateValue) || stateValue > LOW_BATTERY_THRESHOLD) {
       return false;
     }
 
-    const stateValue = parseFloat(state);
-    return !isNaN(stateValue) && stateValue <= LOW_BATTERY_THRESHOLD;
+    const deviceId = hass.entities[entityId]?.device_id;
+    if (!deviceId) {
+      return true;
+    }
+
+    if (!deviceEntityLookup) {
+      deviceEntityLookup = _deviceEntityLookup(hass.entities);
+    }
+
+    const batteryChargingEntity = findBatteryChargingEntity(
+      hass.states,
+      deviceEntityLookup[deviceId] ?? []
+    );
+    const batteryCharging = batteryChargingEntity
+      ? hass.states[batteryChargingEntity.entity_id]
+      : undefined;
+
+    return batteryCharging?.state !== "on";
   });
+};
 
 export const filterUnavailableBatteryEntities = (
   hass: HomeAssistant,

--- a/src/panels/maintenance/strategies/maintenance-view-strategy.ts
+++ b/src/panels/maintenance/strategies/maintenance-view-strategy.ts
@@ -16,7 +16,6 @@ import type { TileCardConfig } from "../../lovelace/cards/types";
 import { BINARY_STATE_ON } from "../../../common/const";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import {
-  type DeviceEntityDisplayLookup,
   getDeviceEntityDisplayLookup,
 } from "../../../data/device/device_registry";
 import { findBatteryChargingEntity } from "../../../data/entity/entity_registry";
@@ -46,7 +45,6 @@ export const filterLowBatteryEntities = (
   hass: HomeAssistant,
   entityIds: string[]
 ): string[] => {
-  let deviceEntityLookup: DeviceEntityDisplayLookup | undefined;
 
   return entityIds.filter((entityId) => {
     const state = hass.states[entityId]?.state ?? "";
@@ -65,13 +63,10 @@ export const filterLowBatteryEntities = (
       return true;
     }
 
-    if (!deviceEntityLookup) {
-      deviceEntityLookup = _deviceEntityLookup(hass.entities);
-    }
 
     const batteryChargingEntity = findBatteryChargingEntity(
       hass.states,
-      deviceEntityLookup[deviceId] ?? []
+      _deviceEntityLookup(hass.entities)[deviceId] ?? []
     );
     const batteryCharging = batteryChargingEntity
       ? hass.states[batteryChargingEntity.entity_id]

--- a/src/panels/maintenance/strategies/maintenance-view-strategy.ts
+++ b/src/panels/maintenance/strategies/maintenance-view-strategy.ts
@@ -15,9 +15,7 @@ import type { HomeAssistant } from "../../../types";
 import type { TileCardConfig } from "../../lovelace/cards/types";
 import { BINARY_STATE_ON } from "../../../common/const";
 import { computeDomain } from "../../../common/entity/compute_domain";
-import {
-  getDeviceEntityDisplayLookup,
-} from "../../../data/device/device_registry";
+import { getDeviceEntityDisplayLookup } from "../../../data/device/device_registry";
 import { findBatteryChargingEntity } from "../../../data/entity/entity_registry";
 
 export interface MaintenanceViewStrategyConfig {
@@ -45,7 +43,6 @@ export const filterLowBatteryEntities = (
   hass: HomeAssistant,
   entityIds: string[]
 ): string[] => {
-
   return entityIds.filter((entityId) => {
     const state = hass.states[entityId]?.state ?? "";
 
@@ -62,7 +59,6 @@ export const filterLowBatteryEntities = (
     if (!deviceId) {
       return true;
     }
-
 
     const batteryChargingEntity = findBatteryChargingEntity(
       hass.states,

--- a/test/panels/maintenance/strategies/maintenance-view-strategy.test.ts
+++ b/test/panels/maintenance/strategies/maintenance-view-strategy.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { filterLowBatteryEntities } from "../../../../src/panels/maintenance/strategies/maintenance-view-strategy";
+import { mockEntity } from "../../../common/entity/context/context-mock";
+import { createMockEntityState, createMockHass } from "../../../fixtures/hass";
+
+describe("filterLowBatteryEntities", () => {
+  it("filters numeric battery entities by the low battery threshold", () => {
+    const hass = createMockHass({
+      "sensor.low_battery": createMockEntityState("sensor.low_battery", "20", {
+        device_class: "battery",
+      }),
+      "sensor.ok_battery": createMockEntityState("sensor.ok_battery", "21", {
+        device_class: "battery",
+      }),
+    });
+
+    expect(
+      filterLowBatteryEntities(hass, [
+        "sensor.low_battery",
+        "sensor.ok_battery",
+      ])
+    ).toEqual(["sensor.low_battery"]);
+  });
+
+  it("excludes a low battery when its device is charging", () => {
+    const entities = {
+      "sensor.device_1_battery": mockEntity({
+        entity_id: "sensor.device_1_battery",
+        device_id: "device_1",
+      }),
+      "binary_sensor.device_1_battery_charging": mockEntity({
+        entity_id: "binary_sensor.device_1_battery_charging",
+        device_id: "device_1",
+      }),
+      "sensor.device_2_battery": mockEntity({
+        entity_id: "sensor.device_2_battery",
+        device_id: "device_2",
+      }),
+      "binary_sensor.device_2_battery_charging": mockEntity({
+        entity_id: "binary_sensor.device_2_battery_charging",
+        device_id: "device_2",
+      }),
+    };
+
+    const hass = createMockHass(
+      {
+        "sensor.device_1_battery": createMockEntityState(
+          "sensor.device_1_battery",
+          "10",
+          { device_class: "battery" }
+        ),
+        "binary_sensor.device_1_battery_charging": createMockEntityState(
+          "binary_sensor.device_1_battery_charging",
+          "on",
+          { device_class: "battery_charging" }
+        ),
+        "sensor.device_2_battery": createMockEntityState(
+          "sensor.device_2_battery",
+          "10",
+          { device_class: "battery" }
+        ),
+        "binary_sensor.device_2_battery_charging": createMockEntityState(
+          "binary_sensor.device_2_battery_charging",
+          "off",
+          { device_class: "battery_charging" }
+        ),
+      },
+      { entities }
+    );
+
+    expect(
+      filterLowBatteryEntities(hass, [
+        "sensor.device_1_battery",
+        "sensor.device_2_battery",
+      ])
+    ).toEqual(["sensor.device_2_battery"]);
+  });
+
+  it("keeps binary battery sensor behavior unchanged", () => {
+    const hass = createMockHass({
+      "binary_sensor.low_battery": createMockEntityState(
+        "binary_sensor.low_battery",
+        "on",
+        { device_class: "battery" }
+      ),
+      "binary_sensor.ok_battery": createMockEntityState(
+        "binary_sensor.ok_battery",
+        "off",
+        { device_class: "battery" }
+      ),
+    });
+
+    expect(
+      filterLowBatteryEntities(hass, [
+        "binary_sensor.low_battery",
+        "binary_sensor.ok_battery",
+      ])
+    ).toEqual(["binary_sensor.low_battery"]);
+  });
+
+  it("updates the device lookup when the entity registry changes", () => {
+    const states = {
+      "sensor.battery": createMockEntityState("sensor.battery", "10", {
+        device_class: "battery",
+      }),
+      "binary_sensor.battery_charging": createMockEntityState(
+        "binary_sensor.battery_charging",
+        "on",
+        { device_class: "battery_charging" }
+      ),
+    };
+
+    const firstHass = createMockHass(states, {
+      entities: {
+        "sensor.battery": mockEntity({
+          entity_id: "sensor.battery",
+          device_id: "device_1",
+        }),
+        "binary_sensor.battery_charging": mockEntity({
+          entity_id: "binary_sensor.battery_charging",
+          device_id: "device_1",
+        }),
+      },
+    });
+
+    expect(filterLowBatteryEntities(firstHass, ["sensor.battery"])).toEqual([]);
+
+    const secondHass = createMockHass(states, {
+      entities: {
+        "sensor.battery": mockEntity({
+          entity_id: "sensor.battery",
+          device_id: "device_1",
+        }),
+        "binary_sensor.battery_charging": mockEntity({
+          entity_id: "binary_sensor.battery_charging",
+          device_id: "device_2",
+        }),
+      },
+    });
+
+    expect(filterLowBatteryEntities(secondHass, ["sensor.battery"])).toEqual([
+      "sensor.battery",
+    ]);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Improve the entity lookup used by the low battery maintenance filter.

The existing implementation scans the full entity registry for each device while looking for a battery charging entity. This change builds and memoizes a device-to-entity lookup instead and reuses it while filtering battery entities.

The lookup is initialized only when it is needed for a low numeric battery entity with a device. Battery values above the low battery threshold and non-numeric states are filtered before performing the device lookup.

Tests cover the low battery threshold, charging state, binary battery sensors, and entity registry changes.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr