### PR TITLE
Fix gallery dev server crash on Windows from a raw path passed to import()

### DIFF
--- a/build-scripts/gulp/gallery.js
+++ b/build-scripts/gulp/gallery.js
@@ -4,6 +4,7 @@ import gulp from "gulp";
 import { load as loadYaml } from "js-yaml";
 import { marked } from "marked";
 import path from "path";
+import { pathToFileURL } from "node:url";
 import { createWorkflowLockTask } from "../output-lock.mjs";
 import paths from "../paths.cjs";
 import "./clean.js";
@@ -87,7 +88,10 @@ gulp.task("gather-gallery-pages", async function gatherPages() {
 
   // Generate sidebar
   const sidebarPath = path.resolve(paths.gallery_dir, "sidebar.js");
-  const sidebar = (await import(sidebarPath)).default;
+  // Node's ESM loader rejects a raw absolute path here on Windows
+  // (ERR_UNSUPPORTED_ESM_URL_SCHEME on the "d:" scheme); a file:// URL
+  // works on every platform.
+  const sidebar = (await import(pathToFileURL(sidebarPath).href)).default;
 
   const pagesToProcess = {};
   for (const key of processed) {


### PR DESCRIPTION
## Proposed change

`gather-gallery-pages` (the gulp task that builds the Style Guide gallery's page list) resolves `gallery/sidebar.js` to an absolute filesystem path with `path.resolve` and passes that straight to a dynamic `import()`:

```js
const sidebarPath = path.resolve(paths.gallery_dir, "sidebar.js");
const sidebar = (await import(sidebarPath)).default;
```

Node's ESM loader only accepts `file`, `data`, and `node` URL schemes. On Windows, `path.resolve` produces a drive-letter path like `d:\opensource\frontend\gallery\sidebar.js`, and Node reads the part before the first `:` as the URL scheme, so this throws:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
```

`gather-gallery-pages` runs unconditionally at the start of both `develop-gallery` and `build-gallery`, so this crashes the gallery dev server (and presumably the production gallery build) before it does anything else, on every Windows machine. `pathToFileURL()` converts the path to a `file://` URL, which the ESM loader accepts on every platform.

## Screenshots

Not applicable — dev tooling only, no UI change.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: no existing issue found for this; opening directly since the fix is small and unambiguous
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

Verified by reproducing the crash on Windows (`yarn dev:gallery`, also confirmed via `gulp develop-gallery` directly) before the fix, then confirming `gather-gallery-pages` completes and the gallery dev server starts and serves the app after the fix.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
