### PR TITLE
Make the media selector clear button follow image_upload

### DIFF
--- a/src/components/ha-selector/ha-selector-media.ts
+++ b/src/components/ha-selector/ha-selector-media.ts
@@ -204,7 +204,7 @@ export class HaMediaSelector extends LitElement {
                 </div>
               </ha-card>
               ${
-                this.selector.media?.clearable
+                this.selector.media?.image_upload
                   ? html`<div>
                       <ha-button
                         appearance="plain"

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -380,7 +380,6 @@ export interface MediaSelector {
   media: {
     accept?: string[];
     image_upload?: boolean;
-    clearable?: boolean;
     hide_content_type?: boolean;
     content_id_helper?: string;
   } | null;

--- a/src/panels/lovelace/editor/config-elements/elements/hui-image-element-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/elements/hui-image-element-editor.ts
@@ -104,7 +104,6 @@ export class HuiImageElementEditor
           selector: {
             media: {
               accept: ["image/*"] as string[],
-              clearable: true,
               image_upload: true,
               hide_content_type: true,
               content_id_helper: localize(

--- a/src/panels/lovelace/editor/config-elements/hui-picture-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-card-editor.ts
@@ -44,7 +44,6 @@ export class HuiPictureCardEditor
           selector: {
             media: {
               accept: ["image/*"] as string[],
-              clearable: true,
               image_upload: true,
               hide_content_type: true,
               content_id_helper: localize(

--- a/src/panels/lovelace/editor/config-elements/hui-picture-elements-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-elements-card-editor.ts
@@ -124,7 +124,6 @@ export class HuiPictureElementsCardEditor
               selector: {
                 media: {
                   accept: ["image/*"] as string[],
-                  clearable: true,
                   image_upload: true,
                   hide_content_type: true,
                   content_id_helper: localize(
@@ -138,7 +137,6 @@ export class HuiPictureElementsCardEditor
               selector: {
                 media: {
                   accept: ["image/*"] as string[],
-                  clearable: true,
                   image_upload: true,
                   hide_content_type: true,
                   content_id_helper: localize(

--- a/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
@@ -82,7 +82,6 @@ export class HuiPictureEntityCardEditor
           selector: {
             media: {
               accept: ["image/*"] as string[],
-              clearable: true,
               image_upload: true,
               hide_content_type: true,
               content_id_helper: localize(

--- a/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
@@ -78,7 +78,6 @@ export class HuiPictureGlanceCardEditor
           selector: {
             media: {
               accept: ["image/*"] as string[],
-              clearable: true,
               image_upload: true,
               hide_content_type: true,
               content_id_helper: localize(

--- a/src/panels/lovelace/editor/view-editor/hui-view-background-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-background-editor.ts
@@ -43,7 +43,6 @@ export class HuiViewBackgroundEditor extends LitElement {
           selector: {
             media: {
               accept: ["image/*"] as string[],
-              clearable: true,
               image_upload: true,
               hide_content_type: true,
               content_id_helper: this.hass.localize(


### PR DESCRIPTION
## Proposed change

Makes the media selector's clear button follow `image_upload` instead of the
separate `clearable` option, and removes `clearable`.

home-assistant/core#180452 exposes `image_upload` to YAML. On review there it was
pointed out that the two flags are always used together, and that `image_upload`
without `clearable` does not really work: the uploader is only rendered while the
value is empty, so with no clear button a field can upload exactly once and never
return to the uploader. The core PR therefore exposes only `image_upload`, and
this makes the frontend match.

`clearable` goes with it, since nothing reads it once the button follows
`image_upload`. Behaviour is unchanged: all seven `clearable: true` in the six
picture editors pair one-to-one with `image_upload: true`, so the button appears
exactly where it did before.

This touches code that home-assistant/frontend#53815 is moving into a new
`ha-media-item-picker` component. Per that PR author's suggestion this is floated
against current dev, and whichever merges first, the other gets resolved
afterwards.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47665
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/180452

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
