### PR TITLE
Use the cloud auto-login flow in the voice satellite wizard

### DIFF
--- a/src/data/cloud.ts
+++ b/src/data/cloud.ts
@@ -64,6 +64,11 @@ export interface CloudStatusLoggedIn {
 
 export type CloudStatus = CloudStatusNotLoggedIn | CloudStatusLoggedIn;
 
+export const cloudStatusAutoLogin = (
+  status: CloudStatus | undefined
+): CloudAutoLogin | null =>
+  !status || status.logged_in ? null : (status.auto_login ?? null);
+
 // Onboarding items the backend tracks. Mirrors ONBOARDING_ITEMS in the cloud
 // integration; onboarding is complete once every item has been onboarded.
 export const ONBOARDING_ITEMS = [
@@ -126,16 +131,6 @@ export const cloudForgotPassword = (hass: HomeAssistant, email: string) =>
     email,
   });
 
-export const cloudRegister = (
-  hass: HomeAssistant,
-  email: string,
-  password: string
-) =>
-  hass.callApi("POST", "cloud/register", {
-    email,
-    password,
-  });
-
 export const cloudRegisterAutoLogin = (
   hass: HomeAssistant,
   email: string,
@@ -161,11 +156,6 @@ export const subscribeCloudEvents = (
 ) =>
   hass.connection.subscribeMessage<CloudEvent>(callback, {
     type: "cloud/subscribe_events",
-  });
-
-export const cloudResendVerification = (hass: HomeAssistant, email: string) =>
-  hass.callApi("POST", "cloud/resend_confirm", {
-    email,
   });
 
 export const fetchCloudStatus = (hass: HomeAssistant) =>

--- a/src/dialogs/voice-assistant-setup/cloud/cloud-step-signin.ts
+++ b/src/dialogs/voice-assistant-setup/cloud/cloud-step-signin.ts
@@ -1,215 +1,43 @@
 import { LitElement, css, html } from "lit";
-import { customElement, property, query, state } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { navigate } from "../../../common/navigate";
-import "../../../components/ha-alert";
-import "../../../components/ha-button";
-import "../../../components/ha-svg-icon";
-import "../../../components/input/ha-input";
-import type { HaInput } from "../../../components/input/ha-input";
-import { cloudLogin } from "../../../data/cloud";
-import { showCloudAlreadyConnectedDialog } from "../../../panels/config/cloud/dialog-cloud-already-connected/show-dialog-cloud-already-connected";
+import "../../../panels/config/cloud/login/cloud-login";
 import type { HomeAssistant } from "../../../types";
-import {
-  showAlertDialog,
-  showPromptDialog,
-} from "../../generic/show-dialog-box";
 import { AssistantSetupStyles } from "../styles";
 
 @customElement("cloud-step-signin")
 export class CloudStepSignin extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @state() private _requestInProgress = false;
-
-  @state() private _error?: string;
-
-  @state() private _checkConnection = true;
-
-  @query("#email", true) private _emailField!: HaInput;
-
-  @query("#password", true) private _passwordField!: HaInput;
+  @property() public email?: string;
 
   render() {
     return html`<div class="content">
-        <img
-          src=${`/static/images/logo_nabu_casa${this.hass.themes?.darkMode ? "_dark" : ""}.png`}
-          alt="Nabu Casa logo"
-        />
-        <h1>${this.hass.localize("ui.panel.config.cloud.login.sign_in")}</h1>
-        ${
-          this._error
-            ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
-            : ""
-        }
-        <ha-input
-          autofocus
-          id="email"
-          name="email"
-          .label=${this.hass.localize(
-            "ui.panel.config.cloud.register.email_address"
-          )}
-          .disabled=${this._requestInProgress}
-          type="email"
-          autocomplete="email"
-          required
-          @keydown=${this._keyDown}
-          .validationMessage=${this.hass.localize(
-            "ui.panel.config.cloud.register.email_error_msg"
-          )}
-        ></ha-input>
-        <ha-input
-          id="password"
-          type="password"
-          password-toggle
-          name="password"
-          .label=${this.hass.localize(
-            "ui.panel.config.cloud.register.password"
-          )}
-          .disabled=${this._requestInProgress}
-          autocomplete="new-password"
-          minlength="8"
-          required
-          @keydown=${this._keyDown}
-          .validationMessage=${this.hass.localize(
-            "ui.panel.config.cloud.register.password_error_msg"
-          )}
-        ></ha-input>
-      </div>
-      <div class="footer">
-        <ha-button
-          @click=${this._handleLogin}
-          .disabled=${this._requestInProgress}
-          >${this.hass.localize(
-            "ui.panel.config.cloud.login.sign_in"
-          )}</ha-button
-        >
-      </div>`;
+      <img
+        src=${`/static/images/logo_nabu_casa${this.hass.themes?.darkMode ? "_dark" : ""}.png`}
+        alt="Nabu Casa logo"
+      />
+      <h1>${this.hass.localize("ui.panel.config.cloud.login.sign_in")}</h1>
+      <cloud-login
+        card-less
+        check-connection
+        .hass=${this.hass}
+        .email=${this.email}
+        .localize=${this.hass.localize}
+        @cloud-forgot-password=${this._forgotPassword}
+        @cloud-logged-in=${this._loggedIn}
+      ></cloud-login>
+    </div>`;
   }
 
-  private _keyDown(ev: KeyboardEvent) {
-    if (ev.key === "Enter") {
-      this._handleLogin();
-    }
+  private _loggedIn() {
+    fireEvent(this, "cloud-step", { step: "DONE" });
   }
 
-  private async _handleLogin() {
-    const emailField = this._emailField;
-    const passwordField = this._passwordField;
-
-    const email = emailField.value as string;
-    const password = passwordField.value as string;
-
-    if (!emailField.reportValidity()) {
-      passwordField.reportValidity();
-      emailField.focus();
-      return;
-    }
-
-    if (!passwordField.reportValidity()) {
-      passwordField.focus();
-      return;
-    }
-
-    this._requestInProgress = true;
-
-    const doLogin = async (username: string, code?: string) => {
-      try {
-        await cloudLogin({
-          hass: this.hass,
-          email: username,
-          ...(code ? { code } : { password }),
-          check_connection: this._checkConnection,
-        });
-      } catch (err: any) {
-        const errCode = err && err.body && err.body.code;
-
-        if (errCode === "mfarequired") {
-          const totpCode = await showPromptDialog(this, {
-            title: this.hass.localize(
-              "ui.panel.config.cloud.login.totp_code_prompt_title"
-            ),
-            inputLabel: this.hass.localize(
-              "ui.panel.config.cloud.login.totp_code"
-            ),
-            inputType: "text",
-            defaultValue: "",
-            confirmText: this.hass.localize(
-              "ui.panel.config.cloud.login.submit"
-            ),
-          });
-          if (totpCode !== null && totpCode !== "") {
-            await doLogin(username, totpCode.trim());
-            return;
-          }
-        }
-
-        if (errCode === "alreadyconnectederror") {
-          showCloudAlreadyConnectedDialog(this, {
-            details: JSON.parse(err.body.message),
-            logInHereAction: () => {
-              this._checkConnection = false;
-              doLogin(username);
-            },
-            closeDialog: () => {
-              this._requestInProgress = false;
-            },
-          });
-          return;
-        }
-
-        if (errCode === "usernotfound" && username !== username.toLowerCase()) {
-          await doLogin(username.toLowerCase());
-          return;
-        }
-
-        if (errCode === "PasswordChangeRequired") {
-          showAlertDialog(this, {
-            title: this.hass.localize(
-              "ui.panel.config.cloud.login.alert_password_change_required"
-            ),
-          });
-          navigate("/config/cloud/forgot-password");
-          fireEvent(this, "closed");
-          return;
-        }
-
-        this._requestInProgress = false;
-
-        switch (errCode) {
-          case "UserNotConfirmed":
-            this._error = this.hass.localize(
-              "ui.panel.config.cloud.login.alert_email_confirm_necessary"
-            );
-            break;
-          case "mfarequired":
-            this._error = this.hass.localize(
-              "ui.panel.config.cloud.login.alert_mfa_code_required"
-            );
-            break;
-          case "mfaexpiredornotstarted":
-            this._error = this.hass.localize(
-              "ui.panel.config.cloud.login.alert_mfa_expired_or_not_started"
-            );
-            break;
-          case "invalidtotpcode":
-            this._error = this.hass.localize(
-              "ui.panel.config.cloud.login.alert_totp_code_invalid"
-            );
-            break;
-          default:
-            this._error =
-              err && err.body && err.body.message
-                ? err.body.message
-                : "Unknown error";
-            break;
-        }
-
-        emailField.focus();
-      }
-    };
-
-    await doLogin(email);
+  private _forgotPassword() {
+    navigate("/config/cloud/forgot-password");
+    fireEvent(this, "closed");
   }
 
   static styles = [
@@ -217,6 +45,13 @@ export class CloudStepSignin extends LitElement {
     css`
       :host {
         display: block;
+      }
+      .content {
+        width: 100%;
+      }
+      cloud-login {
+        display: block;
+        text-align: start;
       }
     `,
   ];

--- a/src/dialogs/voice-assistant-setup/cloud/cloud-step-signup.ts
+++ b/src/dialogs/voice-assistant-setup/cloud/cloud-step-signup.ts
@@ -1,16 +1,17 @@
+import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { LitElement, css, html } from "lit";
-import { customElement, property, query, state } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
+import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import { fireEvent } from "../../../common/dom/fire_event";
-import "../../../components/ha-alert";
-import "../../../components/ha-button";
-import "../../../components/ha-svg-icon";
-import "../../../components/input/ha-input";
-import type { HaInput } from "../../../components/input/ha-input";
+import "../../../components/ha-spinner";
+import type { CloudAutoLogin, CloudStatus } from "../../../data/cloud";
 import {
-  cloudLogin,
-  cloudRegister,
-  cloudResendVerification,
+  cancelCloudAutoLogin,
+  cloudStatusAutoLogin,
+  fetchCloudStatus,
+  subscribeCloudEvents,
 } from "../../../data/cloud";
+import "../../../panels/config/cloud/register/cloud-register-card";
 import type { HomeAssistant } from "../../../types";
 import { AssistantSetupStyles } from "../styles";
 
@@ -18,203 +19,127 @@ import { AssistantSetupStyles } from "../styles";
 export class CloudStepSignup extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @state() private _requestInProgress = false;
+  @state() private _autoLogin: CloudAutoLogin | null = null;
 
-  @state() private _email?: string;
+  @state() private _loading = true;
 
-  @state() private _password?: string;
+  private _email?: string;
 
-  @state() private _error?: string;
+  private _unsubCloudEvents?: Promise<UnsubscribeFunc>;
 
-  @state() private _state?: "VERIFY";
+  private _statusRead: Promise<void> = Promise.resolve();
 
-  @query("#email", true) private _emailField!: HaInput;
+  private _wasLoggedIn?: boolean;
 
-  @query("#password", true) private _passwordField!: HaInput;
+  public connectedCallback(): void {
+    super.connectedCallback();
+    this._watchCloudStatus();
+    this._loadInitialStatus();
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._unsubCloudEvents?.then((unsub) => unsub()).catch(() => undefined);
+    this._unsubCloudEvents = undefined;
+  }
 
   render() {
     return html`<div class="content">
-        <img
-          src=${`/static/images/logo_nabu_casa${this.hass.themes?.darkMode ? "_dark" : ""}.png`}
-          alt="Nabu Casa logo"
-        />
-        <h1>
-          ${this.hass.localize("ui.panel.config.cloud.register.create_account")}
-        </h1>
-        ${
-          this._error
-            ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
-            : ""
-        }
-        ${
-          this._state === "VERIFY"
-            ? html`<p>
-                ${this.hass.localize(
-                  "ui.panel.config.cloud.register.confirm_email",
-                  { email: this._email }
-                )}
-              </p>`
-            : html`<ha-input
-                  autofocus
-                  id="email"
-                  name="email"
-                  .label=${this.hass.localize(
-                    "ui.panel.config.cloud.register.email_address"
-                  )}
-                  .disabled=${this._requestInProgress}
-                  type="email"
-                  autocomplete="email"
-                  required
-                  @keydown=${this._keyDown}
-                  .validationMessage=${this.hass.localize(
-                    "ui.panel.config.cloud.register.email_error_msg"
-                  )}
-                ></ha-input>
-                <ha-input
-                  id="password"
-                  type="password"
-                  password-toggle
-                  name="password"
-                  .label=${this.hass.localize(
-                    "ui.panel.config.cloud.register.password"
-                  )}
-                  .disabled=${this._requestInProgress}
-                  autocomplete="new-password"
-                  minlength="8"
-                  required
-                  @keydown=${this._keyDown}
-                  .validationMessage=${this.hass.localize(
-                    "ui.panel.config.cloud.register.password_error_msg"
-                  )}
-                ></ha-input>`
-        }
-      </div>
-      <div class="footer side-by-side">
-        ${
-          this._state === "VERIFY"
-            ? html`<ha-button
-                  @click=${this._handleResendVerifyEmail}
-                  .disabled=${this._requestInProgress}
-                  appearance="plain"
-                  >${this.hass.localize(
-                    "ui.panel.config.cloud.register.resend_confirm_email"
-                  )}</ha-button
-                ><ha-button
-                  @click=${this._login}
-                  .disabled=${this._requestInProgress}
-                  >${this.hass.localize(
-                    "ui.panel.config.cloud.register.clicked_confirm"
-                  )}</ha-button
-                >`
-            : html`<ha-button
-                  @click=${this._signIn}
-                  .disabled=${this._requestInProgress}
-                  appearance="plain"
-                  >${this.hass.localize(
-                    "ui.panel.config.cloud.login.sign_in"
-                  )}</ha-button
-                >
-                <ha-button
-                  @click=${this._handleRegister}
-                  .disabled=${this._requestInProgress}
-                  >${this.hass.localize("ui.common.next")}</ha-button
-                >`
-        }
-      </div>`;
+      <img
+        src=${`/static/images/logo_nabu_casa${this.hass.themes?.darkMode ? "_dark" : ""}.png`}
+        alt="Nabu Casa logo"
+      />
+      ${
+        this._loading
+          ? html`<div class="loading"><ha-spinner></ha-spinner></div>`
+          : html`<cloud-register-card
+              card-less
+              .hass=${this.hass}
+              .autoLogin=${this._autoLogin}
+              @cloud-email-changed=${this._emailChanged}
+              @cloud-sign-in-instead=${this._signIn}
+              @cloud-cancel-auto-login=${this._cancelAutoLogin}
+              @ha-refresh-cloud-status=${this._refreshCloudStatus}
+            ></cloud-register-card>`
+      }
+    </div>`;
+  }
+
+  // The cloud panel is fed status by ha-panel-config; this dialog is mounted at
+  // the root, outside it, so the step does the watching. Every cloud event means
+  // one thing here — the state moved, read it back — because cloud/status holds
+  // everything the events carry.
+  private _watchCloudStatus() {
+    if (this._unsubCloudEvents) {
+      return;
+    }
+
+    const subscription = subscribeCloudEvents(this.hass, () => {
+      this._refreshCloudStatus();
+    });
+    this._unsubCloudEvents = subscription;
+
+    subscription.catch(() => {
+      if (this._unsubCloudEvents === subscription) {
+        this._unsubCloudEvents = undefined;
+      }
+    });
+  }
+
+  private async _loadInitialStatus() {
+    await this._refreshCloudStatus();
+    this._loading = false;
+  }
+
+  private _refreshCloudStatus = (): Promise<void> => {
+    this._statusRead = this._statusRead
+      .then(() => this._readCloudStatus())
+      .catch(() => undefined);
+    return this._statusRead;
+  };
+
+  private async _readCloudStatus(): Promise<void> {
+    let status: CloudStatus;
+    try {
+      status = await fetchCloudStatus(this.hass);
+    } catch (_err) {
+      // Nothing to reconcile against. The registration form is the right place
+      // to be, and the next event tries again.
+      return;
+    }
+
+    // Lit keeps updating an element that was connected once.
+    if (!this.isConnected) {
+      return;
+    }
+
+    const wasLoggedIn = this._wasLoggedIn;
+    this._wasLoggedIn = status.logged_in;
+    this._autoLogin = cloudStatusAutoLogin(status);
+
+    if (status.logged_in && wasLoggedIn === false) {
+      fireEvent(this, "cloud-step", { step: "DONE" });
+    }
+  }
+
+  private _emailChanged(
+    ev: HASSDomEvent<HASSDomEvents["cloud-email-changed"]>
+  ) {
+    this._email = ev.detail.value;
   }
 
   private _signIn() {
-    fireEvent(this, "cloud-step", { step: "SIGNIN" });
+    fireEvent(this, "cloud-step", { step: "SIGNIN", email: this._email });
   }
 
-  private _keyDown(ev: KeyboardEvent) {
-    if (ev.key === "Enter") {
-      this._handleRegister();
-    }
-  }
-
-  private async _handleRegister() {
-    const emailField = this._emailField;
-    const passwordField = this._passwordField;
-
-    let invalid = false;
-
-    if (!emailField.reportValidity()) {
-      invalid = true;
-      emailField.focus();
-    }
-
-    if (!passwordField.reportValidity()) {
-      if (!invalid) {
-        passwordField.focus();
-      }
-      invalid = true;
-    }
-
-    if (invalid) {
-      return;
-    }
-
-    const email = emailField.value!.toLowerCase();
-    const password = passwordField.value!;
-
-    this._requestInProgress = true;
-
+  private async _cancelAutoLogin() {
     try {
-      await cloudRegister(this.hass, email, password);
-      this._email = email;
-      this._password = password;
-      this._verificationEmailSent();
-    } catch (err: any) {
-      this._password = "";
-      this._error =
-        err && err.body && err.body.message
-          ? err.body.message
-          : "Unknown error";
+      await cancelCloudAutoLogin(this.hass);
+    } catch (_err) {
+      // Fire and forget: the card has already returned to the form, and the
+      // read below reconciles a registration the backend refused to drop.
     } finally {
-      this._requestInProgress = false;
-    }
-  }
-
-  private async _handleResendVerifyEmail() {
-    if (!this._email) {
-      return;
-    }
-    try {
-      await cloudResendVerification(this.hass, this._email);
-      this._verificationEmailSent();
-    } catch (err: any) {
-      this._error =
-        err && err.body && err.body.message
-          ? err.body.message
-          : "Unknown error";
-    }
-  }
-
-  private _verificationEmailSent() {
-    this._state = "VERIFY";
-
-    setTimeout(() => this._login(), 5000);
-  }
-
-  private async _login() {
-    if (!this._email || !this._password) {
-      return;
-    }
-
-    try {
-      await cloudLogin({
-        hass: this.hass,
-        email: this._email,
-        password: this._password,
-      });
-      fireEvent(this, "cloud-step", { step: "DONE" });
-    } catch (e: any) {
-      if (e?.body?.code === "usernotconfirmed") {
-        this._verificationEmailSent();
-      } else {
-        this._error = "Something went wrong. Please try again.";
-      }
+      this._refreshCloudStatus();
     }
   }
 
@@ -223,6 +148,14 @@ export class CloudStepSignup extends LitElement {
     css`
       .content {
         width: 100%;
+      }
+      .loading {
+        display: flex;
+        justify-content: center;
+        padding: var(--ha-space-8) 0;
+      }
+      cloud-register-card {
+        text-align: start;
       }
     `,
   ];

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-cloud.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-cloud.ts
@@ -4,6 +4,7 @@ import type { HomeAssistant } from "../../types";
 import "./cloud/cloud-step-intro";
 import "./cloud/cloud-step-signin";
 import "./cloud/cloud-step-signup";
+import type { HASSDomEvent } from "../../common/dom/fire_event";
 import { fireEvent } from "../../common/dom/fire_event";
 import { STEP } from "./voice-assistant-setup-dialog";
 
@@ -12,6 +13,8 @@ export class HaVoiceAssistantSetupStepCloud extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @state() private _state: "SIGNUP" | "SIGNIN" | "INTRO" = "INTRO";
+
+  @state() private _email?: string;
 
   protected override render() {
     if (this._state === "SIGNUP") {
@@ -23,6 +26,7 @@ export class HaVoiceAssistantSetupStepCloud extends LitElement {
     if (this._state === "SIGNIN") {
       return html`<cloud-step-signin
         .hass=${this.hass}
+        .email=${this._email}
         @cloud-step=${this._cloudStep}
       ></cloud-step-signin>`;
     }
@@ -32,13 +36,17 @@ export class HaVoiceAssistantSetupStepCloud extends LitElement {
     ></cloud-step-intro>`;
   }
 
-  private _cloudStep(ev) {
+  private _cloudStep(ev: HASSDomEvent<HASSDomEvents["cloud-step"]>) {
     if (ev.detail.step === "DONE") {
       fireEvent(this, "next-step", {
         step: STEP.PIPELINE,
         noPrevious: true,
       });
       return;
+    }
+    // Carried between the steps so switching does not lose a typed address.
+    if (ev.detail.email !== undefined) {
+      this._email = ev.detail.email;
     }
     this._state = ev.detail.step;
   }
@@ -49,6 +57,6 @@ declare global {
     "ha-voice-assistant-setup-step-cloud": HaVoiceAssistantSetupStepCloud;
   }
   interface HASSDomEvents {
-    "cloud-step": { step: "SIGNUP" | "SIGNIN" | "DONE" };
+    "cloud-step": { step: "SIGNUP" | "SIGNIN" | "DONE"; email?: string };
   }
 }

--- a/src/panels/config/cloud/login/cloud-login-panel.ts
+++ b/src/panels/config/cloud/login/cloud-login-panel.ts
@@ -1,6 +1,7 @@
 import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators";
+import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { navigate } from "../../../../common/navigate";
 import "../../../../components/ha-alert";
@@ -71,11 +72,11 @@ export class CloudLoginPanel extends LitElement {
     cloudLogin.emailField?.focus();
   }
 
-  private _handleForgotPassword() {
+  private _handleForgotPassword(
+    ev: HASSDomEvent<HASSDomEvents["cloud-forgot-password"]>
+  ) {
     this._dismissFlash();
-    fireEvent(this, "cloud-email-changed", {
-      value: this._cloudLoginElement?.emailField?.value ?? this.email ?? "",
-    });
+    fireEvent(this, "cloud-email-changed", { value: ev.detail.email });
     navigate("/config/cloud/forgot-password");
   }
 

--- a/src/panels/config/cloud/login/cloud-login.ts
+++ b/src/panels/config/cloud/login/cloud-login.ts
@@ -226,6 +226,7 @@ export class CloudLogin extends LitElement {
       }
       this.email = "";
       fireEvent(this, "ha-refresh-cloud-status");
+      fireEvent(this, "cloud-logged-in");
     } catch (err: any) {
       const error = await this._handleCloudLoginError(
         err,
@@ -283,7 +284,9 @@ export class CloudLogin extends LitElement {
   }
 
   private _handleForgotPassword() {
-    fireEvent(this, "cloud-forgot-password");
+    fireEvent(this, "cloud-forgot-password", {
+      email: this.emailField?.value ?? this.email ?? "",
+    });
   }
 
   static get styles() {
@@ -325,5 +328,6 @@ declare global {
     "cloud-forgot-password": {
       email: string;
     };
+    "cloud-logged-in": undefined;
   }
 }

--- a/src/panels/config/cloud/register/cloud-register-card.ts
+++ b/src/panels/config/cloud/register/cloud-register-card.ts
@@ -1,0 +1,627 @@
+import { mdiEmailCheckOutline } from "@mdi/js";
+import type { PropertyValues, TemplateResult } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, query, state } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/buttons/ha-progress-button";
+import "../../../../components/ha-alert";
+import "../../../../components/ha-button";
+import "../../../../components/ha-card";
+import "../../../../components/ha-spinner";
+import "../../../../components/ha-svg-icon";
+import "../../../../components/input/ha-input";
+import type { HaInput } from "../../../../components/input/ha-input";
+import type { CloudAutoLogin } from "../../../../data/cloud";
+import {
+  attemptCloudAutoLoginNow,
+  cloudRegisterAutoLogin,
+  resendCloudAutoLoginConfirm,
+} from "../../../../data/cloud";
+import { haStyle } from "../../../../resources/styles";
+import type { HomeAssistant } from "../../../../types";
+import { showToast } from "../../../../util/toast";
+import { cloudSignedOutStyle } from "../cloud-signed-out-style";
+
+// Registration with email-confirmation auto login. Owns the whole flow so the
+// cloud panel page and the voice satellite wizard can present it in their own
+// chrome; hosts supply the pending registration, cancel it on the backend when
+// asked to, and route the way out.
+@customElement("cloud-register-card")
+export class CloudRegisterCard extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public email?: string;
+
+  @property({ attribute: false }) public autoLogin: CloudAutoLogin | null =
+    null;
+
+  @property({ type: Boolean, attribute: "card-less" }) public cardLess = false;
+
+  @state() private _requestInProgress = false;
+
+  @state() private _resendInProgress = false;
+
+  @state() private _attemptInProgress = false;
+
+  @state() private _autoLoginError?: string;
+
+  @state() private _error?: string;
+
+  @state() private _success?: string;
+
+  @state() private _registeredEmail = "";
+
+  @state() private _override?: "form" | "confirm";
+
+  private _failedKey: string | null = null;
+
+  private _confirmingReported?: boolean;
+
+  @query("#email") private _emailField?: HaInput;
+
+  @query("#password") private _passwordField?: HaInput;
+
+  @query("#confirm-title") private _confirmTitle?: HTMLElement;
+
+  private get _confirming(): boolean {
+    return this._override
+      ? this._override === "confirm"
+      : this.autoLogin !== null;
+  }
+
+  private get _pendingEmail(): string {
+    return this._registeredEmail || this.autoLogin?.email || "";
+  }
+
+  protected willUpdate(changedProps: PropertyValues) {
+    super.willUpdate(changedProps);
+
+    if (!changedProps.has("autoLogin")) {
+      return;
+    }
+
+    if (this._override === (this.autoLogin ? "confirm" : "form")) {
+      // The status caught up with the local action, so stop overriding it.
+      this._override = undefined;
+    }
+
+    const failedKey = this.autoLogin?.failed ?? null;
+    if (failedKey !== this._failedKey) {
+      this._failedKey = failedKey;
+      this._resolveAutoLoginError(failedKey);
+    }
+  }
+
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
+
+    const confirming = this._confirming;
+    if (confirming !== this._confirmingReported) {
+      this._confirmingReported = confirming;
+      fireEvent(this, "cloud-register-view-changed", { confirming });
+    }
+  }
+
+  protected render(): TemplateResult {
+    return this._confirming ? this._renderConfirm() : this._renderForm();
+  }
+
+  private _renderForm(): TemplateResult {
+    const title = this.hass.localize(
+      "ui.panel.config.cloud.register.create_account"
+    );
+    const content = html`
+      <div class="card-header-block">
+        ${this.cardLess ? html`<h1>${title}</h1>` : html`<h2>${title}</h2>`}
+        <p>
+          ${this.hass.localize("ui.panel.config.cloud.register.information")}
+        </p>
+      </div>
+      <div class="card-content register-form">
+        ${
+          this._error
+            ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
+            : nothing
+        }
+        <ha-input
+          autofocus
+          id="email"
+          name="email"
+          .label=${this.hass.localize(
+            "ui.panel.config.cloud.register.email_address"
+          )}
+          type="email"
+          autocomplete="email"
+          required
+          .value=${this.email ?? ""}
+          .disabled=${this._requestInProgress}
+          @keydown=${this._keyDown}
+          .validationMessage=${this.hass.localize(
+            "ui.panel.config.cloud.register.email_error_msg"
+          )}
+        ></ha-input>
+        <ha-input
+          id="password"
+          type="password"
+          password-toggle
+          name="password"
+          .label=${this.hass.localize(
+            "ui.panel.config.cloud.register.password"
+          )}
+          autocomplete="new-password"
+          minlength="8"
+          required
+          .disabled=${this._requestInProgress}
+          @keydown=${this._keyDown}
+          .validationMessage=${this.hass.localize(
+            "ui.panel.config.cloud.register.password_error_msg"
+          )}
+        ></ha-input>
+        <p class="terms">
+          ${this.hass.localize("ui.panel.config.cloud.register.terms_notice", {
+            terms: html`<a
+              href="https://www.nabucasa.com/tos/"
+              target="_blank"
+              rel="noreferrer"
+              >${this.hass.localize(
+                "ui.panel.config.cloud.register.link_terms_conditions"
+              )}</a
+            >`,
+            privacy_policy: html`<a
+              href="https://www.nabucasa.com/privacy_policy/"
+              target="_blank"
+              rel="noreferrer"
+              >${this.hass.localize(
+                "ui.panel.config.cloud.register.link_privacy_policy"
+              )}</a
+            >`,
+          })}
+        </p>
+      </div>
+      <div class="card-actions split">
+        <ha-button
+          appearance="plain"
+          .disabled=${this._requestInProgress}
+          @click=${this._handleSignInInstead}
+        >
+          ${this.hass.localize("ui.panel.config.cloud.register.sign_in_instead")}
+        </ha-button>
+        <ha-progress-button
+          @click=${this._handleRegister}
+          .progress=${this._requestInProgress}
+          >${this.hass.localize(
+            "ui.panel.config.cloud.register.start_trial"
+          )}</ha-progress-button
+        >
+      </div>
+    `;
+
+    return this.cardLess
+      ? content
+      : html`<ha-card outlined>${content}</ha-card>`;
+  }
+
+  private _renderConfirm(): TemplateResult {
+    const title = this.hass.localize(
+      "ui.panel.config.cloud.register.check_your_email"
+    );
+    const content = html`
+      <div class="card-content confirm">
+        ${
+          this._autoLoginError
+            ? html`<ha-alert alert-type="error">
+                ${this._autoLoginError}
+              </ha-alert>`
+            : nothing
+        }
+        ${
+          this._error
+            ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
+            : nothing
+        }
+        ${
+          this._success
+            ? html`<ha-alert alert-type="success">${this._success}</ha-alert>`
+            : nothing
+        }
+        <div class="confirm-icon">
+          <ha-svg-icon .path=${mdiEmailCheckOutline}></ha-svg-icon>
+        </div>
+        ${
+          this.cardLess
+            ? html`<h1 id="confirm-title" tabindex="-1">${title}</h1>`
+            : html`<h2 id="confirm-title" tabindex="-1">${title}</h2>`
+        }
+        <p>
+          ${this.hass.localize(
+            "ui.panel.config.cloud.register.confirm_email_body",
+            {
+              email: html`<span class="email">${this._pendingEmail}</span>`,
+            }
+          )}
+        </p>
+        ${
+          this._autoLoginError
+            ? nothing
+            : html`
+                <div class="waiting">
+                  <ha-spinner size="tiny"></ha-spinner>
+                  <span>
+                    ${this.hass.localize(
+                      "ui.panel.config.cloud.register.waiting_for_confirmation"
+                    )}
+                  </span>
+                </div>
+              `
+        }
+      </div>
+      <div class="card-actions split confirm-actions">
+        <ha-button appearance="plain" @click=${this._handleCancelPending}>
+          ${this.hass.localize("ui.common.cancel")}
+        </ha-button>
+        ${
+          this._autoLoginError
+            ? html`<ha-button
+                appearance="accent"
+                @click=${this._handleSignInInstead}
+              >
+                ${this.hass.localize("ui.panel.config.cloud.login.sign_in")}
+              </ha-button>`
+            : html`<ha-progress-button
+                @click=${this._handleAttemptNow}
+                .progress=${this._attemptInProgress}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.cloud.register.clicked_confirm"
+                )}
+              </ha-progress-button>`
+        }
+      </div>
+    `;
+
+    return html`
+      ${this.cardLess ? content : html`<ha-card outlined>${content}</ha-card>`}
+      ${
+        this._autoLoginError
+          ? nothing
+          : html`
+              <p class="footnote">
+                ${this.hass.localize(
+                  "ui.panel.config.cloud.register.nothing_arrived",
+                  {
+                    resend_link: html`<button
+                      class="link"
+                      .disabled=${this._resendInProgress}
+                      @click=${this._handleResendVerifyEmail}
+                    >
+                      ${this.hass.localize(
+                        "ui.panel.config.cloud.register.resend_link"
+                      )}
+                    </button>`,
+                  }
+                )}
+              </p>
+            `
+      }
+    `;
+  }
+
+  private _keyDown(ev: KeyboardEvent) {
+    if (ev.key === "Enter") {
+      this._handleRegister();
+    }
+  }
+
+  private _handleSignInInstead() {
+    const confirming = this._confirming;
+    const fieldValue = this._emailField?.value;
+    fireEvent(this, "cloud-email-changed", {
+      value:
+        fieldValue !== undefined
+          ? fieldValue
+          : this._pendingEmail || this.email || "",
+    });
+    if (confirming) {
+      this._dismiss();
+      fireEvent(this, "cloud-cancel-auto-login");
+    }
+    fireEvent(this, "cloud-sign-in-instead");
+  }
+
+  private _handleCancelPending() {
+    this._dismiss();
+    fireEvent(this, "cloud-cancel-auto-login");
+  }
+
+  private _dismiss() {
+    this._override = "form";
+    this._registeredEmail = "";
+    this._error = undefined;
+    this._success = undefined;
+    this._clearAutoLoginFailure();
+  }
+
+  private _clearAutoLoginFailure() {
+    this._failedKey = null;
+    this._autoLoginError = undefined;
+  }
+
+  private async _handleRegister() {
+    const emailField = this._emailField;
+    const passwordField = this._passwordField;
+
+    if (!emailField || !passwordField) {
+      return;
+    }
+
+    if (!emailField.reportValidity()) {
+      passwordField.reportValidity();
+      emailField.focus();
+      return;
+    }
+
+    if (!passwordField.reportValidity()) {
+      passwordField.focus();
+      return;
+    }
+
+    const email = emailField.value?.toLowerCase() || "";
+    const password = passwordField.value || "";
+
+    this._requestInProgress = true;
+    this._error = undefined;
+
+    try {
+      await cloudRegisterAutoLogin(this.hass, email, password);
+    } catch (err: any) {
+      this._requestInProgress = false;
+      passwordField.value = "";
+      this._error =
+        err?.body?.message || this.hass.localize("ui.common.unknown_error");
+      return;
+    }
+
+    this._registeredEmail = email;
+    this._requestInProgress = false;
+    this._override = "confirm";
+    this._clearAutoLoginFailure();
+    fireEvent(this, "cloud-email-changed", { value: email });
+    fireEvent(this, "cloud-auto-login-started");
+    fireEvent(this, "ha-refresh-cloud-status");
+    await this.updateComplete;
+    this._confirmTitle?.focus();
+  }
+
+  private async _localizeBackendMessage(
+    key: string,
+    domain = "cloud",
+    placeholders?: Record<string, string>
+  ): Promise<string | undefined> {
+    const localize = await this.hass.loadBackendTranslation(
+      "exceptions",
+      domain
+    );
+    return (
+      localize(`component.${domain}.exceptions.${key}.message`, placeholders) ||
+      undefined
+    );
+  }
+
+  private async _websocketErrorMessage(err: any): Promise<string> {
+    if (err?.translation_key) {
+      const message = await this._localizeBackendMessage(
+        err.translation_key,
+        err.translation_domain,
+        err.translation_placeholders
+      );
+      if (message) {
+        return message;
+      }
+    }
+    return err?.message || this.hass.localize("ui.common.unknown_error");
+  }
+
+  private async _resolveAutoLoginError(key: string | null) {
+    if (!key) {
+      this._autoLoginError = undefined;
+      return;
+    }
+
+    let reason: string | undefined;
+    try {
+      reason = await this._localizeBackendMessage(key);
+    } catch (_err) {
+      // The translation load rejects when the socket drops mid-round-trip. The
+      // generic reason still has to land: the status reports this failure once
+      // and nothing else would take the user off the waiting view.
+    }
+
+    if (this._failedKey !== key) {
+      // A newer status superseded this failure while the lookup was in flight.
+      return;
+    }
+
+    this._error = undefined;
+    this._success = undefined;
+    this._autoLoginError =
+      reason ||
+      this.hass.localize("ui.panel.config.cloud.register.auto_login_failed");
+  }
+
+  private async _handleAttemptNow() {
+    if (this._attemptInProgress) {
+      return;
+    }
+    this._attemptInProgress = true;
+
+    try {
+      await attemptCloudAutoLoginNow(this.hass);
+    } catch (err: any) {
+      showToast(this, { message: await this._websocketErrorMessage(err) });
+      return;
+    } finally {
+      this._attemptInProgress = false;
+    }
+
+    showToast(this, {
+      message: {
+        translationKey: "ui.panel.config.cloud.register.checking_confirmation",
+      },
+    });
+  }
+
+  private async _handleResendVerifyEmail() {
+    if (this._resendInProgress) {
+      return;
+    }
+
+    this._error = undefined;
+    this._success = undefined;
+    this._resendInProgress = true;
+
+    try {
+      await resendCloudAutoLoginConfirm(this.hass);
+      this._success = this.hass.localize(
+        "ui.panel.config.cloud.register.verification_email_sent"
+      );
+    } catch (err: any) {
+      this._error = await this._websocketErrorMessage(err);
+    } finally {
+      this._resendInProgress = false;
+    }
+  }
+
+  static get styles() {
+    return [
+      haStyle,
+      cloudSignedOutStyle,
+      css`
+        :host {
+          display: block;
+        }
+        :host([card-less]) .card-header-block,
+        :host([card-less]) .confirm {
+          padding-inline: 0;
+        }
+        :host([card-less]) .card-header-block h1 {
+          margin: 0;
+          text-align: center;
+        }
+        :host([card-less]) .confirm h1 {
+          margin: 0;
+        }
+
+        .card-header-block {
+          padding: var(--ha-space-4) var(--ha-space-4) 0;
+        }
+        .card-header-block p {
+          margin: var(--ha-space-2) 0 0;
+          color: var(--secondary-text-color);
+          line-height: var(--ha-line-height-normal);
+        }
+
+        .register-form {
+          display: flex;
+          flex-direction: column;
+        }
+        .terms {
+          margin: var(--ha-space-2) 0 0;
+          font-size: var(--ha-font-size-s);
+          color: var(--secondary-text-color);
+          line-height: var(--ha-line-height-normal);
+        }
+        .terms a,
+        .footnote a,
+        .footnote button.link {
+          color: var(--primary-color);
+        }
+
+        .card-actions.split {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+        .card-actions.confirm-actions {
+          border-top: none;
+        }
+
+        .confirm {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+          gap: var(--ha-space-3);
+          padding: var(--ha-space-8) var(--ha-space-4) var(--ha-space-5);
+        }
+        .confirm ha-alert {
+          width: 100%;
+          text-align: initial;
+        }
+        .confirm-icon {
+          width: 56px;
+          height: 56px;
+          border-radius: var(--ha-border-radius-pill);
+          background: color-mix(in srgb, var(--info-color) 18%, transparent);
+          color: var(--info-color);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          --mdc-icon-size: 28px;
+        }
+        /* Focused programmatically to announce the view; no visible ring. */
+        #confirm-title:focus {
+          outline: none;
+        }
+        .confirm p {
+          margin: 0;
+          max-width: 420px;
+          color: var(--secondary-text-color);
+          line-height: var(--ha-line-height-normal);
+        }
+        .confirm .email {
+          display: inline-block;
+          max-width: 100%;
+          overflow-wrap: anywhere;
+        }
+        .waiting {
+          display: flex;
+          align-items: center;
+          gap: var(--ha-space-2);
+          font-size: var(--ha-font-size-s);
+          color: var(--secondary-text-color);
+        }
+
+        .footnote {
+          display: block;
+          width: 100%;
+          margin: var(--ha-space-3) auto 0;
+          font-size: var(--ha-font-size-s);
+          color: var(--secondary-text-color);
+          text-align: center;
+          text-wrap: pretty;
+        }
+
+        @media (max-width: 500px) {
+          .card-actions.split {
+            flex-direction: column;
+            align-items: stretch;
+            gap: var(--ha-space-2);
+          }
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "cloud-register-card": CloudRegisterCard;
+  }
+
+  interface HASSDomEvents {
+    "cloud-cancel-auto-login": undefined;
+    "cloud-auto-login-started": undefined;
+    "cloud-register-view-changed": { confirming: boolean };
+    "cloud-sign-in-instead": undefined;
+  }
+}

--- a/src/panels/config/cloud/register/cloud-register.ts
+++ b/src/panels/config/cloud/register/cloud-register.ts
@@ -1,32 +1,18 @@
-import { mdiEmailCheckOutline } from "@mdi/js";
-import type { UnsubscribeFunc } from "home-assistant-js-websocket";
-import type { PropertyValues, TemplateResult } from "lit";
-import { css, html, LitElement, nothing } from "lit";
-import { customElement, property, query, state } from "lit/decorators";
+import type { TemplateResult } from "lit";
+import { css, html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { navigate } from "../../../../common/navigate";
-import "../../../../components/buttons/ha-progress-button";
-import "../../../../components/ha-alert";
-import "../../../../components/ha-button";
-import "../../../../components/ha-card";
-import "../../../../components/ha-spinner";
-import "../../../../components/ha-svg-icon";
-import "../../../../components/input/ha-input";
-import type { HaInput } from "../../../../components/input/ha-input";
-import type { CloudAutoLogin, CloudStatus } from "../../../../data/cloud";
-import {
-  attemptCloudAutoLoginNow,
-  cloudRegisterAutoLogin,
-  resendCloudAutoLoginConfirm,
-  subscribeCloudEvents,
-} from "../../../../data/cloud";
+import type { CloudStatus } from "../../../../data/cloud";
+import { cloudStatusAutoLogin } from "../../../../data/cloud";
 import "../../../../layouts/hass-subpage";
 import { haStyle } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
-import { showToast } from "../../../../util/toast";
 import "../cloud-signed-out-menu";
 import { cloudSignedOutStyle } from "../cloud-signed-out-style";
 import { cloudSubpageStyle } from "../account/cloud-subpage-style";
+import "./cloud-register-card";
 
 const BACK_PATH = "/config/cloud/start";
 
@@ -40,76 +26,15 @@ export class CloudRegister extends LitElement {
 
   @property({ attribute: false }) public cloudStatus?: CloudStatus;
 
-  @state() private _view: "form" | "confirm" = "form";
-
-  @state() private _requestInProgress = false;
-
-  @state() private _resendInProgress = false;
-
-  @state() private _autoLoginError?: string;
-
-  @state() private _error?: string;
-
-  @state() private _success?: string;
-
-  @state() private _registeredEmail = "";
-
-  private _unsubCloudEvents?: Promise<UnsubscribeFunc>;
-
-  @query("#email") private _emailField?: HaInput;
-
-  @query("#password") private _passwordField?: HaInput;
-
-  @query("#confirm-title") private _confirmTitle?: HTMLElement;
-
-  private get _autoLogin(): CloudAutoLogin | null {
-    const status = this.cloudStatus;
-    if (!status || status.logged_in) {
-      return null;
-    }
-    return status.auto_login ?? null;
-  }
-
-  private get _pendingEmail(): string {
-    return this._registeredEmail || this._autoLogin?.email || "";
-  }
-
-  public connectedCallback(): void {
-    super.connectedCallback();
-    if (this._autoLogin) {
-      this._view = "confirm";
-    }
-  }
-
-  public disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this._stopWatchingAutoLogin();
-  }
-
-  protected updated(changedProps: PropertyValues) {
-    super.updated(changedProps);
-
-    if (this._view !== "confirm") {
-      return;
-    }
-
-    const failedKey = this._autoLogin?.failed;
-    if (failedKey && !this._autoLoginError) {
-      this._failAutoLogin(failedKey);
-      return;
-    }
-
-    this._watchAutoLogin();
-  }
+  @state() private _confirming = false;
 
   protected render(): TemplateResult {
-    const confirming = this._view === "confirm";
     return html`
       <hass-subpage
         .hass=${this.hass}
         .narrow=${this.narrow}
         back-path=${BACK_PATH}
-        .backCallback=${confirming ? this._handleConfirmBack : undefined}
+        .backCallback=${this._confirming ? this._handleConfirmBack : undefined}
         .header=${this.hass.localize("ui.panel.config.cloud.register.headline")}
       >
         <cloud-signed-out-menu
@@ -117,405 +42,35 @@ export class CloudRegister extends LitElement {
           .hass=${this.hass}
         ></cloud-signed-out-menu>
         <div class="content">
-          ${confirming ? this._renderConfirm() : this._renderForm()}
+          <cloud-register-card
+            .hass=${this.hass}
+            .email=${this.email}
+            .autoLogin=${cloudStatusAutoLogin(this.cloudStatus)}
+            @cloud-register-view-changed=${this._viewChanged}
+            @cloud-sign-in-instead=${this._handleSignInInstead}
+          ></cloud-register-card>
         </div>
       </hass-subpage>
     `;
   }
 
-  private _renderForm(): TemplateResult {
-    return html`
-      <ha-card outlined>
-        <div class="card-header-block">
-          <h2>
-            ${this.hass.localize(
-              "ui.panel.config.cloud.register.create_account"
-            )}
-          </h2>
-          <p>
-            ${this.hass.localize("ui.panel.config.cloud.register.information")}
-          </p>
-        </div>
-        <div class="card-content register-form">
-          ${
-            this._error
-              ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
-              : nothing
-          }
-          <ha-input
-            autofocus
-            id="email"
-            name="email"
-            .label=${this.hass.localize(
-              "ui.panel.config.cloud.register.email_address"
-            )}
-            type="email"
-            autocomplete="email"
-            required
-            .value=${this.email ?? ""}
-            .disabled=${this._requestInProgress}
-            @keydown=${this._keyDown}
-            .validationMessage=${this.hass.localize(
-              "ui.panel.config.cloud.register.email_error_msg"
-            )}
-          ></ha-input>
-          <ha-input
-            id="password"
-            type="password"
-            password-toggle
-            name="password"
-            .label=${this.hass.localize(
-              "ui.panel.config.cloud.register.password"
-            )}
-            autocomplete="new-password"
-            minlength="8"
-            required
-            .disabled=${this._requestInProgress}
-            @keydown=${this._keyDown}
-            .validationMessage=${this.hass.localize(
-              "ui.panel.config.cloud.register.password_error_msg"
-            )}
-          ></ha-input>
-          <p class="terms">
-            ${this.hass.localize(
-              "ui.panel.config.cloud.register.terms_notice",
-              {
-                terms: html`<a
-                  href="https://www.nabucasa.com/tos/"
-                  target="_blank"
-                  rel="noreferrer"
-                  >${this.hass.localize(
-                    "ui.panel.config.cloud.register.link_terms_conditions"
-                  )}</a
-                >`,
-                privacy_policy: html`<a
-                  href="https://www.nabucasa.com/privacy_policy/"
-                  target="_blank"
-                  rel="noreferrer"
-                  >${this.hass.localize(
-                    "ui.panel.config.cloud.register.link_privacy_policy"
-                  )}</a
-                >`,
-              }
-            )}
-          </p>
-        </div>
-        <div class="card-actions split">
-          <ha-button
-            appearance="plain"
-            .disabled=${this._requestInProgress}
-            @click=${this._handleSignInInstead}
-          >
-            ${this.hass.localize(
-              "ui.panel.config.cloud.register.sign_in_instead"
-            )}
-          </ha-button>
-          <ha-progress-button
-            @click=${this._handleRegister}
-            .progress=${this._requestInProgress}
-            >${this.hass.localize(
-              "ui.panel.config.cloud.register.start_trial"
-            )}</ha-progress-button
-          >
-        </div>
-      </ha-card>
-    `;
-  }
-
-  private _renderConfirm(): TemplateResult {
-    return html`
-      <ha-card outlined>
-        <div class="card-content confirm">
-          ${
-            this._autoLoginError
-              ? html`<ha-alert alert-type="error">
-                  ${this._autoLoginError}
-                </ha-alert>`
-              : nothing
-          }
-          ${
-            this._error
-              ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
-              : nothing
-          }
-          ${
-            this._success
-              ? html`<ha-alert alert-type="success">${this._success}</ha-alert>`
-              : nothing
-          }
-          <div class="confirm-icon">
-            <ha-svg-icon .path=${mdiEmailCheckOutline}></ha-svg-icon>
-          </div>
-          <h2 id="confirm-title" tabindex="-1">
-            ${this.hass.localize(
-              "ui.panel.config.cloud.register.check_your_email"
-            )}
-          </h2>
-          <p>
-            ${this.hass.localize(
-              "ui.panel.config.cloud.register.confirm_email_body",
-              {
-                email: html`<span class="email">${this._pendingEmail}</span>`,
-              }
-            )}
-          </p>
-          ${
-            this._autoLoginError
-              ? nothing
-              : html`
-                  <div class="waiting">
-                    <ha-spinner size="tiny"></ha-spinner>
-                    <span>
-                      ${this.hass.localize(
-                        "ui.panel.config.cloud.register.waiting_for_confirmation"
-                      )}
-                    </span>
-                  </div>
-                `
-          }
-        </div>
-        <div class="card-actions split confirm-actions">
-          <ha-button appearance="plain" @click=${this._handleCancelPending}>
-            ${this.hass.localize("ui.common.cancel")}
-          </ha-button>
-          ${
-            this._autoLoginError
-              ? html`<ha-button
-                  appearance="accent"
-                  @click=${this._handleSignInInstead}
-                >
-                  ${this.hass.localize("ui.panel.config.cloud.login.sign_in")}
-                </ha-button>`
-              : html`<ha-button
-                  appearance="accent"
-                  @click=${this._handleAttemptNow}
-                >
-                  ${this.hass.localize(
-                    "ui.panel.config.cloud.register.clicked_confirm"
-                  )}
-                </ha-button>`
-          }
-        </div>
-      </ha-card>
-      ${
-        this._autoLoginError
-          ? nothing
-          : html`
-              <p class="footnote">
-                ${this.hass.localize(
-                  "ui.panel.config.cloud.register.nothing_arrived",
-                  {
-                    resend_link: html`<button
-                      class="link"
-                      .disabled=${this._resendInProgress}
-                      @click=${this._handleResendVerifyEmail}
-                    >
-                      ${this.hass.localize(
-                        "ui.panel.config.cloud.register.resend_link"
-                      )}
-                    </button>`,
-                  }
-                )}
-              </p>
-            `
-      }
-    `;
-  }
-
-  private _keyDown(ev: KeyboardEvent) {
-    if (ev.key === "Enter") {
-      this._handleRegister();
-    }
+  private _viewChanged(
+    ev: HASSDomEvent<HASSDomEvents["cloud-register-view-changed"]>
+  ) {
+    this._confirming = ev.detail.confirming;
   }
 
   private _handleSignInInstead() {
-    const confirming = this._view === "confirm";
-    fireEvent(this, "cloud-email-changed", {
-      // The field wins on the form: it holds whatever was typed after a cancel.
-      value: this._emailField?.value || this._pendingEmail || this.email || "",
-    });
-    this._stopWatchingAutoLogin();
-    if (confirming) {
-      fireEvent(this, "cloud-cancel-auto-login");
-    }
     // Replaces only from the waiting view, whose registration is being
     // cancelled: browser-back must not return to it. The form is a page worth
     // going back to.
-    navigate("/config/cloud/login", { replace: confirming });
+    navigate("/config/cloud/login", { replace: this._confirming });
   }
 
   private _handleConfirmBack = () => {
-    this._stopWatchingAutoLogin();
     fireEvent(this, "cloud-cancel-auto-login");
     navigate(BACK_PATH, { replace: true });
   };
-
-  private _handleCancelPending() {
-    this._resetToForm();
-    fireEvent(this, "cloud-cancel-auto-login");
-  }
-
-  private _resetToForm() {
-    this._stopWatchingAutoLogin();
-    this._view = "form";
-    this._autoLoginError = undefined;
-    this._registeredEmail = "";
-    this._error = undefined;
-    this._success = undefined;
-  }
-
-  private async _handleRegister() {
-    const emailField = this._emailField;
-    const passwordField = this._passwordField;
-
-    if (!emailField || !passwordField) {
-      return;
-    }
-
-    if (!emailField.reportValidity()) {
-      passwordField.reportValidity();
-      emailField.focus();
-      return;
-    }
-
-    if (!passwordField.reportValidity()) {
-      passwordField.focus();
-      return;
-    }
-
-    const email = emailField.value?.toLowerCase() || "";
-    const password = passwordField.value || "";
-
-    this._requestInProgress = true;
-    this._error = undefined;
-
-    try {
-      await cloudRegisterAutoLogin(this.hass, email, password);
-    } catch (err: any) {
-      this._requestInProgress = false;
-      passwordField.value = "";
-      this._error =
-        err?.body?.message || this.hass.localize("ui.common.unknown_error");
-      return;
-    }
-
-    this._registeredEmail = email;
-    this._requestInProgress = false;
-    this._view = "confirm";
-    this._autoLoginError = undefined;
-    fireEvent(this, "cloud-email-changed", { value: email });
-    fireEvent(this, "cloud-auto-login-started");
-    fireEvent(this, "ha-refresh-cloud-status");
-    this._watchAutoLogin();
-    await this.updateComplete;
-    this._confirmTitle?.focus();
-  }
-
-  private _watchAutoLogin() {
-    if (this._unsubCloudEvents || this._autoLoginError) {
-      return;
-    }
-
-    const subscription = subscribeCloudEvents(this.hass, (event) => {
-      if (event.type === "login") {
-        fireEvent(this, "ha-refresh-cloud-status");
-      } else if (event.type === "auto_login_failed") {
-        this._failAutoLogin(event.translation_key);
-      } else if (event.type === "auto_login_cancelled") {
-        this._resetToForm();
-        fireEvent(this, "ha-refresh-cloud-status");
-      }
-    });
-    this._unsubCloudEvents = subscription;
-
-    subscription.catch(() => {
-      if (this._unsubCloudEvents === subscription) {
-        this._unsubCloudEvents = undefined;
-      }
-    });
-  }
-
-  private async _localizeBackendMessage(
-    key: string,
-    domain = "cloud"
-  ): Promise<string | undefined> {
-    const localize = await this.hass.loadBackendTranslation(
-      "exceptions",
-      domain
-    );
-    return (
-      localize(`component.${domain}.exceptions.${key}.message`) || undefined
-    );
-  }
-
-  private async _websocketErrorMessage(err: any): Promise<string> {
-    if (err?.translation_key) {
-      const message = await this._localizeBackendMessage(
-        err.translation_key,
-        err.translation_domain
-      );
-      if (message) {
-        return message;
-      }
-    }
-    return err?.message || this.hass.localize("ui.common.unknown_error");
-  }
-
-  private async _failAutoLogin(translationKey?: string | null) {
-    this._stopWatchingAutoLogin();
-    const reason = translationKey
-      ? await this._localizeBackendMessage(translationKey)
-      : undefined;
-    this._error = undefined;
-    this._success = undefined;
-    this._autoLoginError =
-      reason ||
-      this.hass.localize("ui.panel.config.cloud.register.auto_login_failed");
-    fireEvent(this, "ha-refresh-cloud-status");
-  }
-
-  private _stopWatchingAutoLogin() {
-    this._unsubCloudEvents?.then((unsub) => unsub()).catch(() => undefined);
-    this._unsubCloudEvents = undefined;
-  }
-
-  private async _handleAttemptNow() {
-    this._watchAutoLogin();
-
-    try {
-      await attemptCloudAutoLoginNow(this.hass);
-    } catch (err: any) {
-      showToast(this, { message: await this._websocketErrorMessage(err) });
-      return;
-    }
-
-    showToast(this, {
-      message: {
-        translationKey: "ui.panel.config.cloud.register.checking_confirmation",
-      },
-    });
-  }
-
-  private async _handleResendVerifyEmail() {
-    if (this._resendInProgress) {
-      return;
-    }
-
-    this._error = undefined;
-    this._success = undefined;
-    this._resendInProgress = true;
-
-    try {
-      await resendCloudAutoLoginConfirm(this.hass);
-      this._success = this.hass.localize(
-        "ui.panel.config.cloud.register.verification_email_sent"
-      );
-    } catch (err: any) {
-      this._error = await this._websocketErrorMessage(err);
-    } finally {
-      this._resendInProgress = false;
-    }
-  }
 
   static get styles() {
     return [
@@ -526,106 +81,10 @@ export class CloudRegister extends LitElement {
         .content {
           gap: var(--ha-space-3);
         }
-
-        .card-header-block {
-          padding: var(--ha-space-4) var(--ha-space-4) 0;
-        }
-        .card-header-block p {
-          margin: var(--ha-space-2) 0 0;
-          color: var(--secondary-text-color);
-          line-height: var(--ha-line-height-normal);
-        }
-
-        .register-form {
-          display: flex;
-          flex-direction: column;
-        }
-        .terms {
-          margin: var(--ha-space-2) 0 0;
-          font-size: var(--ha-font-size-s);
-          color: var(--secondary-text-color);
-          line-height: var(--ha-line-height-normal);
-        }
-        .terms a,
-        .footnote a,
-        .footnote button.link {
-          color: var(--primary-color);
-        }
-
-        .card-actions.split {
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-        }
-        .card-actions.confirm-actions {
-          border-top: none;
-        }
-
-        .confirm {
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          text-align: center;
-          gap: var(--ha-space-3);
-          padding: var(--ha-space-8) var(--ha-space-4) var(--ha-space-5);
-        }
-        .confirm ha-alert {
-          width: 100%;
-          text-align: initial;
-        }
-        .confirm-icon {
-          width: 56px;
-          height: 56px;
-          border-radius: var(--ha-border-radius-pill);
-          background: color-mix(in srgb, var(--info-color) 18%, transparent);
-          color: var(--info-color);
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          --mdc-icon-size: 28px;
-        }
-        /* Focused programmatically to announce the view; no visible ring. */
-        #confirm-title:focus {
-          outline: none;
-        }
-        .confirm p {
-          margin: 0;
-          max-width: 420px;
-          color: var(--secondary-text-color);
-          line-height: var(--ha-line-height-normal);
-        }
-        .confirm .email {
-          display: inline-block;
-          max-width: 100%;
-          overflow-wrap: anywhere;
-        }
-        .waiting {
-          display: flex;
-          align-items: center;
-          gap: var(--ha-space-2);
-          font-size: var(--ha-font-size-s);
-          color: var(--secondary-text-color);
-        }
-
-        .footnote {
-          display: block;
+        cloud-register-card {
           width: 100%;
           max-width: 600px;
-          margin: 0 auto;
-          font-size: var(--ha-font-size-s);
-          color: var(--secondary-text-color);
-          text-align: center;
-          text-wrap: pretty;
-        }
-
-        /* Not column-reverse: that paints the buttons against DOM order, so
-           keyboard and screen-reader users reach them back to front. */
-        @media (max-width: 500px) {
-          .card-actions.split {
-            flex-direction: column;
-            align-items: stretch;
-            gap: var(--ha-space-2);
-          }
+          margin-inline: auto;
         }
       `,
     ];
@@ -635,10 +94,5 @@ export class CloudRegister extends LitElement {
 declare global {
   interface HTMLElementTagNameMap {
     "cloud-register": CloudRegister;
-  }
-
-  interface HASSDomEvents {
-    "cloud-cancel-auto-login": undefined;
-    "cloud-auto-login-started": undefined;
   }
 }

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -2,6 +2,7 @@ import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
+import type { HASSDomEvent } from "../../common/dom/fire_event";
 import { listenMediaQuery } from "../../common/dom/media_query";
 import type { CloudStatus } from "../../data/cloud";
 import { fetchCloudStatus, subscribeCloudEvents } from "../../data/cloud";
@@ -17,6 +18,12 @@ declare global {
   // for fire event
   interface HASSDomEvents {
     "ha-refresh-cloud-status": undefined;
+  }
+
+  interface GlobalEventHandlersEventMap {
+    "ha-refresh-cloud-status": HASSDomEvent<
+      HASSDomEvents["ha-refresh-cloud-status"]
+    >;
   }
 }
 
@@ -273,7 +280,19 @@ class HaPanelConfig extends HassRouterPage {
         this._wideSidebar = matches;
       })
     );
-    if (this.hass && isComponentLoaded(this.hass.config, "cloud")) {
+    this._listenOnWindow("ha-refresh-cloud-status", () => {
+      if (this._cloudLoaded()) {
+        this._updateCloudStatus();
+      }
+    });
+    this._listenOnWindow("connection-status", (ev) => {
+      if (ev.detail === "connected" && this._cloudLoaded()) {
+        this._updateCloudStatus();
+        this._subscribeCloudEvents();
+      }
+    });
+
+    if (this._cloudLoaded()) {
       this._subscribeCloudEvents();
       this._updateCloudStatus();
     }
@@ -290,12 +309,20 @@ class HaPanelConfig extends HassRouterPage {
     entityRegistryById.clear();
   }
 
+  private _cloudLoaded(): boolean {
+    return !!this.hass && isComponentLoaded(this.hass.config, "cloud");
+  }
+
+  private _listenOnWindow<EventName extends keyof GlobalEventHandlersEventMap>(
+    type: EventName,
+    listener: (ev: GlobalEventHandlersEventMap[EventName]) => void
+  ) {
+    window.addEventListener(type, listener);
+    this._listeners.push(() => window.removeEventListener(type, listener));
+  }
+
   private _subscribeCloudEvents() {
-    if (
-      this._unsubCloudEvents ||
-      !this.hass ||
-      !isComponentLoaded(this.hass.config, "cloud")
-    ) {
+    if (this._unsubCloudEvents || !this._cloudLoaded()) {
       return;
     }
 
@@ -315,18 +342,6 @@ class HaPanelConfig extends HassRouterPage {
     super.firstUpdated(changedProps);
     this.hass.loadBackendTranslation("title");
     this.hass.loadBackendTranslation("services");
-    if (isComponentLoaded(this.hass.config, "cloud")) {
-      this.addEventListener("connection-status", (ev) => {
-        if (ev.detail === "connected") {
-          this._updateCloudStatus();
-          this._subscribeCloudEvents();
-        }
-      });
-    }
-
-    this.addEventListener("ha-refresh-cloud-status", () =>
-      this._updateCloudStatus()
-    );
     this.style.setProperty(
       "--app-header-background-color",
       "var(--sidebar-background-color)"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5058,10 +5058,7 @@
               }
             },
             "cloud": {
-              "title": "The power of Home Assistant Cloud",
-              "register": {
-                "confirm_email": "Confirm email"
-              }
+              "title": "The power of Home Assistant Cloud"
             },
             "local": {
               "title": "Installing apps",
@@ -6501,9 +6498,7 @@
             "auto_login_failed": "We couldn't sign you in automatically. Confirm your email, then sign in.",
             "nothing_arrived": "Nothing arrived? Check your spam folder, or {resend_link}.",
             "resend_link": "resend the confirmation email",
-            "resend_confirm_email": "Resend confirmation email",
             "clicked_confirm": "I opened the confirmation link",
-            "confirm_email": "Check the email we just sent to {email} and open the confirmation link to continue.",
             "verification_email_sent": "Verification email sent. Check your inbox for instructions on how to activate your account."
           },
           "account": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Further improvements on the cloud register/auto-login, which is landing in 2026.9:
* Replaces the assist pipeline's wizard's own registration and sign-in screens with the cloud panel's, extracted into cloud-register-card, so signing up mid-wizard gets email-confirmation auto login instead of the legacy register plus login polling. The wizard's copy of the login error ladder goes with it.
* Drives the registration state from cloud/status rather than from the cloud events, which carry nothing it does not already hold. The waiting view now clears when the pending registration does, so a restart no longer leaves it spinning on a registration the backend has forgotten.
* Removes unused calls to HA core.

This PR depends on the auto-login state fix in home-assistant/core#180423.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Assist setup flow with the cloud register/auto-login:

https://github.com/user-attachments/assets/2bbeb3ef-14b1-41da-81b7-1ffc82a10be8

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
