### PR TITLE
Optimize update entities computation in hui-updates-card

### DIFF
--- a/src/panels/lovelace/cards/hui-updates-card.ts
+++ b/src/panels/lovelace/cards/hui-updates-card.ts
@@ -29,6 +29,8 @@ export class HuiUpdatesCard extends LitElement implements LovelaceCard {
 
   @state() private _config?: UpdatesCardConfig;
 
+  private _updateCount = 0;
+
   public setConfig(config: UpdatesCardConfig): void {
     this._config = config;
   }
@@ -88,12 +90,12 @@ export class HuiUpdatesCard extends LitElement implements LovelaceCard {
       return;
     }
 
-    const updateEntities = this._getUpdateEntities();
+    this._updateCount = this._getUpdateEntities().length;
 
     // Update visibility based on admin status and updates count
     const shouldBeHidden = Boolean(
       !this.hass.user?.is_admin ||
-      (this._config.hide_empty && updateEntities.length === 0)
+      (this._config.hide_empty && this._updateCount === 0)
     );
 
     if (shouldBeHidden !== this.hidden) {
@@ -108,8 +110,7 @@ export class HuiUpdatesCard extends LitElement implements LovelaceCard {
       return nothing;
     }
 
-    const updateEntities = this._getUpdateEntities();
-    const count = updateEntities.length;
+    const count = this._updateCount;
 
     const label = this.hass.localize("ui.card.updates.title");
     const secondary =

--- a/test/panels/lovelace/cards/hui-updates-card.test.ts
+++ b/test/panels/lovelace/cards/hui-updates-card.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "../../../../src/panels/lovelace/cards/hui-updates-card";
+import type { HuiUpdatesCard } from "../../../../src/panels/lovelace/cards/hui-updates-card";
+import type { UpdatesCardConfig } from "../../../../src/panels/lovelace/cards/types";
+import type { HomeAssistant } from "../../../../src/types";
+
+const { filterUpdateEntities } = vi.hoisted(() => ({
+  filterUpdateEntities: vi.fn(() => []),
+}));
+
+// Bundler-defined globals the card's import graph reads at eval time.
+vi.hoisted(() => {
+  Object.assign(globalThis, {
+    __STATIC_PATH__: "/",
+    __HASS_URL__: "",
+    __BUILD__: "modern",
+    __VERSION__: "test",
+    __BACKWARDS_COMPAT__: false,
+    __SUPERVISOR__: false,
+    __NAMESPACE__: "frontend",
+  });
+});
+
+vi.mock("../../../../src/data/update", () => ({
+  filterUpdateEntities,
+  updateCanInstall: vi.fn(() => true),
+}));
+
+const createHass = (): HomeAssistant =>
+  ({
+    states: {},
+    locale: {
+      language: "en",
+    },
+    user: {
+      is_admin: true,
+    },
+    localize: vi.fn((key: string) => key),
+  }) as unknown as HomeAssistant;
+
+let elements: HuiUpdatesCard[] = [];
+
+const mount = async (): Promise<HuiUpdatesCard> => {
+  const el = document.createElement("hui-updates-card") as HuiUpdatesCard;
+  el.hass = createHass();
+  el.setConfig({
+    type: "updates",
+    hide_empty: false,
+  } as UpdatesCardConfig);
+
+  document.body.appendChild(el);
+  elements.push(el);
+  await el.updateComplete;
+
+  return el;
+};
+
+afterEach(() => {
+  elements.forEach((el) => el.remove());
+  elements = [];
+  vi.restoreAllMocks();
+});
+
+describe("hui-updates-card", () => {
+  // willUpdate() and render() previously each called _getUpdateEntities()
+  // independently; this pins the count to one call per update cycle so a
+  // future edit can't silently reintroduce the duplicate.
+  it("computes update entities once per update cycle", async () => {
+    const element = await mount();
+
+    filterUpdateEntities.mockClear();
+
+    element.hass = {
+      ...element.hass!,
+      states: { ...element.hass!.states },
+    };
+
+    await element.updateComplete;
+
+    expect(filterUpdateEntities).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

`hui-updates-card` computed the list of update entities twice per update cycle: once in `willUpdate()` to decide whether the card should be hidden, and again in `render()` to get the count shown in the card. Both calls used the same inputs and only needed the resulting length, so the second call was redundant.

The computed length is now cached in `willUpdate()` and reused in `render()`, removing the duplicate call.

Regression tests cover the number of computation calls per update cycle.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
