### PR TITLE
Always allow saving vacuum segment mapping

### DIFF
--- a/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
+++ b/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
@@ -116,10 +116,7 @@ export class HaMoreInfoViewVacuumSegmentMapping extends LitElement {
         ></ha-vacuum-segment-area-mapper>
 
         <div class="footer">
-          <ha-button
-            @click=${this._save}
-            .disabled=${!this._dirtyState?.isDirty || this._submitting}
-          >
+          <ha-button @click=${this._save} .disabled=${this._submitting}>
             ${this.hass.localize("ui.common.save")}
           </ha-button>
         </div>

--- a/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
+++ b/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
@@ -201,7 +201,7 @@ export class DialogVacuumSegmentMapping
           <ha-button
             slot="primaryAction"
             @click=${this._save}
-            .disabled=${this._submitting || !this.isDirtyState}
+            .disabled=${this._submitting}
           >
             ${this.hass.localize("ui.common.save")}
           </ha-button>


### PR DESCRIPTION
## Proposed change

The "vacuum segments changed" repair opens the segment mapping dialog. The repair is only resolved when `last_seen_segments` is written back to the entity registry, which happens on save. But save was gated on the area mapping being dirty, so when the mapping was already correct (for example after a rename in the vendor app) the repair could not be resolved without first making a bogus change.

Save is now always enabled in the segment mapping dialog and in the more-info segment mapping view. The dirty state is kept for scrim close prevention and discard confirmation.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #53844
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
