### PR TITLE
Add opt-in red color state text for negative numeric states

### DIFF
--- a/src/common/entity/state_color.ts
+++ b/src/common/entity/state_color.ts
@@ -43,6 +43,23 @@ const STATE_COLORED_DOMAIN = new Set([
   "weather",
 ]);
 
+export const isNegativeNumericState = (state?: string): boolean => {
+  if (!state || state.trim() === "") {
+    return false;
+  }
+
+  const value = Number(state);
+  return Number.isFinite(value) && value < 0;
+};
+
+export const stateValueColorCss = (
+  stateObj: HassEntity,
+  colorNegativeNumericStates = false
+): string | undefined =>
+  colorNegativeNumericStates && isNegativeNumericState(stateObj.state)
+    ? "var(--state-negative-color)"
+    : undefined;
+
 export const stateColorCss = (stateObj: HassEntity, state?: string) => {
   const compareState = state !== undefined ? state : stateObj?.state;
   if (compareState === UNAVAILABLE) {

--- a/src/data/frontend.ts
+++ b/src/data/frontend.ts
@@ -11,6 +11,7 @@ export interface CoreFrontendUserData {
   default_panel?: string;
   apps_info_dismissed?: boolean;
   dashboard_favorite_card_types?: string[];
+  colorNegativeNumericStates?: boolean;
 }
 
 export interface SidebarFrontendUserData {

--- a/src/panels/lovelace/badges/hui-entity-badge.ts
+++ b/src/panels/lovelace/badges/hui-entity-badge.ts
@@ -187,6 +187,9 @@ export class HuiEntityBadge extends LitElement implements LovelaceBadge {
         .content=${this._config.state_content}
         .timeFormat=${this._config.time_format}
         .name=${name}
+        .colorNegativeNumericStates=${
+          this.hass.userData?.colorNegativeNumericStates === true
+        }
       >
       </state-display>
     `;

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -1,8 +1,8 @@
-import { consume } from "@lit/context";
+import { consume, type ContextType } from "@lit/context";
 import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import { computeCssColor } from "../../../common/color/compute-color";
@@ -27,7 +27,7 @@ import { iconColorCSS } from "../../../common/style/icon_color_css";
 import "../../../components/ha-card";
 import "../../../components/ha-ripple";
 import { CLIMATE_HVAC_ACTION_TO_MODE } from "../../../data/climate";
-import { uiContext } from "../../../data/context";
+import { configContext, uiContext } from "../../../data/context";
 import type { EntityRegistryDisplayEntry } from "../../../data/entity/entity_registry";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import type { Themes } from "../../../data/ws-themes";
@@ -90,7 +90,11 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
     };
   }
 
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  public hass!: HomeAssistant;
+
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  private _hassConfig?: ContextType<typeof configContext>;
 
   @state() private _config?: ButtonCardConfig;
 
@@ -228,7 +232,8 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
                 style=${styleMap({
                   color: stateValueColorCss(
                     stateObj,
-                    this.hass.userData?.colorNegativeNumericStates === true
+                    this._hassConfig?.userData?.colorNegativeNumericStates ===
+                      true
                   ),
                 })}
               >

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -2,7 +2,7 @@ import { consume } from "@lit/context";
 import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, state } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import { computeCssColor } from "../../../common/color/compute-color";
@@ -20,6 +20,7 @@ import { stateActive } from "../../../common/entity/state_active";
 import {
   stateColorBrightness,
   stateColorCss,
+  stateValueColorCss,
 } from "../../../common/entity/state_color";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import { iconColorCSS } from "../../../common/style/icon_color_css";
@@ -89,7 +90,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
     };
   }
 
-  public hass!: HomeAssistant;
+  @property({ attribute: false }) public hass!: HomeAssistant;
 
   @state() private _config?: ButtonCardConfig;
 
@@ -222,7 +223,15 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
         }
         ${
           this._config.show_state && stateObj
-            ? html`<span class="state">
+            ? html`<span
+                class="state"
+                style=${styleMap({
+                  color: stateValueColorCss(
+                    stateObj,
+                    this.hass.userData?.colorNegativeNumericStates === true
+                  ),
+                })}
+              >
                 ${this.hass.formatEntityState(stateObj)}
               </span>`
             : nothing

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -146,10 +146,13 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
     const name = this.hass.formatEntityName(stateObj, this._config.name);
 
     const colored = this._getStateColor(stateObj, this._config);
-    const valueColor = stateValueColorCss(
-      stateObj,
-      this.hass.userData?.colorNegativeNumericStates === true
-    );
+    const valueColor =
+      "attribute" in this._config
+        ? undefined
+        : stateValueColorCss(
+            stateObj,
+            this.hass.userData?.colorNegativeNumericStates === true
+          );
 
     const fixedFooter =
       this.layout === "grid" && this._footerElement !== undefined;

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -16,6 +16,7 @@ import {
 import {
   stateColorBrightness,
   stateColorCss,
+  stateValueColorCss,
 } from "../../../common/entity/state_color";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import { iconColorCSS } from "../../../common/style/icon_color_css";
@@ -144,7 +145,11 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
 
     const name = this.hass.formatEntityName(stateObj, this._config.name);
 
-    const colored = stateObj && this._getStateColor(stateObj, this._config);
+    const colored = this._getStateColor(stateObj, this._config);
+    const valueColor = stateValueColorCss(
+      stateObj,
+      this.hass.userData?.colorNegativeNumericStates === true
+    );
 
     const fixedFooter =
       this.layout === "grid" && this._footerElement !== undefined;
@@ -196,12 +201,14 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
                       ></ha-attribute-value>`
                     : this.hass.localize("state.default.unknown"),
                   unit,
-                  false
+                  false,
+                  valueColor
                 )
               : this._renderValueWithUnit(
                   valueFromParts(stateParts),
                   unit,
-                  unitFirst
+                  unitFirst,
+                  valueColor
                 )
           }
         </div>
@@ -222,10 +229,12 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
   private _renderValueWithUnit(
     value: TemplateResult | string,
     unit: string,
-    unitFirst: boolean
+    unitFirst: boolean,
+    valueColor?: string
   ) {
     return html`<span
         class=${classMap({ value: true, "first-part": !unitFirst })}
+        style=${styleMap({ color: valueColor })}
         >${value}</span
       >${
         unit

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -3,9 +3,11 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
+import { styleMap } from "lit/directives/style-map";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
+import { stateValueColorCss } from "../../../common/entity/state_color";
 import "../../../components/entity/state-badge";
 import "../../../components/ha-card";
 import "../../../components/ha-icon";
@@ -338,7 +340,16 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                               capitalize
                             ></ha-relative-time>
                           `
-                        : this.hass!.formatEntityState(stateObj)
+                        : html`<span
+                            style=${styleMap({
+                              color: stateValueColorCss(
+                                stateObj,
+                                this.hass!.userData
+                                  ?.colorNegativeNumericStates === true
+                              ),
+                            })}
+                            >${this.hass!.formatEntityState(stateObj)}</span
+                          >`
                   }
                 </div>
               `

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -268,6 +268,9 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
             .hass=${this.hass}
             .content=${this._config.state_content}
             .timeFormat=${this._config.time_format}
+            .colorNegativeNumericStates=${
+              this.hass.userData?.colorNegativeNumericStates === true
+            }
           >
           </state-display>
         `;

--- a/src/panels/lovelace/common/has-changed.ts
+++ b/src/panels/lovelace/common/has-changed.ts
@@ -31,7 +31,9 @@ export function hasConfigChanged(
       element.hass.formatEntityAttributeName ||
     oldHass.formatEntityAttributeValue !==
       element.hass.formatEntityAttributeValue ||
-    oldHass.config.state !== element.hass.config.state
+    oldHass.config.state !== element.hass.config.state ||
+    oldHass.userData?.colorNegativeNumericStates !==
+      element.hass.userData?.colorNegativeNumericStates
   ) {
     return true;
   }

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -3,10 +3,12 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
+import { styleMap } from "lit/directives/style-map";
 import { DOMAINS_INPUT_ROW } from "../../../common/const";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { toggleAttribute } from "../../../common/dom/toggle_attribute";
 import { computeDomain } from "../../../common/entity/compute_domain";
+import { stateValueColorCss } from "../../../common/entity/state_color";
 import "../../../components/entity/state-badge";
 import "../../../components/ha-relative-time";
 import "../../../components/ha-tooltip";
@@ -61,10 +63,15 @@ export class HuiGenericEntityRow extends LitElement {
 
     const hasSecondary = this.secondaryText || this.config.secondary_info;
     const name = this.hass.formatEntityName(stateObj, this.config.name);
+    const stateValueColor = stateValueColorCss(
+      stateObj,
+      this.hass.userData?.colorNegativeNumericStates === true
+    );
 
     return html`
       <div
         class="row ${classMap({ pointer })}"
+        style=${styleMap({ "--state-value-color": stateValueColor })}
         @action=${this._handleAction}
         .actionHandler=${actionHandler({
           hasHold: hasAction(this.config!.hold_action),
@@ -102,6 +109,10 @@ export class HuiGenericEntityRow extends LitElement {
                               .content=${this.config.secondary_info}
                               .timeFormat=${this.config.time_format}
                               .name=${name}
+                              .colorNegativeNumericStates=${
+                                this.hass.userData
+                                  ?.colorNegativeNumericStates === true
+                              }
                               timestamp-tooltip
                             >
                             </state-display>`
@@ -190,6 +201,9 @@ export class HuiGenericEntityRow extends LitElement {
     ha-relative-time {
       color: var(--secondary-text-color);
     }
+    ::slotted(.text-content) {
+      color: var(--state-value-color, inherit);
+    }
     state-badge {
       flex: 0 0 40px;
     }
@@ -198,6 +212,7 @@ export class HuiGenericEntityRow extends LitElement {
     }
     .state {
       text-align: var(--float-end);
+      color: var(--state-value-color, inherit);
     }
     .value {
       direction: ltr;

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -127,6 +127,7 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
     .state {
       min-width: 45px;
       text-align: end;
+      color: var(--state-value-color, inherit);
     }
     .box {
       flex-grow: 0;

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -1,7 +1,9 @@
 import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
 import { debounce } from "../../../common/util/debounce";
+import { stateValueColorCss } from "../../../common/entity/state_color";
 import "../../../components/ha-slider";
 import "../../../components/input/ha-input";
 import { UNAVAILABLE } from "../../../data/entity/entity";
@@ -71,6 +73,11 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
       `;
     }
 
+    const stateValueColor = stateValueColorCss(
+      stateObj,
+      this.hass.userData?.colorNegativeNumericStates === true
+    );
+
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         ${
@@ -94,6 +101,9 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
             : html`
                 <div class="flex box">
                   <ha-input
+                    style=${styleMap({
+                      "--wa-form-control-value-color": stateValueColor,
+                    })}
                     .disabled=${stateObj.state === UNAVAILABLE}
                     pattern="[0-9]+([\\.][0-9]+)?"
                     .step=${Number(stateObj.attributes.step)}

--- a/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
@@ -1,7 +1,9 @@
 import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
 import { debounce } from "../../../common/util/debounce";
+import { stateValueColorCss } from "../../../common/entity/state_color";
 import "../../../components/ha-slider";
 import "../../../components/input/ha-input";
 import type { HaInput } from "../../../components/input/ha-input";
@@ -73,6 +75,11 @@ class HuiNumberEntityRow extends LitElement implements LovelaceRow {
       `;
     }
 
+    const stateValueColor = stateValueColorCss(
+      stateObj,
+      this.hass.userData?.colorNegativeNumericStates === true
+    );
+
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         ${
@@ -101,6 +108,9 @@ class HuiNumberEntityRow extends LitElement implements LovelaceRow {
             : html`
                 <div class="flex box">
                   <ha-input
+                    style=${styleMap({
+                      "--wa-form-control-value-color": stateValueColor,
+                    })}
                     auto-validate
                     .disabled=${stateObj.state === UNAVAILABLE}
                     pattern="[0-9]+([\\.][0-9]+)?"

--- a/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
@@ -135,6 +135,7 @@ class HuiNumberEntityRow extends LitElement implements LovelaceRow {
     .state {
       min-width: 45px;
       text-align: end;
+      color: var(--state-value-color, inherit);
     }
     .box {
       flex-grow: 0;

--- a/src/panels/lovelace/heading-badges/hui-entity-heading-badge.ts
+++ b/src/panels/lovelace/heading-badges/hui-entity-heading-badge.ts
@@ -185,6 +185,9 @@ export class HuiEntityHeadingBadge
                   .stateObj=${stateObj}
                   .content=${config.state_content}
                   .name=${name}
+                  .colorNegativeNumericStates=${
+                    this.hass.userData?.colorNegativeNumericStates === true
+                  }
                   dash-unavailable
                 ></state-display>
               `

--- a/src/panels/profile/ha-negative-numeric-state-color-row.ts
+++ b/src/panels/profile/ha-negative-numeric-state-color-row.ts
@@ -1,0 +1,75 @@
+import type { TemplateResult } from "lit";
+import { css, html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import "../../components/ha-alert";
+import "../../components/ha-switch";
+import "../../components/item/ha-row-item";
+import type { CoreFrontendUserData } from "../../data/frontend";
+import { saveFrontendUserData } from "../../data/frontend";
+import type { HomeAssistant } from "../../types";
+
+@customElement("ha-negative-numeric-state-color-row")
+class NegativeNumericStateColorRow extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false })
+  public coreUserData?: CoreFrontendUserData | null;
+
+  @state() private _error?: string;
+
+  protected render(): TemplateResult {
+    return html`
+      ${
+        this._error
+          ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
+          : ""
+      }
+      <ha-row-item>
+        <span slot="headline">
+          ${this.hass.localize(
+            "ui.panel.profile.negative_numeric_state_color.header"
+          )}
+        </span>
+        <span slot="supporting-text">
+          ${this.hass.localize(
+            "ui.panel.profile.negative_numeric_state_color.description"
+          )}
+        </span>
+        <ha-switch
+          slot="end"
+          haptic
+          .checked=${this.coreUserData?.colorNegativeNumericStates === true}
+          .disabled=${this.coreUserData === undefined}
+          @change=${this._toggled}
+        ></ha-switch>
+      </ha-row-item>
+    `;
+  }
+
+  private async _toggled(ev: Event) {
+    try {
+      const checked = (ev.currentTarget as HTMLElement & { checked: boolean })
+        .checked;
+      await saveFrontendUserData(this.hass.connection, "core", {
+        ...this.coreUserData,
+        colorNegativeNumericStates: checked,
+      });
+      this._error = undefined;
+    } catch (err: any) {
+      this._error = err.message || err;
+    }
+  }
+
+  static styles = css`
+    ha-alert {
+      margin: 0 16px;
+      display: block;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-negative-numeric-state-color-row": NegativeNumericStateColorRow;
+  }
+}

--- a/src/panels/profile/ha-negative-numeric-state-color-row.ts
+++ b/src/panels/profile/ha-negative-numeric-state-color-row.ts
@@ -1,8 +1,10 @@
 import type { TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import type { HASSDomTargetEvent } from "../../common/dom/fire_event";
 import "../../components/ha-alert";
 import "../../components/ha-switch";
+import type { HaSwitch } from "../../components/ha-switch";
 import "../../components/item/ha-row-item";
 import type { CoreFrontendUserData } from "../../data/frontend";
 import { saveFrontendUserData } from "../../data/frontend";
@@ -38,6 +40,9 @@ class NegativeNumericStateColorRow extends LitElement {
         <ha-switch
           slot="end"
           haptic
+          .title=${this.hass.localize(
+            "ui.panel.profile.negative_numeric_state_color.header"
+          )}
           .checked=${this.coreUserData?.colorNegativeNumericStates === true}
           .disabled=${this.coreUserData === undefined}
           @change=${this._toggled}
@@ -46,10 +51,9 @@ class NegativeNumericStateColorRow extends LitElement {
     `;
   }
 
-  private async _toggled(ev: Event) {
+  private async _toggled(ev: HASSDomTargetEvent<HaSwitch>) {
     try {
-      const checked = (ev.currentTarget as HTMLElement & { checked: boolean })
-        .checked;
+      const checked = ev.target.checked;
       await saveFrontendUserData(this.hass.connection, "core", {
         ...this.coreUserData,
         colorNegativeNumericStates: checked,

--- a/src/panels/profile/ha-profile-section-preferences.ts
+++ b/src/panels/profile/ha-profile-section-preferences.ts
@@ -13,6 +13,7 @@ import "../../layouts/hass-subpage";
 import { haStyle } from "../../resources/styles";
 import type { HomeAssistant, Route } from "../../types";
 import "./ha-entity-id-picker-row";
+import "./ha-negative-numeric-state-color-row";
 import "./ha-pick-dashboard-row";
 
 @customElement("ha-profile-section-preferences")
@@ -82,6 +83,10 @@ class HaProfileSectionPreferences extends LitElement {
               .hass=${this.hass}
             ></ha-pick-dashboard-row>
             <ha-md-list>
+              <ha-negative-numeric-state-color-row
+                .hass=${this.hass}
+                .coreUserData=${this._coreUserData}
+              ></ha-negative-numeric-state-color-row>
               <ha-md-list-item>
                 <span slot="headline"
                   >${this.hass.localize(
@@ -109,7 +114,7 @@ class HaProfileSectionPreferences extends LitElement {
                   ? html`
                       <ha-entity-id-picker-row
                         .hass=${this.hass}
-                        .coreUserData=${this._coreUserData}
+                        .coreUserData=${this._coreUserData || undefined}
                       ></ha-entity-id-picker-row>
                     `
                   : ""

--- a/src/resources/theme/color/color.globals.ts
+++ b/src/resources/theme/color/color.globals.ts
@@ -174,6 +174,7 @@ export const colorStyles = css`
     /* state color */
     --state-active-color: var(--amber-color);
     --state-inactive-color: var(--grey-color);
+    --state-negative-color: var(--red-color);
     --state-unavailable-color: var(--state-icon-unavailable-color, var(--disabled-text-color));
 
     /* state domain colors */

--- a/src/resources/theme/color/color.globals.ts
+++ b/src/resources/theme/color/color.globals.ts
@@ -174,7 +174,7 @@ export const colorStyles = css`
     /* state color */
     --state-active-color: var(--amber-color);
     --state-inactive-color: var(--grey-color);
-    --state-negative-color: var(--red-color);
+    --state-negative-color: var(--ha-color-on-danger-normal);
     --state-unavailable-color: var(--state-icon-unavailable-color, var(--disabled-text-color));
 
     /* state domain colors */

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -6,6 +6,7 @@ import { customElement, property } from "lit/decorators";
 import { join } from "lit/directives/join";
 import { ensureArray } from "../common/array/ensure-array";
 import { computeStateDomain } from "../common/entity/compute_state_domain";
+import { stateValueColorCss } from "../common/entity/state_color";
 import {
   STRINGS_SEPARATOR_DOT,
   TIMESTAMP_STATE_DOMAINS,
@@ -116,6 +117,8 @@ class StateDisplay extends LitElement {
   @property({ attribute: false }) public name?: string;
 
   @property({ attribute: false }) public timeFormat?: string;
+
+  @property({ attribute: false }) public colorNegativeNumericStates = false;
 
   @property({ type: Boolean, attribute: "timestamp-tooltip" })
   public timestampTooltip = false;
@@ -261,11 +264,17 @@ class StateDisplay extends LitElement {
       .map((content) => this._computeContent(content))
       .filter(Boolean);
 
-    if (!values.length) {
-      return html`${this.hass!.formatEntityState(stateObj)}`;
-    }
+    const display = values.length
+      ? join(values, STRINGS_SEPARATOR_DOT)
+      : html`${this.hass!.formatEntityState(stateObj)}`;
+    const valueColor = stateValueColorCss(
+      stateObj,
+      this.colorNegativeNumericStates
+    );
 
-    return join(values, STRINGS_SEPARATOR_DOT);
+    return valueColor
+      ? html`<span style="color: ${valueColor}">${display}</span>`
+      : display;
   }
 }
 

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -259,19 +259,25 @@ class StateDisplay extends LitElement {
   protected render() {
     const stateObj = this.stateObj;
     const contents = ensureArray(this._content);
-
-    const values = contents
-      .map((content) => this._computeContent(content))
-      .filter(Boolean);
-
-    const display = values.length
-      ? join(values, STRINGS_SEPARATOR_DOT)
-      : html`${this.hass!.formatEntityState(stateObj)}`;
     const valueColor = stateValueColorCss(
       stateObj,
       this.colorNegativeNumericStates
     );
 
+    const values = contents
+      .map((content) => {
+        const value = this._computeContent(content);
+        return value && content === "state" && valueColor
+          ? html`<span style="color: ${valueColor}">${value}</span>`
+          : value;
+      })
+      .filter(Boolean);
+
+    if (values.length) {
+      return join(values, STRINGS_SEPARATOR_DOT);
+    }
+
+    const display = html`${this.hass!.formatEntityState(stateObj)}`;
     return valueColor
       ? html`<span style="color: ${valueColor}">${display}</span>`
       : display;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -11221,6 +11221,10 @@
           "description": "You can also press and hold the header of the sidebar to activate edit mode.",
           "button": "Edit"
         },
+        "negative_numeric_state_color": {
+          "header": "Color negative numeric states",
+          "description": "Show negative numeric states in red on standard dashboard cards and widgets."
+        },
         "vibrate": {
           "header": "Vibrate",
           "description": "Enable or disable vibration on this device when controlling devices."

--- a/test/common/entity/state_color.test.ts
+++ b/test/common/entity/state_color.test.ts
@@ -1,0 +1,36 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { describe, expect, it } from "vitest";
+import {
+  isNegativeNumericState,
+  stateValueColorCss,
+} from "../../../src/common/entity/state_color";
+
+const state = (value: string): HassEntity =>
+  ({
+    entity_id: "sensor.test",
+    state: value,
+    attributes: {},
+  }) as HassEntity;
+
+describe("stateValueColorCss", () => {
+  it("colors negative numeric states only when enabled", () => {
+    expect(stateValueColorCss(state("-1.5"), true)).toBe(
+      "var(--state-negative-color)"
+    );
+    expect(stateValueColorCss(state("-1.5"))).toBeUndefined();
+  });
+
+  it("does not color non-negative or non-numeric states", () => {
+    expect(stateValueColorCss(state("0"), true)).toBeUndefined();
+    expect(stateValueColorCss(state("unknown"), true)).toBeUndefined();
+  });
+});
+
+describe("isNegativeNumericState", () => {
+  it("accepts finite negative numbers and rejects other states", () => {
+    expect(isNegativeNumericState("-0.01")).toBe(true);
+    expect(isNegativeNumericState("0")).toBe(false);
+    expect(isNegativeNumericState("-Infinity")).toBe(false);
+    expect(isNegativeNumericState("unavailable")).toBe(false);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adds an opt-in preference to color negative numeric state values red in standard Home Assistant cards.

- Adds the setting to the new Preferences menu introduced in [home-assistant/frontend#52070](https://github.com/home-assistant/frontend/pull/52070).
- The setting is disabled by default and is placed with the other user preferences.
- Keeps icons and custom cards unchanged.
- The native apple device widget implementation is in [home-assistant/iOS#5572](https://github.com/home-assistant/iOS/pull/5572).

## Screenshots
<img width="1411" height="694" alt="image" src="https://github.com/user-attachments/assets/9383f97d-5aed-4a80-9cb0-a7fd1ee591c3" />
<img width="1415" height="703" alt="image" src="https://github.com/user-attachments/assets/9f53c308-c243-46a5-9d78-58cfc5dd0c27" />
<img width="1414" height="695" alt="image" src="https://github.com/user-attachments/assets/85e0a06b-c4ba-4a6b-afc5-96531165527d" />
<img width="1417" height="705" alt="image" src="https://github.com/user-attachments/assets/3f0fef91-2d79-4e44-92cb-6fcba2df7db5" />
<img width="1418" height="696" alt="image" src="https://github.com/user-attachments/assets/dc4ed253-a0a5-40a7-91ce-2c1b7e5c594a" />

<!-- Screenshots will be added before final review. -->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: [home-assistant/frontend#52070](https://github.com/home-assistant/frontend/pull/52070) and [home-assistant/iOS#5572](https://github.com/home-assistant/iOS/pull/5572)
- Link to documentation pull request: [home-assistant/home-assistant.io#47755](https://github.com/home-assistant/home-assistant.io/pull/47755)
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
