### PR TITLE
Rename AI settings URL from /config/ai-tasks to /config/ai

### DIFF
--- a/src/panels/config/config-sections.ts
+++ b/src/panels/config/config-sections.ts
@@ -540,8 +540,8 @@ export const configSections: Record<string, PageNavigation[]> = {
       adminOnly: true,
     },
     {
-      path: "/config/ai-tasks",
-      translationKey: "ai_tasks",
+      path: "/config/ai",
+      translationKey: "ai",
       iconPath: mdiStarFourPoints,
       iconColor: "#8B69E3",
       core: true,

--- a/src/panels/config/core/ha-config-section-ai.ts
+++ b/src/panels/config/core/ha-config-section-ai.ts
@@ -5,8 +5,8 @@ import "./ai-task-pref";
 import "./mcp-pref";
 import type { HomeAssistant } from "../../../types";
 
-@customElement("ha-config-section-ai-tasks")
-class HaConfigSectionAITasks extends LitElement {
+@customElement("ha-config-section-ai")
+class HaConfigSectionAI extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ type: Boolean }) public narrow = false;
@@ -17,7 +17,7 @@ class HaConfigSectionAITasks extends LitElement {
         back-path="/config/system"
         .hass=${this.hass}
         .narrow=${this.narrow}
-        .header=${this.hass.localize("ui.panel.config.ai_tasks.caption")}
+        .header=${this.hass.localize("ui.panel.config.ai.caption")}
       >
         <div class="content">
           <ai-task-pref
@@ -50,6 +50,6 @@ class HaConfigSectionAITasks extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "ha-config-section-ai-tasks": HaConfigSectionAITasks;
+    "ha-config-section-ai": HaConfigSectionAI;
   }
 }

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -181,9 +181,9 @@ class HaPanelConfig extends HassRouterPage {
         tag: "ha-config-labs",
         load: () => import("./labs/ha-config-labs"),
       },
-      "ai-tasks": {
-        tag: "ha-config-section-ai-tasks",
-        load: () => import("./core/ha-config-section-ai-tasks"),
+      ai: {
+        tag: "ha-config-section-ai",
+        load: () => import("./core/ha-config-section-ai"),
       },
       "entity-id-format": {
         tag: "ha-config-section-entity-id-format",

--- a/src/panels/my/ha-panel-my.ts
+++ b/src/panels/my/ha-panel-my.ts
@@ -164,8 +164,11 @@ export const getMyRedirects = (): Redirects => ({
     component: "bluetooth",
     redirect: "/config/bluetooth/visualization",
   },
+  config_ai: {
+    redirect: "/config/ai",
+  },
   config_ai_task: {
-    redirect: "/config/ai-tasks",
+    redirect: "/config/ai",
   },
   config_bluetooth: {
     component: "bluetooth",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1636,7 +1636,7 @@
             "insteon": "[%key:ui::panel::config::dashboard::insteon::main%]",
             "voice-assistants": "[%key:ui::panel::config::dashboard::voice_assistants::main%]",
             "connectivity": "[%key:ui::panel::config::dashboard::connectivity::main%]",
-            "ai-tasks": "[%key:ui::panel::config::ai_tasks::caption%]"
+            "ai": "[%key:ui::panel::config::ai::caption%]"
           }
         },
         "filter_placeholder": "Search entities",
@@ -8857,7 +8857,7 @@
           "intro": "Share anonymized information from your installation to help make Home Assistant better and help us convince manufacturers to add local control and privacy-focused features.",
           "download_device_info": "Preview device analytics"
         },
-        "ai_tasks": {
+        "ai": {
           "caption": "AI",
           "description": "Configure AI suggestions, task preferences, and the Model Context Protocol server"
         },

--- a/test/e2e/app/src/smoke.ts
+++ b/test/e2e/app/src/smoke.ts
@@ -219,7 +219,7 @@ const CONFIG_ROUTES = routeCases([
   ["/config/updates", "ha-config-section-updates"],
   ["/config/repairs", "ha-config-repairs-dashboard"],
   ["/config/analytics", "ha-config-section-analytics"],
-  ["/config/ai-tasks", "ha-config-section-ai-tasks"],
+  ["/config/ai", "ha-config-section-ai"],
   ["/config/labels", "ha-config-labels"],
   ["/config/zone", "ha-config-zone"],
   ["/config/network", "ha-config-section-network"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Follow-up to #53906, which renamed the AI tasks settings page to AI but kept its URL. The page now lives at `/config/ai` so the URL matches its name. The `config_ai_task` my link keeps working and a `config_ai` my link is added alongside it. The old `/config/ai-tasks` URL is dropped, like previous config section moves.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53906, home-assistant/my.home-assistant.io#756
- Link to documentation pull request: home-assistant/home-assistant.io#47810
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
