### PR TITLE
Add show_values toggle to energy and power Sankey cards

### DIFF
--- a/src/components/chart/ha-sankey-chart.ts
+++ b/src/components/chart/ha-sankey-chart.ts
@@ -55,6 +55,9 @@ export class HaSankeyChart extends LitElement {
 
   @property({ type: Boolean }) public vertical = false;
 
+  @property({ type: Boolean, attribute: "show-values" }) public showValues =
+    false;
+
   @property({ attribute: false }) public valueFormatter?: (
     value: number
   ) => string;
@@ -84,7 +87,11 @@ export class HaSankeyChart extends LitElement {
 
     return html`<ha-chart-base
       .hass=${this.hass}
-      .data=${this._createData(this.data, this._sizeController.value?.width)}
+      .data=${this._createData(
+        this.data,
+        this._sizeController.value?.width,
+        this.showValues
+      )}
       .options=${options}
       height="100%"
       .extraComponents=${[SankeyChart]}
@@ -142,7 +149,11 @@ export class HaSankeyChart extends LitElement {
     }
   };
 
-  private _createData = memoizeOne((data: SankeyChartData, width = 0) => {
+  private _computeData = (
+    data: SankeyChartData,
+    width = 0,
+    showValues = false
+  ) => {
     const filteredNodes = data.nodes.filter((n) => n.value > 0);
     const indexes = [...new Set(filteredNodes.map((n) => n.index))].sort();
     const depthMap = new Map<number, number>();
@@ -209,9 +220,19 @@ export class HaSankeyChart extends LitElement {
       layoutIterations: 0,
       animationDuration: 500,
       label: {
-        formatter: (params) =>
-          data.nodes.find((node) => node.id === (params.data as Node).id)
-            ?.label ?? (params.data as Node).id,
+        formatter: (params) => {
+          const nodeData = params.data as Record<string, any>;
+          const node = data.nodes.find((n) => n.id === nodeData.id);
+          const label = node?.label ?? nodeData.id;
+          if (!showValues || !nodeData.id) return label;
+          const formatted = this.valueFormatter
+            ? this.valueFormatter(nodeData.value)
+                .replace(/<[^>]*>/g, "")
+                .replace(/\s+/g, " ")
+                .trim()
+            : String(nodeData.value);
+          return `${label}\n${formatted}`;
+        },
         position: this.vertical ? "bottom" : "right",
         distance: LABEL_DISTANCE,
         minMargin: 5,
@@ -261,7 +282,9 @@ export class HaSankeyChart extends LitElement {
         focus: "adjacency",
       },
     } as SankeySeriesOption;
-  });
+  };
+
+  private _createData = memoizeOne(this._computeData);
 
   private _processLinks(nodes: Node[], rawLinks: Link[]) {
     const accountedIn = new Map<string, number>();

--- a/src/components/chart/ha-sankey-chart.ts
+++ b/src/components/chart/ha-sankey-chart.ts
@@ -196,6 +196,10 @@ export class HaSankeyChart extends LitElement {
     const links = this._processLinks(filteredNodes, data.links);
     const sectionWidth = width / indexes.length;
     const labelSpace = sectionWidth - NODE_SIZE - LABEL_DISTANCE;
+    // Two-line values can wrap the unit onto a third line; keep that text inside the chart.
+    const verticalBottom = showValues
+      ? LABEL_DISTANCE + FONT_SIZE * 3 + OVERFLOW_MARGIN
+      : 25;
 
     return {
       id: "sankey",
@@ -286,7 +290,7 @@ export class HaSankeyChart extends LitElement {
         };
       },
       top: this.vertical ? 0 : OVERFLOW_MARGIN,
-      bottom: this.vertical ? 25 : OVERFLOW_MARGIN,
+      bottom: this.vertical ? verticalBottom : OVERFLOW_MARGIN,
       left: this.vertical ? OVERFLOW_MARGIN : 0,
       right: this.vertical ? OVERFLOW_MARGIN : labelSpace + LABEL_DISTANCE,
       emphasis: {

--- a/src/components/chart/ha-sankey-chart.ts
+++ b/src/components/chart/ha-sankey-chart.ts
@@ -221,14 +221,14 @@ export class HaSankeyChart extends LitElement {
       animationDuration: 500,
       label: {
         formatter: (params) => {
-          const nodeData = params.data as Record<string, any>;
+          const nodeData = params.data as { id: string; value: number };
           const node = data.nodes.find((n) => n.id === nodeData.id);
           const label = node?.label ?? nodeData.id;
           if (!showValues || !nodeData.id) return label;
           const formatted = this.valueFormatter
             ? this.valueFormatter(nodeData.value).replace(/\s+/g, " ").trim()
             : String(nodeData.value);
-          return `${label}\n${formatted}`;
+          return `${label}\n\u2066${formatted}\u2069`;
         },
         position: this.vertical ? "bottom" : "right",
         distance: LABEL_DISTANCE,

--- a/src/components/chart/ha-sankey-chart.ts
+++ b/src/components/chart/ha-sankey-chart.ts
@@ -43,6 +43,8 @@ const OVERFLOW_MARGIN = 5;
 const FONT_SIZE = 12;
 const NODE_GAP = 6;
 const LABEL_DISTANCE = 5;
+const LABEL_MIN_MARGIN = 5;
+const BIDI_MARKS = /[\u200E\u200F\u202A-\u202E\u2066-\u2069]/g;
 
 @customElement("ha-sankey-chart")
 export class HaSankeyChart extends LitElement {
@@ -228,28 +230,40 @@ export class HaSankeyChart extends LitElement {
           const formatted = this.valueFormatter
             ? this.valueFormatter(nodeData.value).replace(/\s+/g, " ").trim()
             : String(nodeData.value);
-          return `${label}\n\u2066${formatted}\u2069`;
+          // LRM keeps numeric values LTR on the canvas without creating wrap points.
+          return `${label}\n\u200E${formatted}`;
         },
         position: this.vertical ? "bottom" : "right",
         distance: LABEL_DISTANCE,
-        minMargin: 5,
+        minMargin: LABEL_MIN_MARGIN,
         overflow: "break",
       },
       labelLayout: (params) => {
         if (this.vertical) {
           // reduce the label font size so the longest word fits on one line
           const longestWord = params.text
+            .replace(BIDI_MARKS, "")
             .split(/\s+/)
-            .reduce(
-              (longest, current) =>
-                longest.length > current.length ? longest : current,
-              ""
-            );
-          const wordWidth = measureTextWidth(longestWord, FONT_SIZE);
+            .reduce((longest, current) => {
+              if (!current) {
+                return longest;
+              }
+              if (!longest) {
+                return current;
+              }
+              return measureTextWidth(current, FONT_SIZE) >
+                measureTextWidth(longest, FONT_SIZE)
+                ? current
+                : longest;
+            }, "");
+          const wordWidth = measureTextWidth(longestWord, FONT_SIZE) || 1;
           const availableWidth = (params.rect.width + 6) * this._currentZoom;
+          // minMargin is applied as padding on the label box, so words must
+          // fit in the inner wrap width or overflow:break splits them.
+          const wrapWidth = Math.max(availableWidth - LABEL_MIN_MARGIN, 1);
           const fontSize = Math.min(
             FONT_SIZE,
-            (availableWidth / wordWidth) * FONT_SIZE
+            (wrapWidth / wordWidth) * FONT_SIZE
           );
           return {
             fontSize: fontSize > 1 ? fontSize : 0,

--- a/src/components/chart/ha-sankey-chart.ts
+++ b/src/components/chart/ha-sankey-chart.ts
@@ -226,10 +226,7 @@ export class HaSankeyChart extends LitElement {
           const label = node?.label ?? nodeData.id;
           if (!showValues || !nodeData.id) return label;
           const formatted = this.valueFormatter
-            ? this.valueFormatter(nodeData.value)
-                .replace(/<[^>]*>/g, "")
-                .replace(/\s+/g, " ")
-                .trim()
+            ? this.valueFormatter(nodeData.value).replace(/\s+/g, " ").trim()
             : String(nodeData.value);
           return `${label}\n${formatted}`;
         },
@@ -242,7 +239,7 @@ export class HaSankeyChart extends LitElement {
         if (this.vertical) {
           // reduce the label font size so the longest word fits on one line
           const longestWord = params.text
-            .split(" ")
+            .split(/\s+/)
             .reduce(
               (longest, current) =>
                 longest.length > current.length ? longest : current,

--- a/src/components/chart/ha-sankey-chart.ts
+++ b/src/components/chart/ha-sankey-chart.ts
@@ -232,7 +232,7 @@ export class HaSankeyChart extends LitElement {
           const label = node?.label ?? nodeData.id;
           if (!showValues || !nodeData.id) return label;
           const formatted = this.valueFormatter
-            ? this.valueFormatter(nodeData.value).replace(/\s+/g, " ").trim()
+            ? this.valueFormatter(nodeData.value).trim()
             : String(nodeData.value);
           // LRM keeps numeric values LTR on the canvas without creating wrap points.
           return `${label}\n\u200E${formatted}`;
@@ -247,7 +247,7 @@ export class HaSankeyChart extends LitElement {
           // reduce the label font size so the longest word fits on one line
           const longestWord = params.text
             .replace(BIDI_MARKS, "")
-            .split(/\s+/)
+            .split(/[ \n]+/)
             .reduce((longest, current) => {
               if (!current) {
                 return longest;

--- a/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
@@ -342,19 +342,18 @@ class HuiEnergySankeyCard
         })}
       >
         <div class="card-content">
-          ${
-            hasData
-              ? html`<ha-sankey-chart
-                  .hass=${this.hass}
-                  .data=${{ nodes, links }}
-                  .vertical=${vertical}
-                  .valueFormatter=${this._valueFormatter}
-                  @node-click=${this._handleNodeClick}
-                ></ha-sankey-chart>`
-              : html`${this.hass.localize(
-                  "ui.panel.lovelace.cards.energy.no_data_period"
-                )}`
-          }
+          ${hasData
+            ? html`<ha-sankey-chart
+                .hass=${this.hass}
+                .data=${{ nodes, links }}
+                .vertical=${vertical}
+                .showValues=${this._config.show_values === true}
+                .valueFormatter=${this._valueFormatter}
+                @node-click=${this._handleNodeClick}
+              ></ha-sankey-chart>`
+            : html`${this.hass.localize(
+                "ui.panel.lovelace.cards.energy.no_data_period"
+              )}`}
         </div>
       </ha-card>
     `;

--- a/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
@@ -342,18 +342,20 @@ class HuiEnergySankeyCard
         })}
       >
         <div class="card-content">
-          ${hasData
-            ? html`<ha-sankey-chart
-                .hass=${this.hass}
-                .data=${{ nodes, links }}
-                .vertical=${vertical}
-                .showValues=${this._config.show_values === true}
-                .valueFormatter=${this._valueFormatter}
-                @node-click=${this._handleNodeClick}
-              ></ha-sankey-chart>`
-            : html`${this.hass.localize(
-                "ui.panel.lovelace.cards.energy.no_data_period"
-              )}`}
+          ${
+            hasData
+              ? html`<ha-sankey-chart
+                  .hass=${this.hass}
+                  .data=${{ nodes, links }}
+                  .vertical=${vertical}
+                  .showValues=${this._config.show_values === true}
+                  .valueFormatter=${this._valueFormatter}
+                  @node-click=${this._handleNodeClick}
+                ></ha-sankey-chart>`
+              : html`${this.hass.localize(
+                  "ui.panel.lovelace.cards.energy.no_data_period"
+                )}`
+          }
         </div>
       </ha-card>
     `;

--- a/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
@@ -341,19 +341,18 @@ class HuiPowerSankeyCard
         })}
       >
         <div class="card-content">
-          ${
-            hasData
-              ? html`<ha-sankey-chart
-                  .hass=${this.hass}
-                  .data=${{ nodes, links }}
-                  .vertical=${vertical}
-                  .valueFormatter=${this._valueFormatter}
-                  @node-click=${this._handleNodeClick}
-                ></ha-sankey-chart>`
-              : html`${this.hass.localize(
-                  "ui.panel.lovelace.cards.energy.no_data"
-                )}`
-          }
+          ${hasData
+            ? html`<ha-sankey-chart
+                .hass=${this.hass}
+                .data=${{ nodes, links }}
+                .vertical=${vertical}
+                .showValues=${this._config.show_values === true}
+                .valueFormatter=${this._valueFormatter}
+                @node-click=${this._handleNodeClick}
+              ></ha-sankey-chart>`
+            : html`${this.hass.localize(
+                "ui.panel.lovelace.cards.energy.no_data"
+              )}`}
         </div>
       </ha-card>
     `;

--- a/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
@@ -341,18 +341,20 @@ class HuiPowerSankeyCard
         })}
       >
         <div class="card-content">
-          ${hasData
-            ? html`<ha-sankey-chart
-                .hass=${this.hass}
-                .data=${{ nodes, links }}
-                .vertical=${vertical}
-                .showValues=${this._config.show_values === true}
-                .valueFormatter=${this._valueFormatter}
-                @node-click=${this._handleNodeClick}
-              ></ha-sankey-chart>`
-            : html`${this.hass.localize(
-                "ui.panel.lovelace.cards.energy.no_data"
-              )}`}
+          ${
+            hasData
+              ? html`<ha-sankey-chart
+                  .hass=${this.hass}
+                  .data=${{ nodes, links }}
+                  .vertical=${vertical}
+                  .showValues=${this._config.show_values === true}
+                  .valueFormatter=${this._valueFormatter}
+                  @node-click=${this._handleNodeClick}
+                ></ha-sankey-chart>`
+              : html`${this.hass.localize(
+                  "ui.panel.lovelace.cards.energy.no_data"
+                )}`
+          }
         </div>
       </ha-card>
     `;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -178,6 +178,7 @@ export interface EnergyCardSankeyConfig extends EnergyCardConfig {
   group_by_floor?: boolean;
   group_by_area?: boolean;
   max_devices?: number;
+  show_values?: boolean;
 }
 
 export interface EnergyDateSelectorCardConfig extends EnergyCardBaseConfig {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -178,7 +178,6 @@ export interface EnergyCardSankeyConfig extends EnergyCardConfig {
   group_by_floor?: boolean;
   group_by_area?: boolean;
   max_devices?: number;
-  show_values?: boolean;
 }
 
 export interface EnergyDateSelectorCardConfig extends EnergyCardBaseConfig {
@@ -257,10 +256,12 @@ export interface PowerSourcesGraphCardConfig extends EnergyCardConfig {
 
 export interface EnergySankeyCardConfig extends EnergyCardSankeyConfig {
   type: "energy-sankey";
+  show_values?: boolean;
 }
 
 export interface PowerSankeyCardConfig extends EnergyCardSankeyConfig {
   type: "power-sankey";
+  show_values?: boolean;
 }
 
 export interface WaterSankeyCardConfig extends EnergyCardSankeyConfig {
@@ -270,6 +271,12 @@ export interface WaterSankeyCardConfig extends EnergyCardSankeyConfig {
 export interface WaterFlowSankeyCardConfig extends EnergyCardSankeyConfig {
   type: "water-flow-sankey";
 }
+
+export type SankeyCardConfig =
+  | EnergySankeyCardConfig
+  | PowerSankeyCardConfig
+  | WaterSankeyCardConfig
+  | WaterFlowSankeyCardConfig;
 
 export interface EntityFilterCardConfig extends LovelaceCardConfig {
   type: "entity-filter";

--- a/src/panels/lovelace/editor/config-elements/hui-energy-sankey-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-sankey-card-editor.ts
@@ -38,6 +38,7 @@ const cardConfigStruct = assign(
     group_by_floor: optional(boolean()),
     group_by_area: optional(boolean()),
     max_devices: optional(number()),
+    show_values: optional(boolean()),
   })
 );
 
@@ -89,6 +90,11 @@ export class HuiEnergySankeyCardEditor
               },
               {
                 name: "group_by_area",
+                required: false,
+                selector: { boolean: {} },
+              },
+              {
+                name: "show_values",
                 required: false,
                 selector: { boolean: {} },
               },
@@ -156,6 +162,7 @@ export class HuiEnergySankeyCardEditor
       case "group_by_floor":
       case "group_by_area":
       case "max_devices":
+      case "show_values":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.energy-sankey.${schema.name}`
         );

--- a/src/panels/lovelace/editor/config-elements/hui-energy-sankey-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-sankey-card-editor.ts
@@ -17,7 +17,7 @@ import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
 import type { HaFormSchema } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
-import type { EnergyCardSankeyConfig } from "../../cards/types";
+import type { SankeyCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 
@@ -51,77 +51,86 @@ export class HuiEnergySankeyCardEditor
 {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
-  @state() private _config?: EnergyCardSankeyConfig;
+  @state() private _config?: SankeyCardConfig;
 
-  public setConfig(config: EnergyCardSankeyConfig): void {
+  public setConfig(config: SankeyCardConfig): void {
     assert(config, cardConfigStruct);
     this._config = config;
   }
 
-  private _schema = memoizeOne((localize: LocalizeFunc) => {
-    const schema: HaFormSchema[] = [
-      { name: "title", selector: { text: {} } },
-      {
-        name: "",
-        type: "grid",
-        schema: [
-          {
-            name: "layout",
-            required: false,
-            selector: {
-              select: {
-                options: layoutDirections.map((direction) => ({
-                  value: direction,
-                  label: localize(
-                    `ui.panel.lovelace.editor.card.energy-sankey.layout_directions.${direction}`
-                  ),
-                })),
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc, showValuesSupported: boolean) => {
+      const schema: HaFormSchema[] = [
+        { name: "title", selector: { text: {} } },
+        {
+          name: "",
+          type: "grid",
+          schema: [
+            {
+              name: "layout",
+              required: false,
+              selector: {
+                select: {
+                  options: layoutDirections.map((direction) => ({
+                    value: direction,
+                    label: localize(
+                      `ui.panel.lovelace.editor.card.energy-sankey.layout_directions.${direction}`
+                    ),
+                  })),
+                },
               },
             },
-          },
-          {
-            name: "",
-            type: "grid",
-            schema: [
-              {
-                name: "group_by_floor",
-                required: false,
-                selector: { boolean: {} },
-              },
-              {
-                name: "group_by_area",
-                required: false,
-                selector: { boolean: {} },
-              },
-              {
-                name: "show_values",
-                required: false,
-                selector: { boolean: {} },
-              },
-            ],
-          },
-          {
-            name: "max_devices",
-            required: false,
-            selector: { number: { min: 1, mode: "box" } },
-          },
-          {
-            type: "string",
-            name: "collection_key",
-            required: false,
-          },
-        ],
-      },
-    ];
-    return schema;
-  });
+            {
+              name: "",
+              type: "grid",
+              schema: [
+                {
+                  name: "group_by_floor",
+                  required: false,
+                  selector: { boolean: {} },
+                },
+                {
+                  name: "group_by_area",
+                  required: false,
+                  selector: { boolean: {} },
+                },
+                ...(showValuesSupported
+                  ? [
+                      {
+                        name: "show_values",
+                        required: false,
+                        selector: { boolean: {} },
+                      } as const,
+                    ]
+                  : []),
+              ],
+            },
+            {
+              name: "max_devices",
+              required: false,
+              selector: { number: { min: 1, mode: "box" } },
+            },
+            {
+              type: "string",
+              name: "collection_key",
+              required: false,
+            },
+          ],
+        },
+      ];
+      return schema;
+    }
+  );
 
   protected render() {
     if (!this.hass || !this._config) {
       return nothing;
     }
 
-    const schema = this._schema(this.hass.localize);
+    const showValuesSupported =
+      this._config.type === "energy-sankey" ||
+      this._config.type === "power-sankey";
+    const schema = this._schema(this.hass.localize, showValuesSupported);
 
     const data = {
       ...this._config,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10164,6 +10164,7 @@
               "group_by_area": "Group by area",
               "max_devices": "Maximum devices per parent",
               "max_devices_description": "Devices beyond this limit are grouped into an \"Other\" node, smallest first. The limit applies per upstream device, not per floor or area. Defaults to 20.",
+              "show_values": "Show values",
               "layout": "Graph direction",
               "layout_directions": {
                 "auto": "Automatic",


### PR DESCRIPTION
## Proposed change

Adds a `show_values` boolean config option to the Electrical Energy Sankey
and Power Sankey cards. When enabled, each node's value is rendered
directly on its diagram label (e.g. "Solar\n3.4 kWh") instead of only
showing the node name, so the numeric breakdown is visible on the chart
itself without needing to hover for a tooltip.

The option is exposed in the card editor UI as a toggle, and defaults to
off (existing behavior unchanged).

## Screenshots

<!-- Please add a before/after screenshot showing the label with the value enabled. -->

## Type of change

- [x] New feature (thank you!)

## Additional information

- This PR is related to issue or discussion:
- Link to documentation pull request: home-assistant/home-assistant.io#47789
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

![Screenshot_20260907-104643.png](https://github.com/user-attachments/assets/42eb25cb-45a0-4860-b821-cc5ca104e1ac)

