### PR TITLE
Migrate add-to action list to grouped list style

### DIFF
--- a/src/dialogs/add-to/ha-add-to-action-list.ts
+++ b/src/dialogs/add-to/ha-add-to-action-list.ts
@@ -15,7 +15,7 @@ import "../../components/ha-icon";
 import "../../components/ha-svg-icon";
 import type { HaListItemButton } from "../../components/item/ha-list-item-button";
 import "../../components/item/ha-list-item-button";
-import "../../components/list/ha-list-base";
+import "../../components/list/ha-grouped-list";
 import { consumeLocalize } from "../../common/decorators/consume-context-entry";
 
 export interface AddToActionListItem {
@@ -76,20 +76,19 @@ class HaAddToActionList extends LitElement {
     }
 
     return html`
-      <h3 class="section-header">
-        ${this._localizeValue(section.title, section.titleKey)}
-      </h3>
-      ${
-        section.actions.length
-          ? html`<ha-list-base>
-              ${section.actions.map((action, actionIndex) =>
+      <ha-grouped-list
+        .header=${this._localizeValue(section.title, section.titleKey)}
+      >
+        ${
+          section.actions.length
+            ? section.actions.map((action, actionIndex) =>
                 this._renderActionItem(action, sectionIndex, actionIndex)
-              )}
-            </ha-list-base>`
-          : html`<h4 class="empty">
-              ${this._localizeValue(section.empty, section.emptyKey)}
-            </h4>`
-      }
+              )
+            : html`<div class="empty">
+                ${this._localizeValue(section.empty, section.emptyKey)}
+              </div>`
+        }
+      </ha-grouped-list>
     `;
   }
 
@@ -161,26 +160,17 @@ class HaAddToActionList extends LitElement {
   static styles: CSSResultGroup = css`
     :host {
       display: block;
+      padding: 0 var(--ha-space-6);
     }
 
-    .section-header {
-      padding: var(--ha-space-2) var(--ha-space-6) var(--ha-space-1);
-      margin: 0;
-      font-size: var(--ha-font-size-m);
-      font-weight: var(--ha-font-weight-medium);
-      color: var(--secondary-text-color);
+    ha-grouped-list + ha-grouped-list {
+      margin-top: var(--ha-space-6);
     }
 
     .empty {
-      padding: var(--ha-space-2) var(--ha-space-6) var(--ha-space-1);
-      margin: 0;
+      padding: var(--ha-space-2) var(--ha-space-3);
       font-size: var(--ha-font-size-m);
-      font-weight: var(--ha-font-weight-normal);
       color: var(--secondary-text-color);
-    }
-
-    ha-list-item-button {
-      --ha-row-item-padding-inline: var(--ha-space-5);
     }
 
     ha-icon,
@@ -194,7 +184,7 @@ class HaAddToActionList extends LitElement {
     }
 
     .plus {
-      color: var(--primary-color);
+      color: var(--secondary-text-color);
     }
 
     ha-list-item-button[disabled] .start-icon,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Migrates `ha-add-to-action-list` to the grouped list style used by the other more-info subviews since #53920. Sections render as `ha-grouped-list` frames instead of bare headings, and the plus icon follows the secondary text color. The add-to dialogs on the area and device pages share the component and get the same style.

## Screenshots

<img width="608" height="388" alt="CleanShot 2026-09-01 at 14 10 06" src="https://github.com/user-attachments/assets/c8973bec-46ef-4622-b840-7e09b2e74de4" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53920
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
