### PR TITLE
Centralize Supervisor app icons

### DIFF
--- a/src/components/ha-addon-picker.ts
+++ b/src/components/ha-addon-picker.ts
@@ -1,11 +1,12 @@
 import type { RenderItemFunction } from "@lit-labs/virtualizer/virtualize";
-import { html, LitElement, nothing } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { isComponentLoaded } from "../common/config/is_component_loaded";
 import { fireEvent } from "../common/dom/fire_event";
 import { fetchHassioAddonsInfo } from "../data/hassio/addon";
 import type { HomeAssistant, ValueChangedEvent } from "../types";
 import "./ha-alert";
+import "./ha-app-icon";
 import "./ha-combo-box-item";
 import "./ha-generic-picker";
 import type { HaGenericPicker } from "./ha-generic-picker";
@@ -18,13 +19,22 @@ const SEARCH_KEYS = [
   { name: "search_labels.repository", weight: 5 },
 ];
 
-const rowRenderer: RenderItemFunction<PickerComboBoxItem> = (item) => html`
+interface AddonPickerItem extends PickerComboBoxItem {
+  slug: string;
+  hasIcon: boolean;
+}
+
+const rowRenderer: RenderItemFunction<AddonPickerItem> = (item) => html`
   <ha-combo-box-item type="button">
     <span slot="headline">${item.primary}</span>
     <span slot="supporting-text">${item.secondary}</span>
     ${
-      item.icon
-        ? html` <img alt="" slot="start" .src=${item.icon} /> `
+      item.hasIcon
+        ? html`<ha-app-icon
+            slot="start"
+            .slug=${item.slug}
+            .hasIcon=${item.hasIcon}
+          ></ha-app-icon>`
         : nothing
     }
   </ha-combo-box-item>
@@ -40,7 +50,7 @@ class HaAddonPicker extends LitElement {
 
   @property() public helper?: string;
 
-  @state() private _addons?: PickerComboBoxItem[];
+  @state() private _addons?: AddonPickerItem[];
 
   @property({ type: Boolean }) public disabled = false;
 
@@ -102,11 +112,10 @@ class HaAddonPicker extends LitElement {
           .filter((addon) => addon.version)
           .map((addon) => ({
             id: addon.slug,
+            slug: addon.slug,
+            hasIcon: addon.icon,
             primary: addon.name,
             secondary: addon.slug,
-            icon: addon.icon
-              ? `/api/hassio/addons/${addon.slug}/icon`
-              : undefined,
             search_labels: {
               description: addon.description || null,
               repository: addon.repository || null,
@@ -151,15 +160,22 @@ class HaAddonPicker extends LitElement {
   private _valueRenderer = (itemId: string) => {
     const item = this._addons!.find((addon) => addon.id === itemId);
     return html`${
-        item?.icon
-          ? html`<img
+        item?.hasIcon
+          ? html`<ha-app-icon
               slot="start"
-              alt=${item.primary ?? "Unknown"}
-              .src=${item.icon}
-            />`
+              .slug=${item.slug}
+              .hasIcon=${item.hasIcon}
+              .alt=${item.primary ?? "Unknown"}
+            ></ha-app-icon>`
           : nothing
       }<span slot="headline">${item?.primary || "Unknown"}</span>`;
   };
+
+  static styles = css`
+    ha-app-icon {
+      --ha-app-icon-size: var(--ha-space-8);
+    }
+  `;
 }
 
 declare global {

--- a/src/components/ha-app-icon.ts
+++ b/src/components/ha-app-icon.ts
@@ -1,0 +1,76 @@
+import { css, html, LitElement } from "lit";
+import { customElement, property, query, state } from "lit/decorators";
+import { keyed } from "lit/directives/keyed";
+import type { HASSDomCurrentTargetEvent } from "../common/dom/fire_event";
+
+@customElement("ha-app-icon")
+export class HaAppIcon extends LitElement {
+  @property() public slug = "";
+
+  @property({ attribute: "has-icon", type: Boolean })
+  public hasIcon?: boolean;
+
+  @property() public alt = "";
+
+  @property() public loading: "eager" | "lazy" = "eager";
+
+  @state() private _failedSrc?: string;
+
+  @query("img") private _image?: HTMLImageElement;
+
+  private get _src() {
+    return `/api/hassio/addons/${this.slug}/icon`;
+  }
+
+  protected render() {
+    const src = this._src;
+
+    if (!this.slug || this.hasIcon === false || this._failedSrc === src) {
+      return html`<slot></slot>`;
+    }
+
+    return keyed(
+      src,
+      html`
+        <img
+          src=${src}
+          alt=${this.alt}
+          loading=${this.loading}
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer"
+          @error=${this._handleError}
+        />
+      `
+    );
+  }
+
+  private _handleError(ev: HASSDomCurrentTargetEvent<HTMLImageElement>) {
+    if (ev.currentTarget !== this._image) {
+      return;
+    }
+    this._failedSrc = ev.currentTarget.getAttribute("src") ?? undefined;
+  }
+
+  static styles = css`
+    :host {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: var(--ha-app-icon-size, var(--mdc-icon-size));
+      height: var(--ha-app-icon-size, var(--mdc-icon-size));
+      flex-shrink: 0;
+    }
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-app-icon": HaAppIcon;
+  }
+}

--- a/src/components/ha-combo-box-item.ts
+++ b/src/components/ha-combo-box-item.ts
@@ -51,7 +51,8 @@ export class HaComboBoxItem extends HaMdListItem {
         white-space: normal;
       }
       ::slotted(state-badge),
-      ::slotted(img) {
+      ::slotted(img),
+      ::slotted(ha-app-icon) {
         width: 32px;
         height: 32px;
       }

--- a/src/components/ha-combo-box-item.ts
+++ b/src/components/ha-combo-box-item.ts
@@ -56,6 +56,14 @@ export class HaComboBoxItem extends HaMdListItem {
         width: 32px;
         height: 32px;
       }
+      ::slotted(ha-app-icon.colored) {
+        width: var(--ha-space-6);
+        height: var(--ha-space-6);
+        padding: var(--ha-space-1);
+        border-radius: var(--ha-border-radius-circle);
+        background-color: var(--app-icon-background-color);
+        color: var(--white-color);
+      }
       ::slotted(.code) {
         font-family: var(--ha-font-family-code);
         font-size: var(--ha-font-size-xs);

--- a/src/components/ha-combo-box-item.ts
+++ b/src/components/ha-combo-box-item.ts
@@ -57,8 +57,8 @@ export class HaComboBoxItem extends HaMdListItem {
         height: 32px;
       }
       ::slotted(ha-app-icon.colored) {
-        width: var(--ha-space-6);
-        height: var(--ha-space-6);
+        width: 24px;
+        height: 24px;
         padding: var(--ha-space-1);
         border-radius: var(--ha-border-radius-circle);
         background-color: var(--app-icon-background-color);

--- a/src/data/quick_bar.ts
+++ b/src/data/quick_bar.ts
@@ -28,6 +28,7 @@ export interface NavigationComboBoxItem extends PickerComboBoxItem {
   path: string;
   image?: string;
   iconColor?: string;
+  app?: Pick<HassioAddonInfo, "slug" | "icon">;
 }
 
 export interface BaseNavigationCommand {
@@ -38,6 +39,7 @@ export interface BaseNavigationCommand {
   iconPath?: string;
   iconColor?: string;
   image?: string;
+  app?: Pick<HassioAddonInfo, "slug" | "icon">;
 }
 
 export interface ActionCommandComboBoxItem extends PickerComboBoxItem {
@@ -62,19 +64,14 @@ const generateNavigationPanelCommands = (
 
       const primary = localize(translationKey) || panel.title || panel.url_path;
 
-      let image: string | undefined;
-
-      if (apps) {
-        const app = apps.find(({ slug }) => slug === panel.url_path);
-        if (app) {
-          image = app.icon ? `/api/hassio/addons/${app.slug}/icon` : undefined;
-        }
-      }
+      const panelApp = apps?.find(({ slug }) => slug === panel.url_path);
 
       return {
         primary,
         icon,
-        image,
+        app: panelApp
+          ? { slug: panelApp.slug, icon: panelApp.icon }
+          : undefined,
         path: `/${panel.url_path}`,
       };
     });
@@ -171,7 +168,7 @@ export const generateNavigationCommands = (
       for (const app of apps.filter((a) => a.version)) {
         appItems.push({
           path: `/config/app/${app.slug}`,
-          image: app.icon ? `/api/hassio/addons/${app.slug}/icon` : undefined,
+          app: { slug: app.slug, icon: app.icon },
           primary: hass.localize(
             "ui.dialogs.quick-bar.commands.navigation.app_info",
             { app: app.name }

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -344,10 +344,18 @@ export class QuickBar extends LitElement {
                       .slug=${item.app.slug}
                       .hasIcon=${item.app.icon}
                       .alt=${item.primary ?? "Unknown"}
-                      class=${iconColor ? "app-icon colored" : "app-icon"}
-                      style=${styleMap({
-                        "--app-icon-background-color": iconColor,
-                      })}
+                      style=${
+                        iconColor
+                          ? styleMap({
+                              backgroundColor: iconColor,
+                              padding: "var(--ha-space-1)",
+                              borderRadius: "var(--ha-border-radius-circle)",
+                              width: "var(--ha-space-6)",
+                              height: "var(--ha-space-6)",
+                              color: "var(--white-color)",
+                            })
+                          : nothing
+                      }
                     >
                       ${
                         item.icon
@@ -914,18 +922,6 @@ export class QuickBar extends LitElement {
 
         ha-tip a {
           color: var(--primary-color);
-        }
-
-        ha-app-icon.app-icon {
-          --ha-app-icon-size: var(--ha-space-8);
-        }
-
-        ha-app-icon.app-icon.colored {
-          --ha-app-icon-size: var(--ha-space-6);
-          padding: var(--ha-space-1);
-          border-radius: var(--ha-border-radius-circle);
-          background-color: var(--app-icon-background-color);
-          color: var(--white-color);
         }
 
         @media all and (max-width: 450px), all and (max-height: 690px) {

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -4,7 +4,6 @@ import Fuse from "fuse.js";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
-import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
 import type { NavigationFilterOptions } from "../../common/config/filter_navigation_pages";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
@@ -344,16 +343,10 @@ export class QuickBar extends LitElement {
                       .slug=${item.app.slug}
                       .hasIcon=${item.app.icon}
                       .alt=${item.primary ?? "Unknown"}
+                      class=${iconColor ? "colored" : nothing}
                       style=${
                         iconColor
-                          ? styleMap({
-                              backgroundColor: iconColor,
-                              padding: "var(--ha-space-1)",
-                              borderRadius: "var(--ha-border-radius-circle)",
-                              width: "var(--ha-space-6)",
-                              height: "var(--ha-space-6)",
-                              color: "var(--white-color)",
-                            })
+                          ? `--app-icon-background-color: ${iconColor}`
                           : nothing
                       }
                     >

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -4,6 +4,7 @@ import Fuse from "fuse.js";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
 import type { NavigationFilterOptions } from "../../common/config/filter_navigation_pages";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
@@ -12,6 +13,7 @@ import { navigate } from "../../common/navigate";
 import { caseInsensitiveStringCompare } from "../../common/string/compare";
 import "../../components/entity/state-badge";
 import "../../components/ha-adaptive-dialog";
+import "../../components/ha-app-icon";
 import "../../components/ha-combo-box-item";
 import "../../components/ha-domain-icon";
 import "../../components/ha-icon";
@@ -310,6 +312,7 @@ export class QuickBar extends LitElement {
     }
 
     const iconPath = item.icon_path || mdiDevices;
+    const iconColor = "iconColor" in item ? item.iconColor : undefined;
 
     return html`
       <ha-combo-box-item
@@ -334,44 +337,63 @@ export class QuickBar extends LitElement {
                     brand-fallback
                   ></ha-domain-icon>
                 `
-              : "image" in item && item.image
+              : "app" in item && item.app
                 ? html`
-                    <img
+                    <ha-app-icon
                       slot="start"
-                      alt=${item.primary ?? "Unknown"}
-                      .src=${item.image}
-                      style=${
-                        "iconColor" in item && item.iconColor
-                          ? `background-color: ${item.iconColor}; padding: 4px; border-radius: var(--ha-border-radius-circle); width: 24px; height: 24px`
-                          : ""
+                      .slug=${item.app.slug}
+                      .hasIcon=${item.app.icon}
+                      .alt=${item.primary ?? "Unknown"}
+                      class=${iconColor ? "app-icon colored" : "app-icon"}
+                      style=${styleMap({
+                        "--app-icon-background-color": iconColor,
+                      })}
+                    >
+                      ${
+                        item.icon
+                          ? html`<ha-icon .icon=${item.icon}></ha-icon>`
+                          : html`<ha-svg-icon .path=${iconPath}></ha-svg-icon>`
                       }
-                    />
+                    </ha-app-icon>
                   `
-                : item.icon
-                  ? html`<ha-icon
-                      style="margin: var(--ha-space-1);"
-                      slot="start"
-                      .icon=${item.icon}
-                    ></ha-icon>`
-                  : "iconColor" in item && item.iconColor
-                    ? html`
-                        <div
-                          slot="start"
-                          style=${`padding: 4px; border-radius: var(--ha-border-radius-circle); background-color: ${item.iconColor};`}
-                        >
+                : "image" in item && item.image
+                  ? html`
+                      <img
+                        slot="start"
+                        alt=${item.primary ?? "Unknown"}
+                        .src=${item.image}
+                        style=${
+                          "iconColor" in item && item.iconColor
+                            ? `background-color: ${item.iconColor}; padding: 4px; border-radius: var(--ha-border-radius-circle); width: 24px; height: 24px`
+                            : ""
+                        }
+                      />
+                    `
+                  : item.icon
+                    ? html`<ha-icon
+                        style="margin: var(--ha-space-1);"
+                        slot="start"
+                        .icon=${item.icon}
+                      ></ha-icon>`
+                    : "iconColor" in item && item.iconColor
+                      ? html`
+                          <div
+                            slot="start"
+                            style=${`padding: 4px; border-radius: var(--ha-border-radius-circle); background-color: ${item.iconColor};`}
+                          >
+                            <ha-svg-icon
+                              style="color: var(--white-color); --mdc-icon-size: 24px;"
+                              .path=${iconPath}
+                            ></ha-svg-icon>
+                          </div>
+                        `
+                      : html`
                           <ha-svg-icon
-                            style="color: var(--white-color); --mdc-icon-size: 24px;"
+                            style="margin: var(--ha-space-1);"
+                            slot="start"
                             .path=${iconPath}
                           ></ha-svg-icon>
-                        </div>
-                      `
-                    : html`
-                        <ha-svg-icon
-                          style="margin: var(--ha-space-1);"
-                          slot="start"
-                          .path=${iconPath}
-                        ></ha-svg-icon>
-                      `
+                        `
         }
         <span slot="headline">${item.primary}</span>
         ${
@@ -892,6 +914,18 @@ export class QuickBar extends LitElement {
 
         ha-tip a {
           color: var(--primary-color);
+        }
+
+        ha-app-icon.app-icon {
+          --ha-app-icon-size: var(--ha-space-8);
+        }
+
+        ha-app-icon.app-icon.colored {
+          --ha-app-icon-size: var(--ha-space-6);
+          padding: var(--ha-space-1);
+          border-radius: var(--ha-border-radius-circle);
+          background-color: var(--app-icon-background-color);
+          color: var(--white-color);
         }
 
         @media all and (max-width: 450px), all and (max-height: 690px) {

--- a/src/panels/config/apps/components/supervisor-apps-card-content.ts
+++ b/src/panels/config/apps/components/supervisor-apps-card-content.ts
@@ -3,6 +3,7 @@ import { mdiCheckCircle, mdiHelpCircleOutline } from "@mdi/js";
 import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import "../../../../components/ha-app-icon";
 import "../../../../components/ha-svg-icon";
 import type { AddonStage, AddonState } from "../../../../data/hassio/addon";
 import type { HomeAssistant } from "../../../../types";
@@ -41,21 +42,28 @@ class SupervisorAppsCardContent extends LitElement {
 
   @property() public icon = mdiHelpCircleOutline;
 
-  @property({ attribute: false }) public iconImage?: string;
+  @property({ attribute: false }) public appSlug?: string;
+
+  @property({ attribute: false }) public hasAppIcon?: boolean;
 
   protected render(): TemplateResult {
     return html`
       <div class="app">
         <div class="icon-wrapper">
           ${
-            this.iconImage
+            this.appSlug
               ? html`
-                  <img
-                    class="icon-image"
-                    src=${this.iconImage}
-                    .title=${this.iconTitle}
-                    alt=${this.iconTitle ?? ""}
-                  />
+                  <ha-app-icon
+                    .slug=${this.appSlug}
+                    .hasIcon=${this.hasAppIcon}
+                    .alt=${this.iconTitle ?? ""}
+                    .title=${this.iconTitle ?? ""}
+                  >
+                    <ha-svg-icon
+                      class="app-icon"
+                      .path=${this.icon}
+                    ></ha-svg-icon>
+                  </ha-app-icon>
                 `
               : html`
                   <ha-svg-icon
@@ -134,15 +142,15 @@ class SupervisorAppsCardContent extends LitElement {
       width: 40px;
       height: 40px;
       flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
     .app-icon {
-      margin-left: var(--ha-space-2);
-      margin-top: var(--ha-space-2);
       color: var(--secondary-text-color);
     }
-    .icon-image {
-      max-height: 40px;
-      max-width: 40px;
+    ha-app-icon {
+      --ha-app-icon-size: 40px;
     }
     .title {
       flex: 1;

--- a/src/panels/config/apps/ha-config-apps-installed.ts
+++ b/src/panels/config/apps/ha-config-apps-installed.ts
@@ -151,11 +151,8 @@ export class HaConfigAppsInstalled extends LitElement {
                                     "ui.panel.config.apps.installed.app_running"
                                   )
                           }
-                          .iconImage=${
-                            addon.icon
-                              ? `/api/hassio/addons/${addon.slug}/icon`
-                              : undefined
-                          }
+                          .appSlug=${addon.slug}
+                          .hasAppIcon=${addon.icon}
                         ></supervisor-apps-card-content>
                       </div>
                     </ha-card>

--- a/src/panels/config/apps/supervisor-apps-repository.ts
+++ b/src/panels/config/apps/supervisor-apps-repository.ts
@@ -116,11 +116,8 @@ export class SupervisorAppsRepositoryEl extends LitElement {
                           ? "not_available"
                           : ""
                     }
-                    .iconImage=${
-                      addon.icon
-                        ? `/api/hassio/addons/${addon.slug}/icon`
-                        : undefined
-                    }
+                    .appSlug=${addon.slug}
+                    .hasAppIcon=${addon.icon}
                     .showTopbar=${addon.installed || !addon.available}
                     .topbarClass=${
                       addon.installed

--- a/src/panels/config/backup/components/ha-backup-addons-picker.ts
+++ b/src/panels/config/backup/components/ha-backup-addons-picker.ts
@@ -4,8 +4,10 @@ import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { stringCompare } from "../../../../common/string/compare";
+import "../../../../components/ha-app-icon";
 import "../../../../components/ha-checkbox";
 import type { HaCheckbox } from "../../../../components/ha-checkbox";
+import "../../../../components/ha-svg-icon";
 import type { HomeAssistant } from "../../../../types";
 import "./ha-backup-formfield-label";
 
@@ -50,13 +52,17 @@ export class HaBackupAddonsPicker extends LitElement {
               <ha-backup-formfield-label
                 .label=${item.name}
                 .version=${this.hideVersion ? undefined : item.version}
-                .iconPath=${item.iconPath || mdiPuzzle}
-                .imageUrl=${
-                  this.addons?.find((a) => a.slug === item.slug)?.icon
-                    ? `/api/hassio/addons/${item.slug}/icon`
-                    : undefined
-                }
               >
+                <ha-app-icon
+                  slot="icon"
+                  .slug=${item.slug}
+                  .hasIcon=${item.icon}
+                  loading="lazy"
+                >
+                  <ha-svg-icon
+                    .path=${item.iconPath || mdiPuzzle}
+                  ></ha-svg-icon>
+                </ha-app-icon>
               </ha-backup-formfield-label>
             </ha-checkbox>
           `
@@ -85,6 +91,10 @@ export class HaBackupAddonsPicker extends LitElement {
       gap: var(--ha-space-2);
       padding-inline-start: var(--ha-space-2);
       padding-bottom: var(--ha-space-3);
+    }
+
+    ha-app-icon {
+      --ha-app-icon-size: var(--ha-space-6);
     }
   `;
 }

--- a/src/panels/config/backup/components/ha-backup-formfield-label.ts
+++ b/src/panels/config/backup/components/ha-backup-formfield-label.ts
@@ -15,20 +15,25 @@ class SupervisorFormfieldLabel extends LitElement {
 
   protected render(): TemplateResult {
     return html`
-      ${
-        this.imageUrl
-          ? html`<img
-              loading="lazy"
-              alt=""
-              src=${this.imageUrl}
-              class="icon"
-            />`
-          : this.iconPath
-            ? html`
-                <ha-svg-icon .path=${this.iconPath} class="icon"></ha-svg-icon>
-              `
-            : nothing
-      }
+      <slot name="icon">
+        ${
+          this.imageUrl
+            ? html`<img
+                loading="lazy"
+                alt=""
+                src=${this.imageUrl}
+                class="icon"
+              />`
+            : this.iconPath
+              ? html`
+                  <ha-svg-icon
+                    .path=${this.iconPath}
+                    class="icon"
+                  ></ha-svg-icon>
+                `
+              : nothing
+        }
+      </slot>
       <span class="label">
         ${this.label}
         ${

--- a/src/panels/config/integrations/integration-panels/serial/serial-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/serial/serial-config-dashboard.ts
@@ -17,6 +17,7 @@ import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../../../../common/config/is_component_loaded";
 import { caseInsensitiveStringCompare } from "../../../../../common/string/compare";
 import "../../../../../components/ha-alert";
+import "../../../../../components/ha-app-icon";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-icon-button";
 import "../../../../../components/ha-icon-next";
@@ -204,23 +205,12 @@ export class SerialConfigDashboard extends LitElement {
         });
   }
 
-  private _renderConsumerIcon(src: string, alt: string): TemplateResult {
-    return html`<img
-      slot="start"
-      .src=${src}
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-      alt=${alt}
-    />`;
-  }
-
   // The panel the integration behind this consumer is configured in, if it has
   // one. A stopped consumer has no panel loaded to send the user to.
   private _consumerPanel(consumer: SerialPortConsumer): string | undefined {
     if (!consumer.active) {
       return undefined;
     }
-
     const domain =
       consumer.kind === "config_entry"
         ? consumer.domain
@@ -253,22 +243,28 @@ export class SerialConfigDashboard extends LitElement {
       <ha-md-list-item type="link" href=${href} class="consumer">
         ${
           consumer.kind === "config_entry"
-            ? this._renderConsumerIcon(
-                brandsUrl(
+            ? html`<img
+                slot="start"
+                .src=${brandsUrl(
                   {
                     domain: consumer.domain!,
                     type: "icon",
                     darkOptimized: this.hass.themes?.darkMode,
                   },
                   this.hass.auth.data.hassUrl
-                ),
-                consumer.domain!
-              )
+                )}
+                crossorigin="anonymous"
+                referrerpolicy="no-referrer"
+                alt=${consumer.domain!}
+              />`
             : consumer.kind === "app"
-              ? this._renderConsumerIcon(
-                  `/api/hassio/addons/${consumer.slug}/icon`,
-                  consumer.slug!
-                )
+              ? html`<ha-app-icon
+                  slot="start"
+                  .slug=${consumer.slug!}
+                  .alt=${consumer.title || consumer.slug!}
+                >
+                  <ha-svg-icon .path=${mdiPuzzle}></ha-svg-icon>
+                </ha-app-icon>`
               : html`<ha-svg-icon
                   slot="start"
                   .path=${mdiPuzzle}
@@ -673,7 +669,8 @@ export class SerialConfigDashboard extends LitElement {
           --md-list-item-leading-space: var(--ha-space-14);
         }
 
-        ha-md-list-item.consumer img[slot="start"] {
+        ha-md-list-item.consumer img[slot="start"],
+        ha-md-list-item.consumer ha-app-icon[slot="start"] {
           width: 24px;
           height: 24px;
         }

--- a/src/panels/config/logs/ha-config-logs.ts
+++ b/src/panels/config/logs/ha-config-logs.ts
@@ -17,6 +17,7 @@ import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import { navigate } from "../../../common/navigate";
 import { stringCompare } from "../../../common/string/compare";
 import { extractSearchParam } from "../../../common/url/search-params";
+import "../../../components/ha-app-icon";
 import "../../../components/ha-button";
 import "../../../components/ha-generic-picker";
 import type { HaGenericPicker } from "../../../components/ha-generic-picker";
@@ -24,7 +25,10 @@ import type { PickerComboBoxItem } from "../../../components/ha-picker-combo-box
 import "../../../components/input/ha-input-search";
 import type { HaInputSearch } from "../../../components/input/ha-input-search";
 import type { LogProvider } from "../../../data/error_log";
-import { fetchHassioAddonsInfo } from "../../../data/hassio/addon";
+import {
+  fetchHassioAddonsInfo,
+  type HassioAddonInfo,
+} from "../../../data/hassio/addon";
 import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-subpage";
 import { mdiHomeAssistant } from "../../../resources/home-assistant-logo-svg";
@@ -60,6 +64,11 @@ const logProviders: LogProvider[] = [
     name: "Multicast",
   },
 ];
+
+interface LogProviderPickerItem extends PickerComboBoxItem {
+  addon?: HassioAddonInfo;
+  hasAppIcon?: boolean;
+}
 
 @customElement("ha-config-logs")
 export class HaConfigLogs extends LitElement {
@@ -138,18 +147,9 @@ export class HaConfigLogs extends LitElement {
                     @click=${this._openPicker}
                   >
                     ${
-                      selectedProvider?.icon
-                        ? html`<img
-                            src=${selectedProvider.icon}
-                            alt=${selectedProvider.primary}
-                            slot="start"
-                          />`
-                        : selectedProvider?.icon_path
-                          ? html`<ha-svg-icon
-                              slot="start"
-                              .path=${selectedProvider.icon_path}
-                            ></ha-svg-icon>`
-                          : nothing
+                      selectedProvider
+                        ? this._renderProviderIcon(selectedProvider)
+                        : nothing
                     }
                     ${selectedProvider?.primary}
                     <ha-svg-icon
@@ -264,33 +264,40 @@ export class HaConfigLogs extends LitElement {
     }
   }
 
-  private _getLogProviderItems = (): PickerComboBoxItem[] =>
+  private _getLogProviderItems = (): LogProviderPickerItem[] =>
     this._logProviders.map((provider) => ({
       id: provider.key,
       primary: provider.name,
-      icon: provider.addon
+      addon: provider.addon,
+      hasAppIcon: provider.addon
         ? atLeastVersion(this.hass.config.version, 0, 105) &&
           provider.addon.icon
-          ? `/api/hassio/addons/${provider.addon.slug}/icon`
-          : undefined
         : undefined,
       icon_path: provider.addon
         ? mdiPuzzle
         : this._getProviderIconPath(provider.key),
     }));
 
-  private _providerRenderer = (item: PickerComboBoxItem) => html`
+  private _renderProviderIcon(item: LogProviderPickerItem) {
+    if (item.addon) {
+      return html`<ha-app-icon
+        slot="start"
+        .alt=${item.primary}
+        .hasIcon=${item.hasAppIcon}
+        .slug=${item.addon.slug}
+      >
+        <ha-svg-icon .path=${item.icon_path}></ha-svg-icon>
+      </ha-app-icon>`;
+    }
+
+    return item.icon_path
+      ? html`<ha-svg-icon slot="start" .path=${item.icon_path}></ha-svg-icon>`
+      : nothing;
+  }
+
+  private _providerRenderer = (item: LogProviderPickerItem) => html`
     <ha-combo-box-item type="button" compact>
-      ${
-        item.icon
-          ? html`<img src=${item.icon} alt=${item.primary} slot="start" />`
-          : item.icon_path
-            ? html`<ha-svg-icon
-                slot="start"
-                .path=${item.icon_path}
-              ></ha-svg-icon>`
-            : nothing
-      }
+      ${this._renderProviderIcon(item)}
       <span slot="headline">${item.primary}</span>
       ${
         item.secondary
@@ -308,11 +315,10 @@ export class HaConfigLogs extends LitElement {
       return {
         id: provider.key,
         primary: provider.name,
-        icon: provider.addon
+        addon: provider.addon,
+        hasAppIcon: provider.addon
           ? atLeastVersion(this.hass.config.version, 0, 105) &&
             provider.addon.icon
-            ? `/api/hassio/addons/${provider.addon.slug}/icon`
-            : undefined
           : undefined,
         icon_path: provider.addon
           ? mdiPuzzle
@@ -365,8 +371,8 @@ export class HaConfigLogs extends LitElement {
           --mdc-icon-size: var(--ha-space-6);
         }
 
-        img {
-          height: 32px;
+        ha-app-icon {
+          --ha-app-icon-size: 32px;
         }
 
         @media all and (max-width: 870px) {

--- a/test/components/ha-app-icon.test.ts
+++ b/test/components/ha-app-icon.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { HaAppIcon } from "../../src/components/ha-app-icon";
+import "../../src/components/ha-app-icon";
+
+let appIcon: HaAppIcon | undefined;
+
+const mountAppIcon = async (properties: Partial<HaAppIcon> = {}) => {
+  appIcon = document.createElement("ha-app-icon");
+  Object.assign(appIcon, properties);
+  appIcon.append(document.createElement("ha-svg-icon"));
+  document.body.append(appIcon);
+  await appIcon.updateComplete;
+  return appIcon;
+};
+
+afterEach(() => {
+  appIcon?.remove();
+  appIcon = undefined;
+});
+
+describe("ha-app-icon", () => {
+  it("does not request an unavailable icon", async () => {
+    const element = await mountAppIcon({ slug: "example", hasIcon: false });
+
+    expect(element.shadowRoot!.querySelector("img")).toBeNull();
+    expect(element.shadowRoot!.querySelector("slot")).not.toBeNull();
+  });
+
+  it.each([true, undefined])(
+    "requests the icon when availability is %s",
+    async (hasIcon) => {
+      const element = await mountAppIcon({ slug: "example", hasIcon });
+
+      expect(
+        element.shadowRoot!.querySelector("img")!.getAttribute("src")
+      ).toBe("/api/hassio/addons/example/icon");
+    }
+  );
+
+  it("renders the fallback after an image error", async () => {
+    const element = await mountAppIcon({ slug: "example", hasIcon: true });
+
+    element.shadowRoot!.querySelector("img")!.dispatchEvent(new Event("error"));
+    await element.updateComplete;
+
+    expect(element.shadowRoot!.querySelector("img")).toBeNull();
+    expect(element.shadowRoot!.querySelector("slot")).not.toBeNull();
+  });
+
+  it("tries a new source after the slug changes", async () => {
+    const element = await mountAppIcon({ slug: "first", hasIcon: true });
+    element.shadowRoot!.querySelector("img")!.dispatchEvent(new Event("error"));
+    await element.updateComplete;
+
+    element.slug = "second";
+    await element.updateComplete;
+
+    expect(element.shadowRoot!.querySelector("img")!.getAttribute("src")).toBe(
+      "/api/hassio/addons/second/icon"
+    );
+  });
+
+  it("ignores an error from a previous source", async () => {
+    const element = await mountAppIcon({ slug: "first", hasIcon: true });
+    const firstImage = element.shadowRoot!.querySelector("img")!;
+
+    element.slug = "second";
+    await element.updateComplete;
+    firstImage.dispatchEvent(new Event("error"));
+    await element.updateComplete;
+
+    expect(element.shadowRoot!.querySelector("img")!.getAttribute("src")).toBe(
+      "/api/hassio/addons/second/icon"
+    );
+  });
+
+  it("ignores an old error after returning to the same source", async () => {
+    const element = await mountAppIcon({ slug: "first", hasIcon: true });
+    const firstImage = element.shadowRoot!.querySelector("img")!;
+
+    element.slug = "second";
+    await element.updateComplete;
+    element.slug = "first";
+    await element.updateComplete;
+    firstImage.dispatchEvent(new Event("error"));
+    await element.updateComplete;
+
+    expect(element.shadowRoot!.querySelector("img")!.getAttribute("src")).toBe(
+      "/api/hassio/addons/first/icon"
+    );
+  });
+});


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add a shared `ha-app-icon` component and use it wherever Supervisor app icons are shown. This centralizes icon loading and fallback behavior while preserving the existing presentation in app pickers, the quick bar, logs, backups, app cards, and serial settings.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if your PR has no visual changes.
-->

Testing using single url change (better fix in stacked pr #53942):
<img width="1088" height="452" alt="image" src="https://github.com/user-attachments/assets/4fa18927-338e-4c35-83f3-0e055734b0eb" />

<details>
<summary>Testing</summary>

<img width="1913" height="2115" alt="image" src="https://github.com/user-attachments/assets/8e672f7b-2061-4644-8bd1-4f7427ad9789" />
<img width="1913" height="2115" alt="image" src="https://github.com/user-attachments/assets/d9f501c1-ea96-41ce-8eb0-9b59d823dcef" />
<img width="1057" height="1017" alt="image" src="https://github.com/user-attachments/assets/76f3a8db-c778-4d6a-bbd0-2ef102d2a165" />
<img width="1913" height="2115" alt="image" src="https://github.com/user-attachments/assets/76fe7df2-8e98-4f58-8a51-cd57ed845cd1" />
<img width="1737" height="766" alt="image" src="https://github.com/user-attachments/assets/e98cc467-d4e9-49ea-9a5b-660c8c7a1bfc" />
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/af4fbf8e-9b3f-422c-9f31-1deb99f8eb3e" />
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/775ca3b9-fd41-4423-80c1-e2e946bfad80" />

</details>


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
