### PR TITLE
Fix color selector label overlapping the swatch when no value is set

### DIFF
--- a/gallery/src/pages/components/ha-input.ts
+++ b/gallery/src/pages/components/ha-input.ts
@@ -102,6 +102,7 @@ export class DemoHaInput extends LitElement {
                     <ha-input label="URL" type="url" placeholder="https://...">
                     </ha-input>
                     <ha-input label="Date" type="date"></ha-input>
+                    <ha-input label="Color" type="color"></ha-input>
                   </div>
 
                   <h3>States</h3>

--- a/src/components/input/ha-input.ts
+++ b/src/components/input/ha-input.ts
@@ -374,7 +374,8 @@ export class HaInput extends WaInputMixin(LitElement) {
 
       wa-input.label-raised::part(label),
       :host(:focus-within) wa-input::part(label),
-      :host([type="date"]) wa-input::part(label) {
+      :host([type="date"]) wa-input::part(label),
+      :host([type="color"]) wa-input::part(label) {
         padding-top: var(--ha-space-3);
         font-size: var(--ha-font-size-xs);
       }


### PR DESCRIPTION
## Proposed change

Fixes #53820. With no value, `ha-selector-color_rgb` renders `<ha-input type="color" value="">`. `ha-input` only raises the label out of its resting position when `this.value` is non-empty (`label-raised` class in `render()`), which is correct for every other input type: an empty text/number/etc. input is genuinely blank, so the resting label reads fine.

`type="color"` isn't like those. A native `<input type="color">` has no representable empty state — with `value=""` the browser still paints a solid `#000000` swatch immediately, regardless of the raised-label class. So the label stays in its large resting position and sits directly on top of that swatch, which is what the issue describes as "the label struck through."

`ha-input` already solves this exact class of problem for `type="date"`: a native date picker likewise always shows content (the `mm/dd/yyyy`-style placeholder) even when logically empty, so its label is forced into the raised position unconditionally via a dedicated CSS rule, independent of the `label-raised` class:

```css
wa-input.label-raised::part(label),
:host(:focus-within) wa-input::part(label),
:host([type="date"]) wa-input::part(label) {
```

This PR adds `:host([type="color"])` to that same selector, so the color input's label is always raised too — applying the identical, already-proven fix rather than inventing a new mechanism. Also added a "Color" example to the `ha-input` gallery page next to the existing "Date" one, since that's the smallest reviewable surface for this.

## Screenshots

I wasn't able to attach a screenshot: rendering the gallery locally hit an unrelated pre-existing build break in this environment (`rspack` failing to resolve `object-hash`'s default export), separate from anything this PR touches, and not something I wanted to fold into this fix. The reasoning above is a direct copy of the mechanism `ha-input` already uses for `type="date"`'s identical problem, applied to `type="color"`; happy to add a screenshot if a maintainer can confirm locally or points me at a working gallery build.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #53820
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
