### PR TITLE
Clarify what uninstalling an app deletes

### DIFF
--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -280,14 +280,14 @@ export const restartHassioAddon = async (
 export const uninstallHassioAddon = async (
   callWS: CallWS,
   slug: string,
-  removeData: boolean
+  removeConfig: boolean
 ): Promise<void> => {
   await callWS({
     type: "supervisor/api",
     endpoint: `/addons/${slug}/uninstall`,
     method: "post",
     timeout: null,
-    data: { remove_config: removeData },
+    data: { remove_config: removeConfig },
   });
 };
 

--- a/src/panels/config/apps/app-view/info/supervisor-app-info.ts
+++ b/src/panels/config/apps/app-view/info/supervisor-app-info.ts
@@ -1462,9 +1462,9 @@ class SupervisorAppInfo extends MobileAwareMixin(LitElement) {
       return;
     }
 
-    let removeData = false;
-    const _removeDataToggled = (e: Event) => {
-      removeData = (e.target as HaSwitch).checked;
+    let removeConfig = false;
+    const _removeConfigToggled = (e: Event) => {
+      removeConfig = (e.target as HaSwitch).checked;
     };
 
     const confirmed = await showConfirmationDialog(this, {
@@ -1475,16 +1475,21 @@ class SupervisorAppInfo extends MobileAwareMixin(LitElement) {
         }
       ),
       text: html`
+        <p>
+          ${this.i18n.localize(
+            "ui.panel.config.apps.dashboard.uninstall_dialog.text"
+          )}
+        </p>
         <ha-formfield
           .label=${html`<p>
             ${this.i18n.localize(
-              "ui.panel.config.apps.dashboard.uninstall_dialog.remove_data"
+              "ui.panel.config.apps.dashboard.uninstall_dialog.remove_config"
             )}
           </p>`}
         >
           <ha-switch
-            @change=${_removeDataToggled}
-            .checked=${removeData}
+            @change=${_removeConfigToggled}
+            .checked=${removeConfig}
             haptic
           ></ha-switch>
         </ha-formfield>
@@ -1503,7 +1508,7 @@ class SupervisorAppInfo extends MobileAwareMixin(LitElement) {
     this._uninstalling = true;
     this._error = undefined;
     try {
-      await uninstallHassioAddon(this.api.callWS, addon.slug, removeData);
+      await uninstallHassioAddon(this.api.callWS, addon.slug, removeConfig);
       const eventdata = {
         success: true,
         response: undefined,

--- a/src/panels/config/apps/app-view/info/supervisor-app-info.ts
+++ b/src/panels/config/apps/app-view/info/supervisor-app-info.ts
@@ -1469,15 +1469,15 @@ class SupervisorAppInfo extends MobileAwareMixin(LitElement) {
 
     const confirmed = await showConfirmationDialog(this, {
       title: this.i18n.localize(
-        "ui.panel.config.apps.dashboard.uninstall_dialog.title",
-        {
-          name: getAppDisplayName(addon.name, addon.stage),
-        }
+        "ui.panel.config.apps.dashboard.uninstall_dialog.title"
       ),
       text: html`
         <p>
           ${this.i18n.localize(
-            "ui.panel.config.apps.dashboard.uninstall_dialog.text"
+            "ui.panel.config.apps.dashboard.uninstall_dialog.text",
+            {
+              name: getAppDisplayName(addon.name, addon.stage),
+            }
           )}
         </p>
         <ha-formfield

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3081,7 +3081,7 @@
             },
             "uninstall_dialog": {
               "title": "Uninstall app",
-              "text": "{name} and everything in its private data folder will be permanently deleted, including any databases, credentials and other internal state it kept there.",
+              "text": "{name} and everything in its private data folder will be permanently deleted, including any databases, credentials, and other internal state it kept there.",
               "remove_config": "Also delete the app's configuration folder (if used)",
               "uninstall": "Uninstall"
             },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3080,8 +3080,8 @@
               "view_supervisor_logs": "View supervisor logs"
             },
             "uninstall_dialog": {
-              "title": "Uninstall {name}?",
-              "text": "This permanently deletes the app and the data it stored, including its databases and any other files it created.",
+              "title": "Uninstall app",
+              "text": "{name} and all the data it stored will be permanently deleted, including its databases and any other files it created.",
               "remove_config": "Also remove the app's configuration folder",
               "uninstall": "Uninstall"
             },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3081,8 +3081,8 @@
             },
             "uninstall_dialog": {
               "title": "Uninstall app",
-              "text": "{name} and all the data it stored will be permanently deleted, including its databases and any other files it created.",
-              "remove_config": "Also remove the app's configuration folder",
+              "text": "{name} and everything stored in its private data folder will be permanently deleted, including its databases and any other files it created.",
+              "remove_config": "Also delete the app's configuration folder (if used)",
               "uninstall": "Uninstall"
             },
             "restart_dialog": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3081,7 +3081,7 @@
             },
             "uninstall_dialog": {
               "title": "Uninstall app",
-              "text": "{name} and everything stored in its private data folder will be permanently deleted, including its databases and any other files it created.",
+              "text": "{name} and everything in its private data folder will be permanently deleted, including any databases, credentials and other internal state it kept there.",
               "remove_config": "Also delete the app's configuration folder (if used)",
               "uninstall": "Uninstall"
             },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3081,7 +3081,8 @@
             },
             "uninstall_dialog": {
               "title": "Uninstall {name}?",
-              "remove_data": "Also remove app data",
+              "text": "This permanently deletes the app and the data it stored, including its databases and any other files it created.",
+              "remove_config": "Also remove the app's configuration folder",
               "uninstall": "Uninstall"
             },
             "restart_dialog": {


### PR DESCRIPTION
## Proposed change

The uninstall dialog offers a single switch labeled "Also remove app data". That names the wrong thing twice over. The switch sends `remove_config`, which Supervisor applies to the app's public config folder — `/addon_configs/<slug>`, and only for apps that opt into it with `map: addon_config`. The app's data folder is deleted on uninstall either way, independent of the switch. So the label describes the one part of the operation the user has no choice about, and says nothing about the part they do.

The wording traces back to https://github.com/home-assistant/frontend/pull/22268, which introduced the switch by analogy to deleting an app on iOS ("ask the user if they also want to delete the add-on data"). The API field it drives came from https://github.com/home-assistant/supervisor/pull/4913, which describes it strictly as the "public config folder (if used)". Every other surface kept that framing: the endpoint table in the Supervisor API docs reads "Delete addon's config folder (if used)", and the CLI's `apps uninstall --remove-config` flag is documented the same way. The frontend is the only place that calls it data.

That same PR also replaced the dialog's existing sentence, "Its configuration will be permanently deleted.", with the switch, so the dialog stopped saying anything about the unconditional part of an uninstall.

This relabels the switch after the folder it actually removes, and restores a statement of what uninstalling always does — permanently deleting the app and the data it stored, including its databases and any other files it created. The local variable and the `uninstallHassioAddon` parameter are renamed to `removeConfig` to match the API field they carry. No behavior change.

Deliberately not addressed: an equivalent opt-out for the app's data folder. Unlike the config folder it is not reachable through any share or UI, and uninstall drops the app's record from Supervisor's store, so a retained copy would be invisible disk usage that nothing ever reclaims — and it would preserve the app's state while losing its option values. A partial backup remains the way to keep an app's data across an uninstall.

## Screenshots

<!-- TODO: before/after of the uninstall dialog -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/22268 https://github.com/home-assistant/supervisor/pull/4913
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
