### PR TITLE
Fix date, datetime, and color temperature initial values

### DIFF
--- a/src/components/ha-form/get-selector-initial-value.ts
+++ b/src/components/ha-form/get-selector-initial-value.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_MIN_KELVIN } from "../../common/color/convert-light-color";
 import type {
   Selector,
   SelectorForType,
@@ -39,8 +40,8 @@ const SELECTOR_INITIAL_VALUES = {
   conversation_agent: undefined,
   constant: (selector) => selector.constant?.value,
   country: (selector) => selector.country?.countries?.[0],
-  date: () => `${new Date().toISOString().slice(0, 10)}T00:00:00`,
-  datetime: () => `${new Date().toISOString().slice(0, 10)}T00:00:00`,
+  date: () => new Date().toISOString().slice(0, 10),
+  datetime: () => `${new Date().toISOString().slice(0, 10)} 00:00:00`,
   device: (selector) => (selector.device?.multiple ? [] : ""),
   device_class: (selector) =>
     selector.device_class?.multiple ? [] : undefined,
@@ -106,7 +107,13 @@ const SELECTOR_INITIAL_VALUES = {
   tts: undefined,
   tts_voice: undefined,
   location: undefined,
-  color_temp: (selector) => selector.color_temp?.min_mireds ?? 153,
+  color_temp: (selector) => {
+    if (selector.color_temp?.unit === "kelvin") {
+      return selector.color_temp.min ?? DEFAULT_MIN_KELVIN;
+    }
+
+    return selector.color_temp?.min ?? selector.color_temp?.min_mireds ?? 153;
+  },
   ui_action: undefined,
   ui_clock_date_format: undefined,
   ui_color: undefined,

--- a/test/components/ha-form/compute-initial-ha-form-data.test.ts
+++ b/test/components/ha-form/compute-initial-ha-form-data.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { DEFAULT_MIN_KELVIN } from "../../../src/common/color/convert-light-color";
 import { computeInitialHaFormData } from "../../../src/components/ha-form/compute-initial-ha-form-data";
 import type { Selector } from "../../../src/data/selector";
 import type { HaFormSchema } from "../../../src/components/ha-form/types";
@@ -206,6 +207,85 @@ describe("computeInitialHaFormData", () => {
         active_choice: "First",
         First: [],
       },
+    });
+  });
+
+  it("initializes a required date selector with a date-only value", () => {
+    const result = computeInitialHaFormData([requiredField({ date: {} })]);
+
+    expect(result.value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("initializes a required datetime selector with its canonical format", () => {
+    const result = computeInitialHaFormData([requiredField({ datetime: {} })]);
+
+    expect(result.value).toMatch(/^\d{4}-\d{2}-\d{2} 00:00:00$/);
+  });
+
+  it("initializes a required kelvin color temperature from its minimum", () => {
+    expect(
+      computeInitialHaFormData([
+        requiredField({
+          color_temp: {
+            unit: "kelvin",
+            min: 2000,
+          },
+        }),
+      ])
+    ).toEqual({
+      value: 2000,
+    });
+
+    expect(
+      computeInitialHaFormData([
+        requiredField({
+          color_temp: {
+            unit: "kelvin",
+          },
+        }),
+      ])
+    ).toEqual({
+      value: DEFAULT_MIN_KELVIN,
+    });
+  });
+
+  it("initializes a required mired color temperature from its minimum", () => {
+    expect(
+      computeInitialHaFormData([
+        requiredField({
+          color_temp: {
+            unit: "mired",
+            min: 160,
+          },
+        }),
+      ])
+    ).toEqual({
+      value: 160,
+    });
+
+    expect(
+      computeInitialHaFormData([
+        requiredField({
+          color_temp: {
+            unit: "mired",
+            min_mireds: 170,
+          },
+        }),
+      ])
+    ).toEqual({
+      value: 170,
+    });
+
+    expect(
+      computeInitialHaFormData([
+        requiredField({
+          color_temp: {
+            unit: "mired",
+          },
+        }),
+      ])
+    ).toEqual({
+      value: 153,
     });
   });
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Follow-up to #53729. Align the centralized selector initial values with the existing selector value contracts.

Date selectors now use a date-only value, datetime selectors use the canonical space-separated format, and color temperature selectors respect Kelvin and Mired minimums, including the default Kelvin minimum.

Regression tests cover the corrected initial values.<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
