### PR TITLE
Hide empty labels row in more-info related view

### DIFF
--- a/src/dialogs/more-info/ha-more-info-related.ts
+++ b/src/dialogs/more-info/ha-more-info-related.ts
@@ -242,7 +242,7 @@ class HaMoreInfoRelated extends LitElement {
       padding-bottom: max(var(--safe-area-inset-bottom), var(--ha-space-6));
     }
 
-    ha-related-items {
+    ha-grouped-list + ha-related-items {
       margin-top: var(--ha-space-6);
     }
 

--- a/src/dialogs/more-info/ha-more-info-related.ts
+++ b/src/dialogs/more-info/ha-more-info-related.ts
@@ -155,43 +155,46 @@ class HaMoreInfoRelated extends LitElement {
         />`,
       });
     }
-    contextEntries.push({
-      translationKey: "ui.dialogs.more_info_control.labels",
-      value:
-        labels.map(({ id, entry }) => entry?.name ?? id).join(", ") ||
-        this.hass.localize("ui.dialogs.more_info_control.no_labels"),
-      displayValue: labels.length
-        ? html`<div class="labels">
-            ${labels.map(
-              ({ id, entry }) => html`
-                <ha-label
-                  class="text-ellipsis"
-                  .color=${entry?.color ?? undefined}
-                  .description=${entry?.description ?? undefined}
-                >
-                  ${
-                    entry?.icon
-                      ? html`<ha-icon
-                          slot="icon"
-                          .icon=${entry.icon}
-                        ></ha-icon>`
-                      : nothing
-                  }
-                  ${entry?.name ?? id}
-                </ha-label>
-              `
-            )}
-          </div>`
-        : undefined,
-    });
+    if (labels.length) {
+      contextEntries.push({
+        translationKey: "ui.dialogs.more_info_control.labels",
+        value: labels.map(({ id, entry }) => entry?.name ?? id).join(", "),
+        displayValue: html`<div class="labels">
+          ${labels.map(
+            ({ id, entry }) => html`
+              <ha-label
+                class="text-ellipsis"
+                .color=${entry?.color ?? undefined}
+                .description=${entry?.description ?? undefined}
+              >
+                ${
+                  entry?.icon
+                    ? html`<ha-icon slot="icon" .icon=${entry.icon}></ha-icon>`
+                    : nothing
+                }
+                ${entry?.name ?? id}
+              </ha-label>
+            `
+          )}
+        </div>`,
+      });
+    }
 
     return html`
       <div class="content">
-        <ha-grouped-list
-          .header=${this.hass.localize("ui.dialogs.more_info_control.context")}
-        >
-          ${this._renderEntries(contextEntries)}
-        </ha-grouped-list>
+        ${
+          contextEntries.length
+            ? html`
+                <ha-grouped-list
+                  .header=${this.hass.localize(
+                    "ui.dialogs.more_info_control.context"
+                  )}
+                >
+                  ${this._renderEntries(contextEntries)}
+                </ha-grouped-list>
+              `
+            : nothing
+        }
         <ha-related-items
           .hass=${this.hass}
           .itemId=${this.params.entityId}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1694,7 +1694,6 @@
         "entity_id": "ID",
         "copy_value": "Copy {label}: {value}",
         "labels": "Labels",
-        "no_labels": "None",
         "toggle_yaml_mode": "Toggle YAML mode",
         "back_to_info": "Back to info",
         "info": "Information",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The Related view of the more-info dialog always showed a "Labels" row, with "None" when the entity had no label. The row is now only shown when the entity has labels, like the other context rows, and the Context group is hidden entirely when there is nothing to show.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53920
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
