### PR TITLE
Show to-do subtasks in the list card and item dialog

### DIFF
--- a/src/data/todo.ts
+++ b/src/data/todo.ts
@@ -29,6 +29,8 @@ export interface TodoItem {
   description?: string | null;
   due?: string | null;
   completed?: string | null;
+  /** UID of the item this item is a subtask of. Subtasks are one level deep. */
+  parent_uid?: string | null;
 }
 
 export enum TodoListEntityFeature {
@@ -39,6 +41,7 @@ export enum TodoListEntityFeature {
   SET_DUE_DATE_ON_ITEM = 16,
   SET_DUE_DATETIME_ON_ITEM = 32,
   SET_DESCRIPTION_ON_ITEM = 64,
+  SET_PARENT_ON_ITEM = 128,
 }
 
 export const getTodoLists = (
@@ -102,6 +105,7 @@ export const updateItem = (
         item.due === undefined || item.due?.includes("T")
           ? undefined
           : item.due,
+      parent: item.parent_uid,
     },
     { entity_id }
   );
@@ -122,6 +126,7 @@ export const createItem = (
         item.due === undefined || item.due?.includes("T")
           ? undefined
           : item.due,
+      parent: item.parent_uid || undefined,
     },
     { entity_id }
   );

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -619,12 +619,52 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
       : undefined;
   }
 
+  /**
+   * Order items so each subtask directly follows its parent. Subtasks whose
+   * parent is not in this list, because it is filtered out or completed, stay
+   * where they are and are rendered as top-level items.
+   */
+  private _groupSubtasks(items: TodoItem[], uids: Set<string>): TodoItem[] {
+    const children = new Map<string, TodoItem[]>();
+    for (const item of items) {
+      if (item.parent_uid && uids.has(item.parent_uid)) {
+        const siblings = children.get(item.parent_uid);
+        if (siblings) {
+          siblings.push(item);
+        } else {
+          children.set(item.parent_uid, [item]);
+        }
+      }
+    }
+    if (!children.size) {
+      return items;
+    }
+    const ordered: TodoItem[] = [];
+    for (const item of items) {
+      if (item.parent_uid && uids.has(item.parent_uid)) {
+        continue;
+      }
+      ordered.push(item, ...(children.get(item.uid) ?? []));
+    }
+    return ordered;
+  }
+
   private _renderItems(items: TodoItem[], unavailable = false) {
+    // Reordering uses the flat move API, so the hierarchy is not shown there.
+    const uids = this._reordering
+      ? new Set<string>()
+      : new Set(items.map((item) => item.uid));
+    const orderedItems = this._reordering
+      ? items
+      : this._groupSubtasks(items, uids);
     return html`
       ${repeat(
-        items,
+        orderedItems,
         (item) => item.uid,
         (item) => {
+          const isSubtask = Boolean(
+            item.parent_uid && uids.has(item.parent_uid)
+          );
           const showDelete =
             this._todoListSupportsFeature(
               TodoListEntityFeature.DELETE_TODO_ITEM
@@ -645,6 +685,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                 draggable: item.status !== TodoItemStatus.Completed,
                 completed: item.status === TodoItemStatus.Completed,
                 multiline: Boolean(item.description || item.due),
+                subtask: isSubtask,
               })}"
               .selected=${item.status === TodoItemStatus.Completed}
               .disabled=${unavailable}
@@ -1013,6 +1054,10 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
       min-height: 40px;
       height: auto;
       --mdc-list-side-padding: var(--ha-space-5);
+    }
+
+    ha-check-list-item.subtask {
+      --mdc-list-side-padding: var(--ha-space-10);
     }
 
     .row {

--- a/src/panels/todo/dialog-todo-item-editor.ts
+++ b/src/panels/todo/dialog-todo-item-editor.ts
@@ -17,6 +17,7 @@ import type { HaCheckbox } from "../../components/ha-checkbox";
 import "../../components/ha-date-input";
 import "../../components/ha-dialog";
 import "../../components/ha-dialog-footer";
+import "../../components/ha-select";
 import "../../components/ha-textarea";
 import type { HaTextArea } from "../../components/ha-textarea";
 import "../../components/ha-time-input";
@@ -28,6 +29,7 @@ import {
   TodoListEntityFeature,
   createItem,
   deleteItems,
+  fetchItems,
   updateItem,
 } from "../../data/todo";
 import { showConfirmationDialog } from "../../dialogs/generic/show-dialog-box";
@@ -42,6 +44,7 @@ interface TodoItemFormState {
   due?: Date;
   checked: boolean;
   hasTime: boolean;
+  parentUid?: string;
 }
 
 @customElement("dialog-todo-item-editor")
@@ -70,6 +73,10 @@ class DialogTodoItemEditor extends DirtyStateProviderMixin<TodoItemFormState>()(
 
   @state() private _open = false;
 
+  @state() private _parentUid?: string;
+
+  @state() private _parentCandidates?: TodoItem[];
+
   // Dates are manipulated and displayed in the browser timezone
   // which may be different from the Home Assistant timezone. When
   // events are persisted, they are relative to the Home Assistant
@@ -96,12 +103,46 @@ class DialogTodoItemEditor extends DirtyStateProviderMixin<TodoItemFormState>()(
       this._due = entry.due
         ? new Date(this._hasTime ? entry.due : `${entry.due}T00:00:00`)
         : undefined;
+      this._parentUid = entry.parent_uid || undefined;
     } else {
       this._hasTime = false;
       this._checked = false;
       this._due = undefined;
+      this._parentUid = undefined;
     }
     this._initDirtyTracking({ type: "deep" }, this._currentState());
+    if (
+      this._todoListSupportsFeature(TodoListEntityFeature.SET_PARENT_ON_ITEM)
+    ) {
+      this._loadParentCandidates();
+    }
+  }
+
+  /**
+   * Load the items that this item can be made a subtask of. Subtasks are one
+   * level deep, so an item that already has subtasks cannot become one itself.
+   */
+  private async _loadParentCandidates(): Promise<void> {
+    const entity = this._params!.entity;
+    let items: TodoItem[];
+    try {
+      items = await fetchItems(this.hass!, entity);
+    } catch (_err: any) {
+      this._parentCandidates = [];
+      return;
+    }
+    if (this._params?.entity !== entity) {
+      return;
+    }
+    const uid =
+      this._params.item && "uid" in this._params.item
+        ? this._params.item.uid
+        : undefined;
+    const hasSubtasks =
+      uid !== undefined && items.some((item) => item.parent_uid === uid);
+    this._parentCandidates = hasSubtasks
+      ? []
+      : items.filter((item) => !item.parent_uid && item.uid !== uid);
   }
 
   private _currentState(): TodoItemFormState {
@@ -111,6 +152,7 @@ class DialogTodoItemEditor extends DirtyStateProviderMixin<TodoItemFormState>()(
       due: this._due,
       checked: this._checked,
       hasTime: this._hasTime,
+      parentUid: this._parentUid,
     };
   }
 
@@ -129,6 +171,8 @@ class DialogTodoItemEditor extends DirtyStateProviderMixin<TodoItemFormState>()(
     this._summary = "";
     this._description = "";
     this._hasTime = false;
+    this._parentUid = undefined;
+    this._parentCandidates = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
@@ -255,6 +299,26 @@ class DialogTodoItemEditor extends DirtyStateProviderMixin<TodoItemFormState>()(
                 </div>`
               : nothing
           }
+          ${
+            this._todoListSupportsFeature(
+              TodoListEntityFeature.SET_PARENT_ON_ITEM
+            ) && this._parentCandidates?.length
+              ? html`<ha-select
+                  .label=${this.hass.localize("ui.components.todo.item.parent")}
+                  .helper=${this.hass.localize(
+                    "ui.components.todo.item.parent_helper"
+                  )}
+                  .value=${this._parentUid ?? ""}
+                  .options=${this._parentCandidates.map((item) => ({
+                    value: item.uid,
+                    label: item.summary,
+                  }))}
+                  .disabled=${!canUpdate}
+                  clearable
+                  @selected=${this._parentChanged}
+                ></ha-select>`
+              : nothing
+          }
         </div>
         <ha-dialog-footer slot="footer">
           ${
@@ -375,6 +439,11 @@ class DialogTodoItemEditor extends DirtyStateProviderMixin<TodoItemFormState>()(
     this._updateDirtyState(this._currentState());
   }
 
+  private _parentChanged(ev: ValueChangedEvent<string | undefined>) {
+    this._parentUid = ev.detail.value || undefined;
+    this._updateDirtyState(this._currentState());
+  }
+
   private async _createItem() {
     if (!this._summary) {
       this._error = this.hass.localize(
@@ -393,6 +462,7 @@ class DialogTodoItemEditor extends DirtyStateProviderMixin<TodoItemFormState>()(
             ? this._due.toISOString()
             : this._formatDate(this._due)
           : undefined,
+        parent_uid: this._parentUid,
       });
     } catch (err: any) {
       this._error = err ? err.message : "Unknown error";
@@ -440,6 +510,11 @@ class DialogTodoItemEditor extends DirtyStateProviderMixin<TodoItemFormState>()(
         status: this._checked
           ? TodoItemStatus.Completed
           : TodoItemStatus.NeedsAction,
+        parent_uid: this._todoListSupportsFeature(
+          TodoListEntityFeature.SET_PARENT_ON_ITEM
+        )
+          ? (this._parentUid ?? null)
+          : undefined,
       });
     } catch (err: any) {
       this._error = err ? err.message : "Unknown error";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1302,6 +1302,8 @@
           "edit": "Edit item",
           "save": "Save item",
           "due": "Due date",
+          "parent": "Subtask of",
+          "parent_helper": "Group this item under another item on the list",
           "completed_time": "Completed { datetime }",
           "not_all_required_fields": "Not all required fields are filled in",
           "confirm_delete": {


### PR DESCRIPTION
## Proposed change

Frontend support for to-do subtasks, matching the backend fields added in
home-assistant/core#180732.

- `TodoItem` gains `parent_uid`, and `TodoListEntityFeature` gains
  `SET_PARENT_ON_ITEM`. `createItem` and `updateItem` pass the parent through.
- The to-do list card renders each subtask directly under the item it belongs
  to, indented one step.
- The item dialog gains a **Subtask of** picker for lists that support it.

Two rendering details worth calling out for review:

Subtasks are grouped per rendered section rather than globally. A subtask whose
parent is not in the same section, because the parent is completed or falls
outside the due date period, stays where it is and renders as a top-level item
instead of disappearing or dangling under the wrong heading.

Reordering is left flat. The `todo/item/move` websocket command only takes a
`previous_uid`, so it has no way to express a parent change, and showing a
hierarchy that drag-and-drop cannot actually manipulate would be misleading.

The picker offers only top-level items, excludes the item being edited, and is
hidden entirely for an item that already has subtasks of its own. That mirrors
the single-level limit the backend enforces, so the UI cannot construct a
hierarchy the backend would reject.

## Screenshots

<img width="1100" height="657" alt="1-todo-list-card-subtask-indented" src="https://github.com/user-attachments/assets/d546cc4f-93d7-4920-af7d-9779f6f7f420" />
<img width="1100" height="657" alt="2-item-dialog-subtask-of-field" src="https://github.com/user-attachments/assets/d6ad7d57-7128-46fc-a00e-577f27b5fadf" />
<img width="1100" height="657" alt="3-item-dialog-parent-dropdown" src="https://github.com/user-attachments/assets/3879e83e-803c-454f-9623-726767949b67" />


Card with a subtask indented under its parent, the **Subtask of** field, and the
parent dropdown showing only eligible items.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47737
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/180732

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
