### PR TITLE
Allow shared translations for subentry abort

### DIFF
--- a/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
@@ -55,18 +55,17 @@ export const showSubConfigFlowDialog = (
     deleteFlow: deleteSubConfigFlow,
 
     renderAbortDescription(hass, step) {
-      const description =
-        hass.localize(
-          `component.${step.translation_domain || configEntry.domain}.config_subentries.${flowType}.abort.${step.reason}`,
-          step.description_placeholders
-        ) ||
-        // Shared reasons are defined once under `config`, not per subentry type
-        (step.translation_domain
-          ? hass.localize(
-              `component.${step.translation_domain}.config.abort.${step.reason}`,
-              step.description_placeholders
-            )
-          : undefined);
+      // A translation domain means the reason is shared by several integrations
+      // and is defined once under `config`, not per subentry type
+      const description = step.translation_domain
+        ? hass.localize(
+            `component.${step.translation_domain}.config.abort.${step.reason}`,
+            step.description_placeholders
+          )
+        : hass.localize(
+            `component.${configEntry.domain}.config_subentries.${flowType}.abort.${step.reason}`,
+            step.description_placeholders
+          );
 
       return description
         ? html`

--- a/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
@@ -34,6 +34,8 @@ export const showSubConfigFlowDialog = (
         hass.loadBackendTranslation("selector", configEntry.domain),
         // Used as fallback if no header defined for step
         hass.loadBackendTranslation("title", configEntry.domain),
+        // Shared abort reasons live in the homeassistant integration
+        hass.loadBackendTranslation("config", "homeassistant"),
       ]);
       return step;
     },
@@ -46,16 +48,25 @@ export const showSubConfigFlowDialog = (
         configEntry.domain
       );
       await hass.loadBackendTranslation("selector", configEntry.domain);
+      await hass.loadBackendTranslation("config", "homeassistant");
       return step;
     },
     handleFlowStep: handleSubConfigFlowStep,
     deleteFlow: deleteSubConfigFlow,
 
     renderAbortDescription(hass, step) {
-      const description = hass.localize(
-        `component.${step.translation_domain || configEntry.domain}.config_subentries.${flowType}.abort.${step.reason}`,
-        step.description_placeholders
-      );
+      const description =
+        hass.localize(
+          `component.${step.translation_domain || configEntry.domain}.config_subentries.${flowType}.abort.${step.reason}`,
+          step.description_placeholders
+        ) ||
+        // Shared reasons are defined once under `config`, not per subentry type
+        (step.translation_domain
+          ? hass.localize(
+              `component.${step.translation_domain}.config.abort.${step.reason}`,
+              step.description_placeholders
+            )
+          : undefined);
 
       return description
         ? html`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Allows the backend to use shared translations for subentry flows.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
