### PR TITLE
Improve config panels type safety

### DIFF
--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -15,6 +15,7 @@ import { classMap } from "lit/directives/class-map";
 import { repeat } from "lit/directives/repeat";
 import memoizeOne from "memoize-one";
 import { ensureArray } from "../../../common/array/ensure-array";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { mainWindow } from "../../../common/dom/get_main_window";
 import { computeAreaName } from "../../../common/entity/compute_area_name";
@@ -2166,8 +2167,8 @@ class DialogAddAutomationElement
     }
   }
 
-  private _handleFilterInput = (ev: InputEvent) => {
-    this._debounceFilterChanged((ev.target as HaInputSearch).value ?? "");
+  private _handleFilterInput = (ev: HASSDomTargetEvent<HaInputSearch>) => {
+    this._debounceFilterChanged(ev.target.value ?? "");
   };
 
   private _debounceFilterChanged = debounce((value: string) => {

--- a/src/panels/config/automation/dialog-new-automation.ts
+++ b/src/panels/config/automation/dialog-new-automation.ts
@@ -10,6 +10,7 @@ import type { CSSResultGroup } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { shouldHandleRequestSelectedEvent } from "../../../common/mwc/handle-request-selected-event";
 import { stringCompare } from "../../../common/string/compare";
@@ -304,8 +305,8 @@ class DialogNewAutomation extends LitElement {
     `;
   }
 
-  private _handleSearchChange(ev: InputEvent) {
-    this._filter = (ev.target as HaInputSearch).value ?? "";
+  private _handleSearchChange(ev: HASSDomTargetEvent<HaInputSearch>) {
+    this._filter = ev.target.value ?? "";
   }
 
   private async _blueprint(ev) {

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -4,6 +4,7 @@ import type { CSSResultGroup } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import { fireEvent } from "../../../common/dom/fire_event";
 import type { WindowWithPreloads } from "../../../data/preloads";
 import type {
@@ -268,8 +269,8 @@ class DialogNewDashboard extends LitElement implements HassDialog {
     `;
   }
 
-  private _handleSearchChange(ev: InputEvent) {
-    this._filter = (ev.target as HaInputSearch).value ?? "";
+  private _handleSearchChange(ev: HASSDomTargetEvent<HaInputSearch>) {
+    this._filter = ev.target.value ?? "";
   }
 
   private _filterStrategies = memoizeOne(

--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -49,6 +49,10 @@ import "../repairs/ha-config-repairs";
 import "./ha-config-navigation";
 import "./ha-config-updates";
 
+type DashboardSummary<Key extends string, Item> = Record<Key, Item[]> & {
+  total: number;
+};
+
 const randomTip = (openFn: any, hass: HomeAssistant, narrow: boolean) => {
   const weighted: string[] = [];
   let tips = [
@@ -153,7 +157,7 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
 
   @state() private _tip?: string;
 
-  @state() private _repairsIssues: { issues: RepairsIssue[]; total: number } = {
+  @state() private _repairsIssues: DashboardSummary<"issues", RepairsIssue> = {
     issues: [],
     total: 0,
   };
@@ -383,7 +387,7 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
     (
       entities: HomeAssistant["states"],
       entityRegistry: HomeAssistant["entities"]
-    ): { updates: UpdateEntity[]; total: number } => {
+    ): DashboardSummary<"updates", UpdateEntity> => {
       const updates = filterUpdateEntitiesParameterized(
         entities,
         false,

--- a/src/panels/config/dashboard/ha-config-navigation.ts
+++ b/src/panels/config/dashboard/ha-config-navigation.ts
@@ -6,6 +6,7 @@ import memoizeOne from "memoize-one";
 import { filterNavigationPages } from "../../../common/config/filter_navigation_pages";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-next";
+import type { CloudStatus } from "../../../data/cloud";
 import { getConfigEntries } from "../../../data/config_entries";
 import type { PageNavigation } from "../../../layouts/hass-tabs-subpage";
 import {
@@ -79,7 +80,7 @@ class HaConfigNavigation extends LitElement {
           `ui.panel.config.dashboard.${page.translationKey}.main`
         ),
       description:
-        page.component === "cloud" && page.info
+        page.component === "cloud" && (page.info as CloudStatus)
           ? page.info.logged_in
             ? `
                   ${this.hass.localize(

--- a/src/panels/config/dashboard/ha-config-navigation.ts
+++ b/src/panels/config/dashboard/ha-config-navigation.ts
@@ -6,7 +6,6 @@ import memoizeOne from "memoize-one";
 import { filterNavigationPages } from "../../../common/config/filter_navigation_pages";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-next";
-import type { CloudStatus } from "../../../data/cloud";
 import { getConfigEntries } from "../../../data/config_entries";
 import type { PageNavigation } from "../../../layouts/hass-tabs-subpage";
 import {
@@ -80,7 +79,7 @@ class HaConfigNavigation extends LitElement {
           `ui.panel.config.dashboard.${page.translationKey}.main`
         ),
       description:
-        page.component === "cloud" && (page.info as CloudStatus)
+        page.component === "cloud" && page.info
           ? page.info.logged_in
             ? `
                   ${this.hass.localize(

--- a/src/panels/config/dashboard/ha-config-updates.ts
+++ b/src/panels/config/dashboard/ha-config-updates.ts
@@ -4,6 +4,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 import { consumeLocalize } from "../../../common/decorators/consume-context-entry";
+import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDeviceNameDisplay } from "../../../common/entity/compute_device_name";
 import { getDeviceArea } from "../../../common/entity/context/get_device_context";
@@ -11,6 +12,7 @@ import "../../../components/entity/state-badge";
 import "../../../components/ha-alert";
 import "../../../components/ha-icon-next";
 import "../../../components/ha-spinner";
+import type { HaListItemButton } from "../../../components/item/ha-list-item-button";
 import "../../../components/item/ha-list-item-button";
 import "../../../components/list/ha-list-base";
 import "../../../components/progress/ha-progress-ring";
@@ -152,9 +154,13 @@ class HaConfigUpdates extends LitElement {
     `;
   }
 
-  private _openMoreInfo(ev: MouseEvent): void {
+  private _openMoreInfo(
+    ev: HASSDomCurrentTargetEvent<
+      HaListItemButton & { entity_id: UpdateEntity["entity_id"] }
+    >
+  ): void {
     fireEvent(this, "hass-more-info", {
-      entityId: (ev.currentTarget as any).entity_id,
+      entityId: ev.currentTarget.entity_id,
     });
   }
 

--- a/src/panels/config/helpers/dialog-helper-detail.ts
+++ b/src/panels/config/helpers/dialog-helper-detail.ts
@@ -5,6 +5,7 @@ import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { dynamicElement } from "../../../common/dom/dynamic-element-directive";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { stringCompare } from "../../../common/string/compare";
@@ -368,9 +369,8 @@ export class DialogHelperDetail extends DirtyStateProviderMixin<
     }
   );
 
-  private async _filterChanged(e: InputEvent) {
-    const target = e.target as HaInputSearch;
-    this._filter = target.value;
+  private async _filterChanged(e: HASSDomTargetEvent<HaInputSearch>) {
+    this._filter = e.target.value;
   }
 
   private _valueChanged(ev: CustomEvent): void {

--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -7,6 +7,10 @@ import { customElement, query, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import type {
+  HASSDomCurrentTargetEvent,
+  HASSDomTargetEvent,
+} from "../../../common/dom/fire_event";
 import { fireEvent } from "../../../common/dom/fire_event";
 import {
   PROTOCOL_INTEGRATIONS,
@@ -661,16 +665,17 @@ class AddIntegrationDialog extends LitElement {
     );
   }
 
-  private async _filterChanged(ev: InputEvent) {
-    this._filter = (ev.target as HaInputSearch).value ?? "";
+  private async _filterChanged(ev: HASSDomTargetEvent<HaInputSearch>) {
+    this._filter = ev.target.value ?? "";
   }
 
-  private _integrationPicked = (ev: Event) => {
-    const listItem = ev.currentTarget as HaIntegrationListItem;
-    if (!listItem?.integration) {
+  private _integrationPicked = (
+    ev: HASSDomCurrentTargetEvent<HaIntegrationListItem>
+  ) => {
+    if (!ev.currentTarget.integration) {
       return;
     }
-    this._handleIntegrationPicked(listItem.integration);
+    this._handleIntegrationPicked(ev.currentTarget.integration);
   };
 
   private async _handleIntegrationPicked(integration: IntegrationListItem) {

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -18,6 +18,7 @@ import { customElement, property, queryAll, state } from "lit/decorators";
 import { until } from "lit/directives/until";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import { computeDeviceNameDisplay } from "../../../common/entity/compute_device_name";
 import {
   PROTOCOL_INTEGRATIONS,
@@ -1231,8 +1232,8 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
       this._filterTree(data, filter, areas)
   );
 
-  private _handleSearchChange(ev: InputEvent) {
-    this._filter = (ev.target as HaInputSearch).value ?? "";
+  private _handleSearchChange(ev: HASSDomTargetEvent<HaInputSearch>) {
+    this._filter = ev.target.value ?? "";
   }
 
   private async _handleEnableDebugLogging() {

--- a/src/panels/config/integrations/ha-config-integrations-dashboard.ts
+++ b/src/panels/config/integrations/ha-config-integrations-dashboard.ts
@@ -10,6 +10,7 @@ import { ifDefined } from "lit/directives/if-defined";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { deepActiveElement } from "../../../common/dom/deep-active-element";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import {
   PROTOCOL_INTEGRATIONS,
   protocolIntegrationPicked,
@@ -884,8 +885,8 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
     this._showDisabled = !this._showDisabled;
   }
 
-  private _handleSearchChange(ev: InputEvent) {
-    this._filter = (ev.target as HaInputSearch).value ?? "";
+  private _handleSearchChange(ev: HASSDomTargetEvent<HaInputSearch>) {
+    this._filter = ev.target.value ?? "";
     updateHistoryState({ filter: this._filter });
   }
 

--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
@@ -8,6 +8,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { relativeTime } from "../../../../../common/datetime/relative_time";
+import type { HASSDomTargetEvent } from "../../../../../common/dom/fire_event";
 import { getDeviceArea } from "../../../../../common/entity/context/get_device_context";
 import { navigate } from "../../../../../common/navigate";
 import { throttle } from "../../../../../common/util/throttle";
@@ -174,8 +175,8 @@ export class BluetoothNetworkVisualization extends LitElement {
     return attributes;
   };
 
-  private _handleSearchChange(ev: InputEvent): void {
-    this._searchFilter = (ev.target as HaInputSearch).value ?? "";
+  private _handleSearchChange(ev: HASSDomTargetEvent<HaInputSearch>): void {
+    this._searchFilter = ev.target.value ?? "";
   }
 
   private _getRssiColorVar = memoizeOne((rssi: number): string => {

--- a/src/panels/config/integrations/integration-panels/matter/matter-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/matter/matter-network-visualization.ts
@@ -9,6 +9,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { relativeTime } from "../../../../../common/datetime/relative_time";
+import type { HASSDomTargetEvent } from "../../../../../common/dom/fire_event";
 import { getDeviceArea } from "../../../../../common/entity/context/get_device_context";
 import { navigate } from "../../../../../common/navigate";
 import type { LocalizeKeys } from "../../../../../common/translations/localize";
@@ -189,8 +190,8 @@ export class MatterNetworkVisualization extends LitElement {
     ></ha-input-search>`;
   }
 
-  private _handleSearchChange(ev: InputEvent): void {
-    this._searchFilter = (ev.target as HaInputSearch).value ?? "";
+  private _handleSearchChange(ev: HASSDomTargetEvent<HaInputSearch>): void {
+    this._searchFilter = ev.target.value ?? "";
   }
 
   private async _refreshTopology(): Promise<void> {

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -6,6 +6,7 @@ import type {
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import type { HASSDomTargetEvent } from "../../../../../common/dom/fire_event";
 import { getDeviceArea } from "../../../../../common/entity/context/get_device_context";
 import { navigate } from "../../../../../common/navigate";
 import "../../../../../components/chart/ha-network-graph";
@@ -130,8 +131,8 @@ export class ZHANetworkVisualizationPage extends LitElement {
     return attributes;
   };
 
-  private _handleSearchChange(ev: InputEvent): void {
-    this._searchFilter = (ev.target as HaInputSearch).value ?? "";
+  private _handleSearchChange(ev: HASSDomTargetEvent<HaInputSearch>): void {
+    this._searchFilter = ev.target.value ?? "";
   }
 
   private _tooltipFormatter = (params: TopLevelFormatterParams) => {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
@@ -7,6 +7,7 @@ import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import type { HASSDomTargetEvent } from "../../../../../common/dom/fire_event";
 import { getDeviceArea } from "../../../../../common/entity/context/get_device_context";
 import { navigate } from "../../../../../common/navigate";
 import { debounce } from "../../../../../common/util/debounce";
@@ -218,8 +219,8 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
     return attributes;
   };
 
-  private _handleSearchChange(ev: InputEvent): void {
-    this._searchFilter = (ev.target as HaInputSearch).value ?? "";
+  private _handleSearchChange(ev: HASSDomTargetEvent<HaInputSearch>): void {
+    this._searchFilter = ev.target.value ?? "";
   }
 
   private _tooltipFormatter = (params: TopLevelFormatterParams) => {

--- a/src/panels/config/logs/ha-config-logs.ts
+++ b/src/panels/config/logs/ha-config-logs.ts
@@ -13,6 +13,7 @@ import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { atLeastVersion } from "../../../common/config/version";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import { navigate } from "../../../common/navigate";
 import { stringCompare } from "../../../common/string/compare";
 import { extractSearchParam } from "../../../common/url/search-params";
@@ -95,8 +96,8 @@ export class HaConfigLogs extends LitElement {
     this._init();
   }
 
-  private async _filterChanged(ev: InputEvent) {
-    this._filter = (ev.target as HaInputSearch).value ?? "";
+  private async _filterChanged(ev: HASSDomTargetEvent<HaInputSearch>) {
+    this._filter = ev.target.value ?? "";
   }
 
   protected render(): TemplateResult {

--- a/src/panels/config/network/ha-config-url-form.ts
+++ b/src/panels/config/network/ha-config-url-form.ts
@@ -363,18 +363,19 @@ class ConfigUrlForm extends SubscribeMixin(LitElement) {
   }
 
   private _toggleCloud(ev: HASSDomCurrentTargetEvent<HaSwitch>) {
-    this._cloudChecked = (ev.currentTarget as HaSwitch).checked;
+    this._cloudChecked = ev.currentTarget.checked;
     this._showCustomExternalUrl = !this._cloudChecked;
   }
 
   private _toggleInternalAutomatic(ev: HASSDomCurrentTargetEvent<HaSwitch>) {
-    this._showCustomInternalUrl = !(ev.currentTarget as HaSwitch).checked;
+    this._showCustomInternalUrl = !ev.currentTarget.checked;
   }
 
-  private _handleChange(ev: InputEvent) {
-    const target = ev.currentTarget as HaInputCopy;
+  private _handleChange(
+    ev: InputEvent & HASSDomCurrentTargetEvent<HaInputCopy>
+  ) {
     const input = ev.composedPath()[0] as HaInput;
-    this[`_${target.dataset.name}`] = input.value || "";
+    this[`_${ev.currentTarget.dataset.name}`] = input.value || "";
   }
 
   private async _save() {

--- a/src/panels/config/tools/event/event-subscribe-card.ts
+++ b/src/panels/config/tools/event/event-subscribe-card.ts
@@ -10,6 +10,7 @@ import type { TemplateResult, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { formatTimeWithSeconds } from "../../../../common/datetime/format_time";
+import type { HASSDomTargetEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-alert";
 import "../../../../components/ha-button";
 import "../../../../components/ha-card";
@@ -286,13 +287,13 @@ class EventSubscribeCard extends LitElement {
     this._viewedEventId = this._events[next].id;
   }
 
-  private _valueChanged(ev: InputEvent) {
-    this._eventType = (ev.target as HaInput).value ?? "";
+  private _valueChanged(ev: HASSDomTargetEvent<HaInput>) {
+    this._eventType = ev.target.value ?? "";
     this._error = undefined;
   }
 
-  private _filterChanged(ev: InputEvent) {
-    this._eventFilter = (ev.target as HaInput).value ?? "";
+  private _filterChanged(ev: HASSDomTargetEvent<HaInput>) {
+    this._eventFilter = ev.target.value ?? "";
   }
 
   private _testEventFilter(event: HassEvent): boolean {

--- a/src/panels/config/tools/state/tools-state.ts
+++ b/src/panels/config/tools/state/tools-state.ts
@@ -12,6 +12,7 @@ import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { formatDateTimeWithSeconds } from "../../../../common/datetime/format_date_time";
 import { storage } from "../../../../common/decorators/storage";
+import type { HASSDomTargetEvent } from "../../../../common/dom/fire_event";
 import { escapeRegExp } from "../../../../common/string/escape_regexp";
 import { computeAreaName } from "../../../../common/entity/compute_area_name";
 import { computeDeviceName } from "../../../../common/entity/compute_device_name";
@@ -414,28 +415,28 @@ class HaPanelDevState extends LitElement {
     this._expanded = true;
   }
 
-  private _stateChanged(ev: InputEvent) {
-    this._state = (ev.target as HaInput).value ?? "";
+  private _stateChanged(ev: HASSDomTargetEvent<HaInput>) {
+    this._state = ev.target.value ?? "";
   }
 
-  private _entityFilterChanged(ev: InputEvent) {
-    this._entityFilter = (ev.target as HaInputSearch).value ?? "";
+  private _entityFilterChanged(ev: HASSDomTargetEvent<HaInputSearch>) {
+    this._entityFilter = ev.target.value ?? "";
   }
 
-  private _stateFilterChanged(ev: InputEvent) {
-    this._stateFilter = (ev.target as HaInputSearch).value ?? "";
+  private _stateFilterChanged(ev: HASSDomTargetEvent<HaInputSearch>) {
+    this._stateFilter = ev.target.value ?? "";
   }
 
-  private _attributeFilterChanged(ev: InputEvent) {
-    this._attributeFilter = (ev.target as HaInputSearch).value ?? "";
+  private _attributeFilterChanged(ev: HASSDomTargetEvent<HaInputSearch>) {
+    this._attributeFilter = ev.target.value ?? "";
   }
 
-  private _deviceFilterChanged(ev: InputEvent) {
-    this._deviceFilter = (ev.target as HaInputSearch).value ?? "";
+  private _deviceFilterChanged(ev: HASSDomTargetEvent<HaInputSearch>) {
+    this._deviceFilter = ev.target.value ?? "";
   }
 
-  private _areaFilterChanged(ev: InputEvent) {
-    this._areaFilter = (ev.target as HaInputSearch).value ?? "";
+  private _areaFilterChanged(ev: HASSDomTargetEvent<HaInputSearch>) {
+    this._areaFilter = ev.target.value ?? "";
   }
 
   private _getHistoryURL(entityId, inputDate) {

--- a/src/panels/config/tools/statistics/tools-statistics.ts
+++ b/src/panels/config/tools/statistics/tools-statistics.ts
@@ -600,13 +600,11 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
     `;
   }
 
-  private _handleSearchChange(
-    ev: InputEvent & HASSDomTargetEvent<HaInputSearch>
-  ) {
-    if (this.filter === (ev.target as HaInputSearch).value) {
+  private _handleSearchChange(ev: HASSDomTargetEvent<HaInputSearch>) {
+    if (this.filter === ev.target.value) {
       return;
     }
-    this.filter = (ev.target as HaInputSearch).value ?? "";
+    this.filter = ev.target.value ?? "";
   }
 
   private _handleSelectionChanged(
@@ -717,9 +715,7 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
   ) {
     ev.stopPropagation();
     showStatisticsAdjustSumDialog(this, {
-      statistic: (
-        ev.currentTarget as HTMLElement & { statistic: StatisticData }
-      ).statistic,
+      statistic: ev.currentTarget.statistic,
     });
   }
 
@@ -795,9 +791,7 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
       HTMLElement & { data: StatisticsValidationResult[] }
     >
   ) => {
-    const issues = (
-      ev.currentTarget as HTMLElement & { data: StatisticsValidationResult[] }
-    ).data.sort(
+    const issues = ev.currentTarget.data.sort(
       (itemA, itemB) =>
         (FIX_ISSUES_ORDER[itemA.type] ?? 99) -
         (FIX_ISSUES_ORDER[itemB.type] ?? 99)

--- a/src/panels/config/voice-assistants/dialog-expose-entity.ts
+++ b/src/panels/config/voice-assistants/dialog-expose-entity.ts
@@ -6,6 +6,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 import memoizeOne from "memoize-one";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import { computeEntityNameList } from "../../../common/entity/compute_entity_name_display";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import { computeRTL } from "../../../common/util/compute_rtl";
@@ -172,8 +173,8 @@ class DialogExposeEntity extends DirtyStateProviderMixin<string[]>()(
     listItem.selected = !listItem.selected;
   }
 
-  private _filterChanged(e: InputEvent) {
-    this._filter = (e.target as HaInputSearch).value;
+  private _filterChanged(e: HASSDomTargetEvent<HaInputSearch>) {
+    this._filter = e.target.value;
   }
 
   private _filterEntities = memoizeOne(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Improve type safety across the config panels without changing runtime behaviour. Event handlers now express their target element types at the function boundary and access typed targets directly, removing repeated assertions and `any` usage. The dashboard summary data also uses a shared generic type, and an unnecessary cloud status assertion is removed.

No functional changes

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
