### PR TITLE
Add pannable option to disable Sankey chart drag panning

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -144,6 +144,11 @@ export class HaChartBase extends LitElement {
   @property({ attribute: "click-label-for-more-info", type: Boolean })
   public clickLabelForMoreInfo = false;
 
+  // Whether a sankey series may be panned by dragging. When false, roam is
+  // never enabled so ECharts does not capture drag gestures at all, letting
+  // touch drags fall through to the page for scrolling instead.
+  @property({ attribute: false }) public sankeyPannable = true;
+
   @state() private _isZoomed = false;
 
   @state() private _zoomRatio = 1;
@@ -365,6 +370,9 @@ export class HaChartBase extends LitElement {
       if (chartOptions.series) {
         this._updateSankeyRoam();
       }
+    }
+    if (changedProps.has("sankeyPannable")) {
+      this._updateSankeyRoam();
     }
   }
 
@@ -1279,7 +1287,11 @@ export class HaChartBase extends LitElement {
       this.chart?.setOption({
         series: sankeySeries.map((s: any) => ({
           id: s.id,
-          roam: this._modifierPressed || this._isTouchDevice ? true : "move",
+          roam: !this.sankeyPannable
+            ? false
+            : this._modifierPressed || this._isTouchDevice
+              ? true
+              : "move",
         })),
       });
     }

--- a/src/components/chart/ha-sankey-chart.ts
+++ b/src/components/chart/ha-sankey-chart.ts
@@ -55,6 +55,8 @@ export class HaSankeyChart extends LitElement {
 
   @property({ type: Boolean }) public vertical = false;
 
+  @property({ type: Boolean }) public pannable = true;
+
   @property({ attribute: false }) public valueFormatter?: (
     value: number
   ) => string;
@@ -88,6 +90,7 @@ export class HaSankeyChart extends LitElement {
       .options=${options}
       height="100%"
       .extraComponents=${[SankeyChart]}
+      .sankeyPannable=${this.pannable}
       @chart-click=${this._handleChartClick}
       @chart-sankeyroam=${this._handleChartSankeyRoam}
     ></ha-chart-base>`;

--- a/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
@@ -348,6 +348,7 @@ class HuiEnergySankeyCard
                   .hass=${this.hass}
                   .data=${{ nodes, links }}
                   .vertical=${vertical}
+                  .pannable=${this._config.pannable !== false}
                   .valueFormatter=${this._valueFormatter}
                   @node-click=${this._handleNodeClick}
                 ></ha-sankey-chart>`

--- a/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
@@ -347,6 +347,7 @@ class HuiPowerSankeyCard
                   .hass=${this.hass}
                   .data=${{ nodes, links }}
                   .vertical=${vertical}
+                  .pannable=${this._config.pannable !== false}
                   .valueFormatter=${this._valueFormatter}
                   @node-click=${this._handleNodeClick}
                 ></ha-sankey-chart>`

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -178,6 +178,7 @@ export interface EnergyCardSankeyConfig extends EnergyCardConfig {
   group_by_floor?: boolean;
   group_by_area?: boolean;
   max_devices?: number;
+  pannable?: boolean;
 }
 
 export interface EnergyDateSelectorCardConfig extends EnergyCardBaseConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-energy-sankey-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-sankey-card-editor.ts
@@ -38,6 +38,7 @@ const cardConfigStruct = assign(
     group_by_floor: optional(boolean()),
     group_by_area: optional(boolean()),
     max_devices: optional(number()),
+    pannable: optional(boolean()),
   })
 );
 
@@ -89,6 +90,11 @@ export class HuiEnergySankeyCardEditor
               },
               {
                 name: "group_by_area",
+                required: false,
+                selector: { boolean: {} },
+              },
+              {
+                name: "pannable",
                 required: false,
                 selector: { boolean: {} },
               },
@@ -156,6 +162,7 @@ export class HuiEnergySankeyCardEditor
       case "group_by_floor":
       case "group_by_area":
       case "max_devices":
+      case "pannable":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.energy-sankey.${schema.name}`
         );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10164,6 +10164,7 @@
               "group_by_area": "Group by area",
               "max_devices": "Maximum devices per parent",
               "max_devices_description": "Devices beyond this limit are grouped into an \"Other\" node, smallest first. The limit applies per upstream device, not per floor or area. Defaults to 20.",
+              "pannable": "Allow dragging to pan the graph",
               "layout": "Graph direction",
               "layout_directions": {
                 "auto": "Automatic",


### PR DESCRIPTION
## Proposed change

On touch devices, ECharts always enables `roam` (drag-to-pan/zoom) on the
Sankey series. This means a single-finger drag that starts on the Sankey
chart is captured by the chart instead of scrolling the page, which is
surprising on mobile where every other card scrolls normally with a drag.

Adds a `pannable` boolean config option to the Electrical Energy Sankey
and Power Sankey cards (default `true`, matching current behavior). When
set to `false`, `roam` is never enabled for the series, so ECharts does
not register any drag/pan handling for the chart at all and a touch drag
starting on it falls through to normal page scrolling instead.

## Screenshots

<!-- No visual change; this only affects touch drag behavior. -->

## Type of change

- [x] New feature (thank you!)

## Additional information

- This PR is related to issue or discussion:
- Link to documentation pull request: home-assistant/home-assistant.io#47790
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

