### PR TITLE
Avoid tracking empty ha-input start slots

### DIFF
--- a/src/components/input/ha-input.ts
+++ b/src/components/input/ha-input.ts
@@ -127,6 +127,9 @@ export class HaInput extends WaInputMixin(LitElement) {
   @query("wa-input")
   private _input?: WaInput;
 
+  @query("slot[name='start']")
+  private _startSlot!: HTMLSlotElement;
+
   private _startSlotResizeObserver?: ResizeObserver;
 
   @state()
@@ -165,17 +168,32 @@ export class HaInput extends WaInputMixin(LitElement) {
   ): Promise<void> {
     super.firstUpdated(changedProperties);
 
-    if (!this.insetLabel) {
-      // Wait for wa-input to finish its first render
-      await this._input?.updateComplete;
-      this._syncStartSlotWidth();
-      this._observeStartSlot();
+    await this._updateStartSlot();
+  }
+
+  protected override updated(changedProperties: PropertyValues<this>): void {
+    super.updated(changedProperties);
+
+    if (
+      changedProperties.has("insetLabel") &&
+      changedProperties.get("insetLabel") !== undefined
+    ) {
+      void this._updateStartSlot();
+    }
+  }
+
+  public override connectedCallback(): void {
+    super.connectedCallback();
+
+    // Restore tracking only after the start slot has been rendered.
+    if (this.hasUpdated) {
+      void this._updateStartSlot();
     }
   }
 
   public override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this._startSlotResizeObserver?.disconnect();
+    this._unobserveStartSlot();
   }
 
   protected render() {
@@ -247,7 +265,7 @@ export class HaInput extends WaInputMixin(LitElement) {
               >`
             : nothing
         }
-        <slot name="start" slot="start" @slotchange=${this._syncStartSlotWidth}>
+        <slot name="start" slot="start" @slotchange=${this._startSlotChanged}>
           ${this.renderStartDefault()}
         </slot>
         <slot name="end" slot="end"> ${this.renderEndDefault()} </slot>
@@ -299,6 +317,53 @@ export class HaInput extends WaInputMixin(LitElement) {
     return nothing;
   }
 
+  private _startSlotChanged = (): void => {
+    void this._updateStartSlot();
+  };
+
+  private _hasStartContent(): boolean {
+    // Flattened assigned nodes include fallback content, such as
+    // ha-input-search's default icon.
+    return this._startSlot
+      .assignedNodes({ flatten: true })
+      .some(
+        (node) =>
+          node.nodeType === Node.ELEMENT_NODE ||
+          (node.nodeType === Node.TEXT_NODE &&
+            (node as Text).textContent?.trim() !== "")
+      );
+  }
+
+  private _shouldTrackStartSlot(): boolean {
+    return this.isConnected && !this.insetLabel && this._hasStartContent();
+  }
+
+  private async _updateStartSlot(): Promise<void> {
+    if (this._shouldTrackStartSlot()) {
+      // Wait for wa-input to finish rendering its internal start wrapper.
+      await this._input?.updateComplete;
+    }
+
+    if (!this._shouldTrackStartSlot()) {
+      this._unobserveStartSlot();
+      this._clearStartSlotWidth();
+      return;
+    }
+
+    this._syncStartSlotWidth();
+    this._observeStartSlot();
+  }
+
+  private _unobserveStartSlot(): void {
+    this._startSlotResizeObserver?.disconnect();
+    this._startSlotResizeObserver = undefined;
+  }
+
+  private _clearStartSlotWidth(): void {
+    this.style.removeProperty("--start-slot-width");
+    this.style.removeProperty("--input-padding-inline-start");
+  }
+
   // Safari can report the start-slot width as 0 during the first render, which
   // leaves the floating label overlapping the start icon (e.g. the magnify icon
   // in ha-input-search). Re-sync whenever the wrapper's size changes
@@ -333,8 +398,7 @@ export class HaInput extends WaInputMixin(LitElement) {
         `var(--ha-space-1)`
       );
     } else {
-      this.style.removeProperty("--start-slot-width");
-      this.style.removeProperty("--input-padding-inline-start");
+      this._clearStartSlotWidth();
     }
   };
 

--- a/test/components/input/ha-input.test.ts
+++ b/test/components/input/ha-input.test.ts
@@ -1,0 +1,203 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import "../../../src/components/input/ha-input";
+import "../../../src/components/input/ha-input-search";
+import type { HaInput } from "../../../src/components/input/ha-input";
+
+const activeResizeObservers = new Set<TrackingResizeObserver>();
+
+const internalsProto = window.ElementInternals.prototype;
+const originalSetValidity = Object.getOwnPropertyDescriptor(
+  internalsProto,
+  "setValidity"
+);
+const originalSetFormValue = Object.getOwnPropertyDescriptor(
+  internalsProto,
+  "setFormValue"
+);
+const originalValidity = Object.getOwnPropertyDescriptor(
+  internalsProto,
+  "validity"
+);
+
+const restoreProperty = (
+  property: "setValidity" | "setFormValue" | "validity",
+  descriptor: PropertyDescriptor | undefined
+): void => {
+  if (descriptor) {
+    Object.defineProperty(internalsProto, property, descriptor);
+  } else {
+    delete (internalsProto as unknown as Record<string, unknown>)[property];
+  }
+};
+
+beforeAll(() => {
+  Object.defineProperty(internalsProto, "setValidity", {
+    value: vi.fn(),
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(internalsProto, "setFormValue", {
+    value: vi.fn(),
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(internalsProto, "validity", {
+    get: () => ({ valid: true }),
+    configurable: true,
+  });
+});
+
+afterAll(() => {
+  restoreProperty("setValidity", originalSetValidity);
+  restoreProperty("setFormValue", originalSetFormValue);
+  restoreProperty("validity", originalValidity);
+});
+
+class TrackingResizeObserver {
+  private readonly _targets = new Set<Element>();
+
+  public observe(target: Element): void {
+    this._targets.add(target);
+    activeResizeObservers.add(this);
+  }
+
+  public unobserve(target: Element): void {
+    this._targets.delete(target);
+
+    if (this._targets.size === 0) {
+      activeResizeObservers.delete(this);
+    }
+  }
+
+  public disconnect(): void {
+    this._targets.clear();
+    activeResizeObservers.delete(this);
+  }
+}
+
+describe("ha-input start slot tracking", () => {
+  let inputs: HaInput[] = [];
+
+  const mountInput = async (
+    tag: "ha-input" | "ha-input-search" = "ha-input",
+    setup?: (input: HaInput) => void
+  ): Promise<HaInput> => {
+    const input = document.createElement(tag) as HaInput;
+    setup?.(input);
+    document.body.append(input);
+    inputs.push(input);
+    await input.updateComplete;
+    return input;
+  };
+
+  const createStartContent = (text = "start"): HTMLElement => {
+    const content = document.createElement("span");
+    content.slot = "start";
+    content.textContent = text;
+    return content;
+  };
+
+  const expectActiveObservers = async (count: number): Promise<void> => {
+    await vi.waitFor(() => {
+      expect(activeResizeObservers.size).toBe(count);
+    });
+  };
+
+  beforeEach(() => {
+    activeResizeObservers.clear();
+    vi.stubGlobal("ResizeObserver", TrackingResizeObserver);
+  });
+
+  afterEach(async () => {
+    inputs.forEach((input) => input.remove());
+    inputs = [];
+
+    await expectActiveObservers(0);
+
+    activeResizeObservers.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not observe an empty start slot", async () => {
+    await mountInput();
+
+    await expectActiveObservers(0);
+  });
+
+  it("observes fallback start content", async () => {
+    await mountInput("ha-input-search");
+
+    await expectActiveObservers(1);
+  });
+
+  it("starts and stops tracking when start content changes", async () => {
+    const input = await mountInput();
+    const content = createStartContent();
+
+    input.append(content);
+    await expectActiveObservers(1);
+
+    content.remove();
+    await expectActiveObservers(0);
+  });
+
+  it("stops and resumes tracking when insetLabel changes", async () => {
+    const input = await mountInput("ha-input-search");
+
+    await expectActiveObservers(1);
+
+    input.insetLabel = true;
+    await input.updateComplete;
+    await expectActiveObservers(0);
+
+    input.insetLabel = false;
+    await input.updateComplete;
+    await expectActiveObservers(1);
+  });
+
+  it("cleans up and restores tracking across reconnects", async () => {
+    const input = await mountInput("ha-input-search");
+
+    await expectActiveObservers(1);
+
+    input.remove();
+    await expectActiveObservers(0);
+
+    document.body.append(input);
+    await expectActiveObservers(1);
+  });
+
+  it("settles on the final state after rapid start content changes", async () => {
+    const input = await mountInput();
+
+    const first = createStartContent("first");
+    input.append(first);
+    first.remove();
+
+    const second = createStartContent("second");
+    input.append(second);
+
+    await expectActiveObservers(1);
+
+    second.remove();
+
+    await expectActiveObservers(0);
+  });
+
+  it("tracks initial external start content without leaking observers", async () => {
+    await mountInput("ha-input", (input) => {
+      input.append(createStartContent());
+    });
+
+    await expectActiveObservers(1);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Avoid creating and maintaining start-slot `ResizeObserver` instances for `ha-input` elements when the start slot has no content.

Start-slot tracking is now enabled only while the component is connected, `insetLabel` is disabled, and the slot contains content. Flattened assigned nodes are used so fallback content, such as the default icon in `ha-input-search`, continues to be detected.

The observer lifecycle is also updated when start content or `insetLabel` changes and across disconnects and reconnects, while preserving the existing Safari start-slot width handling.


<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr