### PR TITLE
Only pan sankey charts on touch devices once zoomed

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -362,7 +362,7 @@ export class HaChartBase extends LitElement {
     }
     if (Object.keys(chartOptions).length > 0) {
       this._setChartOptions(chartOptions);
-      if (chartOptions.series) {
+      if (chartOptions.series || changedProps.has("_isZoomed")) {
         this._updateSankeyRoam();
       }
     }
@@ -654,6 +654,8 @@ export class HaChartBase extends LitElement {
       echarts.registerTheme("custom", this._createTheme(style));
 
       this.chart = echarts.init(this._chartContainer!, "custom");
+      this._isZoomed = false;
+      this._zoomRatio = 1;
       this.chart.on("datazoom", (e: any) => {
         this._handleDataZoomEvent(e);
       });
@@ -664,7 +666,7 @@ export class HaChartBase extends LitElement {
         const option = this.chart!.getOption();
         const series = option.series as any[];
         const sankeySeries = series?.find((s: any) => s.type === "sankey");
-        const zoomed = sankeySeries.zoom !== 1;
+        const zoomed = Math.abs(sankeySeries.zoom - 1) > 1e-6;
         this._isZoomed = zoomed;
         if (!zoomed) {
           // Reset center when fully zoomed out
@@ -1279,10 +1281,22 @@ export class HaChartBase extends LitElement {
       this.chart?.setOption({
         series: sankeySeries.map((s: any) => ({
           id: s.id,
-          roam: this._modifierPressed || this._isTouchDevice ? true : "move",
+          roam: this._getSankeyRoam(),
         })),
       });
     }
+  }
+
+  // On touch devices a drag pans only once zoomed, so an unzoomed chart
+  // does not swallow page scrolling. Pinch still zooms via "scale".
+  private _getSankeyRoam(): boolean | "move" | "scale" {
+    if (this._modifierPressed) {
+      return true;
+    }
+    if (this._isTouchDevice) {
+      return this._isZoomed ? true : "scale";
+    }
+    return "move";
   }
 
   private _handleDataZoomEvent(e: any) {

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -654,8 +654,11 @@ export class HaChartBase extends LitElement {
       echarts.registerTheme("custom", this._createTheme(style));
 
       this.chart = echarts.init(this._chartContainer!, "custom");
-      this._isZoomed = false;
-      this._zoomRatio = 1;
+      if (this._isZoomed) {
+        this._isZoomed = false;
+        this._zoomRatio = 1;
+        fireEvent(this, "chart-sankeyroam", { zoom: 1 });
+      }
       this.chart.on("datazoom", (e: any) => {
         this._handleDataZoomEvent(e);
       });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

On touch devices the sankey series always had `roam: true`, so a one-finger drag starting on a sankey card was captured by ECharts and the page could not scroll. The chart now uses `roam: "scale"` until it is zoomed (pinch still zooms in), and switches to `true` once zoomed so dragging pans the chart, mirroring the existing `dataZoom` behaviour for cartesian charts.

Also resets the zoom state when the chart is re-created, and compares the sankey zoom to 1 with a tolerance so pinching back out does not leave the chart in pan mode.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53926
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
