### PR TITLE
Group the connectivity panels behind a Connectivity settings page

### DIFF
--- a/src/panels/config/config-sections.ts
+++ b/src/panels/config/config-sections.ts
@@ -1,4 +1,5 @@
 import {
+  mdiAccessPointNetwork,
   mdiAccount,
   mdiBackupRestore,
   mdiBadgeAccountHorizontal,
@@ -92,13 +93,6 @@ export const configSections: Record<string, PageNavigation[]> = {
       component: "lovelace",
       adminOnly: true,
     },
-    {
-      path: "/config/voice-assistants",
-      translationKey: "voice_assistants",
-      iconPath: mdiMicrophone,
-      iconColor: "#3263C3",
-      adminOnly: true,
-    },
   ],
   dashboard_external_settings: [
     {
@@ -109,6 +103,23 @@ export const configSections: Record<string, PageNavigation[]> = {
     },
   ],
   dashboard_2: [
+    {
+      path: "/config/connectivity",
+      translationKey: "connectivity",
+      iconPath: mdiAccessPointNetwork,
+      iconColor: "#00838F",
+      core: true,
+      adminOnly: true,
+    },
+    {
+      path: "/config/voice-assistants",
+      translationKey: "voice_assistants",
+      iconPath: mdiMicrophone,
+      iconColor: "#3263C3",
+      adminOnly: true,
+    },
+  ],
+  connectivity: [
     {
       path: "/config/matter",
       iconPath:

--- a/src/panels/config/connectivity/ha-config-connectivity.ts
+++ b/src/panels/config/connectivity/ha-config-connectivity.ts
@@ -1,0 +1,80 @@
+import type { CSSResultGroup, TemplateResult } from "lit";
+import { css, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import "../../../components/ha-card";
+import "../../../layouts/hass-subpage";
+import { haStyle } from "../../../resources/styles";
+import type { HomeAssistant } from "../../../types";
+import { configSections } from "../config-sections";
+import "../dashboard/ha-config-navigation";
+import "../ha-config-section";
+
+@customElement("ha-config-connectivity")
+class HaConfigConnectivity extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ type: Boolean }) public narrow = false;
+
+  @property({ attribute: "is-wide", type: Boolean }) public isWide = false;
+
+  protected render(): TemplateResult {
+    const title = this.hass.localize(
+      "ui.panel.config.dashboard.connectivity.main"
+    );
+
+    return html`
+      <hass-subpage
+        .hass=${this.hass}
+        back-path="/config"
+        .header=${title}
+        .narrow=${this.narrow}
+      >
+        <ha-config-section .isWide=${this.isWide} full-width>
+          <ha-card outlined>
+            <ha-config-navigation
+              .hass=${this.hass}
+              .narrow=${this.narrow}
+              .pages=${configSections.connectivity}
+              .label=${title}
+            ></ha-config-navigation>
+          </ha-card>
+        </ha-config-section>
+      </hass-subpage>
+    `;
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      css`
+        ha-config-section {
+          margin: auto;
+          margin-top: -32px;
+          max-width: 600px;
+        }
+
+        ha-card {
+          overflow: hidden;
+          margin-bottom: max(24px, var(--safe-area-inset-bottom));
+        }
+
+        @media all and (max-width: 600px) {
+          ha-card {
+            border-width: 1px 0;
+            border-radius: var(--ha-border-radius-square);
+            box-shadow: unset;
+          }
+          ha-config-section {
+            margin-top: -42px;
+          }
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-config-connectivity": HaConfigConnectivity;
+  }
+}

--- a/src/panels/config/dashboard/ha-config-navigation.ts
+++ b/src/panels/config/dashboard/ha-config-navigation.ts
@@ -24,6 +24,8 @@ class HaConfigNavigation extends LitElement {
 
   @property({ attribute: false }) public pages!: PageNavigation[];
 
+  @property() public label?: string;
+
   @state() private _visiblePages?: PageNavigation[];
 
   private _hasBluetoothConfigEntries = false;
@@ -99,16 +101,15 @@ class HaConfigNavigation extends LitElement {
                 }
               `,
     }));
+    const label = this.label ?? this.hass.localize("panel.config");
     return html`
-      <div class="visually-hidden" role="heading" aria-level="2">
-        ${this.hass.localize("panel.config")}
-      </div>
+      <div class="visually-hidden" role="heading" aria-level="2">${label}</div>
       <ha-config-navigation-list
         has-secondary
         .hass=${this.hass}
         .narrow=${this.narrow}
         .pages=${pages}
-        .label=${this.hass.localize("panel.config")}
+        .label=${label}
       ></ha-config-navigation-list>
     `;
   }

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -63,6 +63,10 @@ class HaPanelConfig extends HassRouterPage {
         tag: "ha-config-cloud",
         load: () => import("./cloud/ha-config-cloud"),
       },
+      connectivity: {
+        tag: "ha-config-connectivity",
+        load: () => import("./connectivity/ha-config-connectivity"),
+      },
       devices: {
         tag: "ha-config-devices",
         load: () => import("./devices/ha-config-devices"),

--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-config-dashboard.ts
@@ -160,7 +160,7 @@ export class BluetoothConfigDashboard extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .header=${this.hass.localize("ui.panel.config.bluetooth.title")}
-        back-path="/config"
+        back-path="/config/connectivity"
       >
         <div class="container">
           <ha-card class="content network-status">

--- a/src/panels/config/integrations/integration-panels/infrared/infrared-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/infrared/infrared-config-dashboard.ts
@@ -52,7 +52,7 @@ export class InfraredConfigDashboard extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .header=${this.hass.localize("ui.panel.config.infrared.title")}
-        back-path="/config"
+        back-path="/config/connectivity"
       >
         <div class="container">
           <ha-card class="content network-status">

--- a/src/panels/config/integrations/integration-panels/matter/matter-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/matter/matter-config-dashboard.ts
@@ -83,7 +83,7 @@ export class MatterConfigDashboard extends LitElement {
         .narrow=${this.narrow}
         .hass=${this.hass}
         header="Matter"
-        back-path="/config"
+        back-path="/config/connectivity"
         has-fab
       >
         <div class="container">

--- a/src/panels/config/integrations/integration-panels/radio_frequency/radio-frequency-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/radio_frequency/radio-frequency-config-dashboard.ts
@@ -43,7 +43,7 @@ export class RadioFrequencyConfigDashboard extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .header=${this.hass.localize("ui.panel.config.radio_frequency.title")}
-        back-path="/config"
+        back-path="/config/connectivity"
       >
         <div class="container">
           <ha-card class="network-status">

--- a/src/panels/config/integrations/integration-panels/serial/serial-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/serial/serial-config-dashboard.ts
@@ -409,7 +409,7 @@ export class SerialConfigDashboard extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .header=${this.hass.localize("ui.panel.config.serial.title")}
-        back-path="/config"
+        back-path="/config/connectivity"
       >
         <ha-icon-button
           slot="toolbar-icon"

--- a/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
@@ -79,7 +79,7 @@ export class ThreadConfigPanel extends SubscribeMixin(LitElement) {
         .narrow=${this.narrow}
         .hass=${this.hass}
         header="Thread"
-        back-path="/config"
+        back-path="/config/connectivity"
       >
         <ha-dropdown slot="toolbar-icon">
           <ha-icon-button

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -101,7 +101,7 @@ class ZHAConfigDashboard extends LitElement {
           .hass=${this.hass}
           .narrow=${this.narrow}
           .header=${this.hass.localize("ui.panel.config.zha.network.caption")}
-          back-path="/config"
+          back-path="/config/connectivity"
         >
           <div class="loading">
             <ha-spinner></ha-spinner>
@@ -129,7 +129,7 @@ class ZHAConfigDashboard extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .header=${this.hass.localize("ui.panel.config.zha.network.caption")}
-        back-path="/config"
+        back-path="/config/connectivity"
         has-fab
       >
         <div class="container">

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -148,7 +148,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
         .header=${this.hass.localize(
           "ui.panel.config.zwave_js.navigation.general"
         )}
-        back-path="/config"
+        back-path="/config/connectivity"
         has-fab
       >
         <ha-icon-button

--- a/src/panels/config/tags/ha-config-tags.ts
+++ b/src/panels/config/tags/ha-config-tags.ts
@@ -191,7 +191,7 @@ export class HaConfigTags extends SubscribeMixin(LitElement) {
       <hass-tabs-subpage-data-table
         .hass=${this.hass}
         .narrow=${this.narrow}
-        back-path="/config"
+        back-path="/config/connectivity"
         .route=${this.route}
         .tabs=${configSections.tags}
         .columns=${this._columns(this.hass.localize)}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1635,6 +1635,7 @@
             "knx": "[%key:ui::panel::config::dashboard::knx::main%]",
             "insteon": "[%key:ui::panel::config::dashboard::insteon::main%]",
             "voice-assistants": "[%key:ui::panel::config::dashboard::voice_assistants::main%]",
+            "connectivity": "[%key:ui::panel::config::dashboard::connectivity::main%]",
             "ai-tasks": "[%key:ui::panel::config::ai_tasks::caption%]"
           }
         },
@@ -2738,6 +2739,10 @@
           "dashboards": {
             "main": "Dashboards",
             "secondary": "Organize how you interact with your home"
+          },
+          "connectivity": {
+            "main": "Connectivity",
+            "secondary": "Communication protocols and radios for your devices"
           },
           "voice_assistants": {
             "main": "Voice assistants",

--- a/test/e2e/app.spec.ts
+++ b/test/e2e/app.spec.ts
@@ -26,6 +26,7 @@ import {
 import {
   appRouteSmokeGroups,
   configLinks,
+  connectivityLinks,
   moreInfoViewElements,
 } from "./app/src/smoke";
 
@@ -590,5 +591,21 @@ test.describe("Config panel", () => {
     "config links point to expected pages",
     configLinks,
     getDashboard
+  );
+
+  // Reached by clicking through from the dashboard: the e2e harness only
+  // resolves config panel translations once the dashboard has mounted.
+  const getConnectivity = async (page) => {
+    const dashboard = await getDashboard(page);
+    await dashboard.getByRole("link", { name: /^Connectivity\b/ }).click();
+    const connectivity = page.locator("ha-config-connectivity");
+    await expect(connectivity).toBeAttached({ timeout: PANEL_TIMEOUT });
+    return connectivity;
+  };
+
+  defineLinkSmokeTests(
+    "connectivity links point to expected pages",
+    connectivityLinks,
+    getConnectivity
   );
 });

--- a/test/e2e/app/src/smoke.ts
+++ b/test/e2e/app/src/smoke.ts
@@ -20,7 +20,15 @@ export const configLinks: LinkSmokeCase[] = [
   { href: "/config/areas", label: "Areas, labels & zones" },
   { href: "/config/apps", label: "Apps" },
   { href: "/config/lovelace/dashboards", label: "Dashboards" },
+  { href: "/config/connectivity", label: "Connectivity" },
   { href: "/config/voice-assistants", label: "Voice assistants" },
+  { href: "/config/person", label: "People" },
+  { href: "/config/system", label: "System" },
+  { href: "/config/tools", label: "Tools" },
+  { href: "/config/info", label: "About" },
+];
+
+export const connectivityLinks: LinkSmokeCase[] = [
   { href: "/config/matter", label: "Matter" },
   { href: "/config/zha", label: "Zigbee" },
   { href: "/config/zwave_js", label: "Z-Wave" },
@@ -31,10 +39,6 @@ export const configLinks: LinkSmokeCase[] = [
   { href: "/config/radio-frequency", label: "Radio frequency" },
   { href: "/insteon", label: "Insteon" },
   { href: "/config/tags", label: "Tags" },
-  { href: "/config/person", label: "People" },
-  { href: "/config/system", label: "System" },
-  { href: "/config/tools", label: "Tools" },
-  { href: "/config/info", label: "About" },
 ];
 
 // ── More-info dialog views ───────────────────────────────────────────────────
@@ -198,6 +202,7 @@ const CONFIG_ROUTES = routeCases([
   ["/config/script", "ha-config-script"],
   ["/config/blueprint", "ha-config-blueprint"],
   ["/config/cloud", "ha-config-cloud"],
+  ["/config/connectivity", "ha-config-connectivity"],
   ["/config/energy", "ha-config-energy"],
   ["/config/hardware", "ha-config-hardware"],
   ["/config/labs", "ha-config-labs"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The second group of the settings menu currently lists every connectivity panel individually. Depending on what you have set up, that is up to twelve rows — Matter, Zigbee, Z-Wave, KNX, MQTT, Thread, Bluetooth, Serial, Infrared, Radio frequency, Insteon, and Tags — sitting at the same level as Devices & services or People. It grows every time a new radio integration ships, and it pushes everything below it further down the page.

This groups them behind a single **Connectivity** entry at `/config/connectivity`. The new page lists exactly the same panels, with the same visibility rules, so nothing becomes unreachable and every existing URL keeps working. The settings root now has a short second group: Connectivity and Voice assistants, with Voice assistants moved down from the first group to join it.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

<img width="240" height="500" alt="image" src="https://github.com/user-attachments/assets/21dd3cf8-13a7-469b-90aa-234986591445" />

<img width="240" height="500" alt="image" src="https://github.com/user-attachments/assets/92dada70-0c99-47e3-82c7-b6d45dd19311" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7Yy1BcbkMjCZEtkTEqyKm)_