### PR TITLE
Add Bluetooth to the demo

### DIFF
--- a/demo/src/configs/demo-configs.ts
+++ b/demo/src/configs/demo-configs.ts
@@ -3,6 +3,7 @@ import type { MockHomeAssistant } from "../../../src/fake_data/provide_hass";
 import type { Lovelace } from "../../../src/panels/lovelace/types";
 import { setDemoAreas } from "../stubs/area_registry";
 import { energyEntities } from "../stubs/entities";
+import { connectivityEntities } from "../stubs/connectivity/fixtures";
 import { setDemoFloors } from "../stubs/floor_registry";
 import { getDemoTheme } from "../stubs/frontend";
 import type { DemoConfig, DemoTheme } from "./types";
@@ -53,6 +54,9 @@ export const setDemoConfig = async (
   setDemoAreas(hass, config.areas);
   hass.addEntities(config.entities(hass.localize), true);
   hass.addEntities(energyEntities());
+  // Replaced the whole state map above, so the entities that do not belong to a
+  // demo config have to be added back.
+  hass.addEntities(connectivityEntities());
 
   // Let the new registries and entities reach the dashboard before saving the
   // config, so dashboard strategies generate against them

--- a/demo/src/ha-demo.ts
+++ b/demo/src/ha-demo.ts
@@ -7,6 +7,12 @@ import { HomeAssistantAppEl } from "../../src/layouts/home-assistant";
 import type { HomeAssistant } from "../../src/types";
 import { applyDemoTheme, selectedDemoConfig } from "./configs/demo-configs";
 import { mockAreaRegistry, setDemoAreas } from "./stubs/area_registry";
+import {
+  connectivityCommands,
+  connectivityComponents,
+  connectivityEntities,
+  connectivityEntityRegistryEntries,
+} from "./stubs/connectivity/fixtures";
 import { mockAuth } from "./stubs/auth";
 import { demoDevices } from "./stubs/devices";
 import { mockDeviceRegistry } from "./stubs/device_registry";
@@ -60,6 +66,7 @@ const CONFIG_PANEL_COMMANDS = [
   "assist_pipeline/",
   "config/entity_registry/settings/",
   "slugify",
+  ...connectivityCommands,
 ];
 
 @customElement("ha-demo")
@@ -87,6 +94,7 @@ export class HaDemo extends HomeAssistantAppEl {
           "assist_pipeline",
           "hassio",
           "hardware",
+          ...connectivityComponents,
         ],
       },
     });
@@ -99,7 +107,7 @@ export class HaDemo extends HomeAssistantAppEl {
 
     mockLovelace(hass, localizePromise);
     mockAuth(hass);
-    mockTranslations(hass);
+    mockTranslations(hass, localizePromise);
     mockHistory(hass);
     mockRecorder(hass);
     mockTodo(hass);
@@ -172,9 +180,11 @@ export class HaDemo extends HomeAssistantAppEl {
         created_at: 0,
         modified_at: 0,
       },
+      ...connectivityEntityRegistryEntries,
     ]);
 
     hass.addEntities(energyEntities());
+    hass.addEntities(connectivityEntities());
 
     // Once config is loaded AND localize, set registries, entities and theme.
     Promise.all([selectedDemoConfig, localizePromise]).then(

--- a/demo/src/stubs/config-panel.ts
+++ b/demo/src/stubs/config-panel.ts
@@ -7,6 +7,7 @@ import { mockBlueprint } from "./blueprint";
 import { mockCloud } from "./cloud";
 import { mockConfig } from "./config";
 import { mockConfigEntries } from "./config_entries";
+import { mockConnectivity } from "./connectivity";
 import { mockDeviceAutomation } from "./device_automation";
 import { mockEntityRegistrySettings } from "./entity_registry_settings";
 import { mockEntitySources } from "./entity_sources";
@@ -26,6 +27,7 @@ export const mockConfigPanel = (hass: MockHomeAssistant) => {
   mockCloud(hass);
   mockConfig(hass);
   mockConfigEntries(hass);
+  mockConnectivity(hass);
   mockDeviceAutomation(hass);
   mockEntitySources(hass);
   mockBlueprint(hass);

--- a/demo/src/stubs/config_entries.ts
+++ b/demo/src/stubs/config_entries.ts
@@ -5,6 +5,7 @@ import type {
 import type { ConfigFlowInProgressMessage } from "../../../src/data/config_flow";
 import type { IntegrationType } from "../../../src/data/integration";
 import type { MockHomeAssistant } from "../../../src/fake_data/provide_hass";
+import { connectivityConfigEntries } from "./connectivity/fixtures";
 
 const baseEntry = {
   source: "user",
@@ -90,6 +91,7 @@ export const demoConfigEntries: {
       supports_options: true,
     },
   },
+  ...connectivityConfigEntries,
 ];
 
 const filterEntries = (filters?: {

--- a/demo/src/stubs/connectivity/bluetooth/fixtures.ts
+++ b/demo/src/stubs/connectivity/bluetooth/fixtures.ts
@@ -1,0 +1,69 @@
+import { configEntry, device } from "../helpers";
+import type { ConnectivityFixtures } from "../types";
+
+export const LOCAL_SOURCE = "00:1A:7D:DA:71:11";
+export const PROXY_SOURCE = "E8:DB:84:A1:C2:30";
+export const SHED_SOURCE = "A4:CF:12:9B:44:70";
+
+const ADAPTER_ENTRY_ID = "mock-bluetooth";
+const PROXY_LIVING_ENTRY_ID = "mock-bluetooth-proxy-living";
+const PROXY_SHED_ENTRY_ID = "mock-bluetooth-proxy-shed";
+
+export const bluetoothFixtures: ConnectivityFixtures = {
+  components: ["bluetooth"],
+  commands: ["bluetooth/"],
+  configEntries: [
+    {
+      type: "hub",
+      entry: configEntry(
+        ADAPTER_ENTRY_ID,
+        "bluetooth",
+        `hci0 (${LOCAL_SOURCE})`,
+        { source: "usb", supports_options: true }
+      ),
+    },
+    {
+      type: "hub",
+      entry: configEntry(
+        PROXY_LIVING_ENTRY_ID,
+        "bluetooth",
+        "Living room proxy",
+        { source: "esphome" }
+      ),
+    },
+    {
+      type: "hub",
+      entry: configEntry(PROXY_SHED_ENTRY_ID, "bluetooth", "Shed proxy", {
+        source: "esphome",
+      }),
+    },
+  ],
+  // Adapters and proxies are matched to their scanner by the bluetooth
+  // connection tuple, see ./mock.
+  devices: [
+    device(
+      "bluetooth-hci0",
+      "hci0",
+      "Home Assistant",
+      "Home Assistant Green",
+      ADAPTER_ENTRY_ID,
+      { connections: [["bluetooth", LOCAL_SOURCE]] }
+    ),
+    device(
+      "bluetooth-proxy-living",
+      "Living room proxy",
+      "Espressif",
+      "ESP32-C3",
+      PROXY_LIVING_ENTRY_ID,
+      { area_id: "living_room", connections: [["bluetooth", PROXY_SOURCE]] }
+    ),
+    device(
+      "bluetooth-proxy-shed",
+      "Shed proxy",
+      "Espressif",
+      "ESP32",
+      PROXY_SHED_ENTRY_ID,
+      { connections: [["bluetooth", SHED_SOURCE]] }
+    ),
+  ],
+};

--- a/demo/src/stubs/connectivity/bluetooth/fixtures.ts
+++ b/demo/src/stubs/connectivity/bluetooth/fixtures.ts
@@ -1,3 +1,4 @@
+import { manifest } from "../../manifest";
 import { configEntry, device } from "../helpers";
 import type { ConnectivityFixtures } from "../types";
 
@@ -12,6 +13,7 @@ const PROXY_SHED_ENTRY_ID = "mock-bluetooth-proxy-shed";
 export const bluetoothFixtures: ConnectivityFixtures = {
   components: ["bluetooth"],
   commands: ["bluetooth/"],
+  manifests: [manifest("bluetooth", "Bluetooth", { integration_type: "hub" })],
   configEntries: [
     {
       type: "hub",

--- a/demo/src/stubs/connectivity/bluetooth/mock.ts
+++ b/demo/src/stubs/connectivity/bluetooth/mock.ts
@@ -1,0 +1,193 @@
+import type {
+  BluetoothAllocationsData,
+  BluetoothDeviceData,
+  BluetoothScannerDetails,
+  BluetoothScannerState,
+} from "../../../../../src/data/bluetooth";
+import type { MockHomeAssistant } from "../../../../../src/fake_data/provide_hass";
+import { emitInitial } from "../subscription";
+import { LOCAL_SOURCE, PROXY_SOURCE, SHED_SOURCE } from "./fixtures";
+
+const SCANNERS: BluetoothScannerDetails[] = [
+  {
+    source: LOCAL_SOURCE,
+    connectable: true,
+    name: "hci0 (Home Assistant Green)",
+    adapter: "hci0",
+    scanner_type: "usb",
+  },
+  {
+    source: PROXY_SOURCE,
+    connectable: true,
+    name: "Living room proxy",
+    adapter: "esp32",
+    scanner_type: "remote",
+  },
+  {
+    source: SHED_SOURCE,
+    connectable: false,
+    name: "Shed proxy",
+    adapter: "esp32",
+    scanner_type: "remote",
+  },
+];
+
+const SCANNER_STATES: BluetoothScannerState[] = [
+  {
+    source: LOCAL_SOURCE,
+    adapter: "hci0",
+    current_mode: "active",
+    requested_mode: "active",
+  },
+  {
+    source: PROXY_SOURCE,
+    adapter: "esp32",
+    current_mode: "active",
+    requested_mode: "active",
+  },
+  {
+    // A proxy configured for passive scanning: it reports advertisements but
+    // cannot connect, matching its `connectable: false` scanner details.
+    source: SHED_SOURCE,
+    adapter: "esp32",
+    current_mode: "passive",
+    requested_mode: "passive",
+  },
+];
+
+const ALLOCATIONS: BluetoothAllocationsData[] = [
+  {
+    source: LOCAL_SOURCE,
+    slots: 5,
+    free: 3,
+    allocated: ["A4:C1:38:11:22:33", "E7:2E:00:B1:9A:1C"],
+  },
+  {
+    source: PROXY_SOURCE,
+    slots: 3,
+    free: 2,
+    allocated: ["FC:58:FA:12:34:56"],
+  },
+];
+
+interface DemoAdvertisement {
+  address: string;
+  name: string;
+  rssi: number;
+  source: string;
+  connectable?: boolean;
+  tx_power?: number;
+  manufacturer_data?: Record<number, string>;
+  service_data?: Record<string, string>;
+  service_uuids?: string[];
+}
+
+const ADVERTISEMENTS: DemoAdvertisement[] = [
+  {
+    address: "A4:C1:38:11:22:33",
+    name: "Govee H5075",
+    rssi: -58,
+    source: LOCAL_SOURCE,
+    manufacturer_data: { 60552: "000104a10b64" },
+    service_uuids: ["0000ec88-0000-1000-8000-00805f9b34fb"],
+  },
+  {
+    address: "E7:2E:00:B1:9A:1C",
+    name: "SwitchBot Meter",
+    rssi: -71,
+    source: LOCAL_SOURCE,
+    service_data: { "0000fd3d-0000-1000-8000-00805f9b34fb": "5400648c14" },
+    service_uuids: ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+  },
+  {
+    address: "FC:58:FA:12:34:56",
+    name: "Xiaomi LYWSD03MMC",
+    rssi: -64,
+    source: PROXY_SOURCE,
+    service_data: { "0000fe95-0000-1000-8000-00805f9b34fb": "3058590e" },
+  },
+  {
+    address: "C4:7C:8D:6A:5B:20",
+    name: "Flower care",
+    rssi: -88,
+    source: SHED_SOURCE,
+    connectable: false,
+    service_uuids: ["0000fe95-0000-1000-8000-00805f9b34fb"],
+  },
+  {
+    address: "D0:36:9A:7F:11:80",
+    name: "Tile Mate",
+    rssi: -79,
+    source: PROXY_SOURCE,
+    connectable: false,
+    service_uuids: ["0000feed-0000-1000-8000-00805f9b34fb"],
+  },
+  {
+    address: "5C:C7:C1:04:9E:2A",
+    name: "Nut Find 3",
+    rssi: -93,
+    source: SHED_SOURCE,
+    connectable: false,
+  },
+];
+
+const buildAdvertisement = (
+  advertisement: DemoAdvertisement
+): BluetoothDeviceData => ({
+  address: advertisement.address,
+  name: advertisement.name,
+  rssi: advertisement.rssi,
+  source: advertisement.source,
+  connectable: advertisement.connectable ?? true,
+  manufacturer_data: advertisement.manufacturer_data ?? {},
+  service_data: advertisement.service_data ?? {},
+  service_uuids: advertisement.service_uuids ?? [],
+  tx_power: advertisement.tx_power ?? -59,
+  time: Date.now() / 1000,
+  raw: null,
+});
+
+// Nudge the signal strength a little on every tick so the monitors and the
+// network map look alive without the rows jumping around.
+const jitter = (rssi: number) =>
+  Math.max(-99, Math.min(-30, rssi + Math.round(Math.random() * 4) - 2));
+
+export const mockBluetooth = (hass: MockHomeAssistant) => {
+  hass.mockWS("bluetooth/subscribe_scanner_details", (_msg, _hass, onChange) =>
+    emitInitial(() => onChange?.({ add: SCANNERS }))
+  );
+
+  hass.mockWS("bluetooth/subscribe_scanner_state", (_msg, _hass, onChange) =>
+    emitInitial(() => SCANNER_STATES.forEach((state) => onChange?.(state)))
+  );
+
+  hass.mockWS(
+    "bluetooth/subscribe_connection_allocations",
+    (msg: { config_entry_id?: string }, _hass, onChange) =>
+      emitInitial(() =>
+        onChange?.(
+          msg.config_entry_id
+            ? ALLOCATIONS.filter((a) => a.source === LOCAL_SOURCE)
+            : ALLOCATIONS
+        )
+      )
+  );
+
+  hass.mockWS("bluetooth/subscribe_advertisements", (_msg, _hass, onChange) => {
+    let advertisements = ADVERTISEMENTS;
+    const stopInitial = emitInitial(() =>
+      onChange?.({ add: advertisements.map(buildAdvertisement) })
+    );
+    const interval = window.setInterval(() => {
+      advertisements = advertisements.map((advertisement) => ({
+        ...advertisement,
+        rssi: jitter(advertisement.rssi),
+      }));
+      onChange?.({ change: advertisements.map(buildAdvertisement) });
+    }, 5000);
+    return () => {
+      stopInitial();
+      clearInterval(interval);
+    };
+  });
+};

--- a/demo/src/stubs/connectivity/fixtures.ts
+++ b/demo/src/stubs/connectivity/fixtures.ts
@@ -1,0 +1,38 @@
+import { bluetoothFixtures } from "./bluetooth/fixtures";
+import type { ConnectivityFixtures } from "./types";
+
+// Every integration reachable from Settings > Connectivity that has frontend
+// data to mock. Each owns its own fixtures, so they can be added and removed
+// one at a time.
+const INTEGRATIONS: ConnectivityFixtures[] = [bluetoothFixtures];
+
+const collect = <T>(
+  pick: (fixtures: ConnectivityFixtures) => T[] | undefined
+) => INTEGRATIONS.flatMap((fixtures) => pick(fixtures) ?? []);
+
+export const connectivityComponents = collect((f) => f.components);
+
+export const connectivityCommands = collect((f) => f.commands);
+
+export const connectivityConfigEntries = collect((f) => f.configEntries);
+
+export const connectivityDevices = collect((f) => f.devices);
+
+export const connectivityEntityRegistryEntries = collect(
+  (f) => f.entityRegistryEntries
+);
+
+export const connectivityEntities = () =>
+  INTEGRATIONS.flatMap((fixtures) => fixtures.entities?.() ?? []);
+
+/** Backend translation resources, merged per category. */
+export const connectivityBackendTranslations = INTEGRATIONS.reduce<
+  Record<string, Record<string, string>>
+>((resources, fixtures) => {
+  for (const [category, keys] of Object.entries(
+    fixtures.backendTranslations ?? {}
+  )) {
+    resources[category] = { ...resources[category], ...keys };
+  }
+  return resources;
+}, {});

--- a/demo/src/stubs/connectivity/fixtures.ts
+++ b/demo/src/stubs/connectivity/fixtures.ts
@@ -16,6 +16,8 @@ export const connectivityCommands = collect((f) => f.commands);
 
 export const connectivityConfigEntries = collect((f) => f.configEntries);
 
+export const connectivityManifests = collect((f) => f.manifests);
+
 export const connectivityDevices = collect((f) => f.devices);
 
 export const connectivityEntityRegistryEntries = collect(

--- a/demo/src/stubs/connectivity/helpers.ts
+++ b/demo/src/stubs/connectivity/helpers.ts
@@ -1,0 +1,129 @@
+import type { ConfigEntry } from "../../../../src/data/config_entries";
+import type { DeviceRegistryEntry } from "../../../../src/data/device/device_registry";
+import type { EntityRegistryEntry } from "../../../../src/data/entity/entity_registry";
+import type { EntityInput } from "../../../../src/fake_data/entities/types";
+
+// Builders for the registry fixtures, so each integration only spells out what
+// makes its own entries different.
+
+const BASE_CONFIG_ENTRY = {
+  source: "user",
+  state: "loaded" as const,
+  supports_options: false,
+  supports_remove_device: false,
+  supports_unload: true,
+  supports_reconfigure: true,
+  supported_subentry_types: {},
+  num_subentries: 0,
+  pref_disable_new_entities: false,
+  pref_disable_polling: false,
+  disabled_by: null,
+  reason: null,
+  error_reason_translation_domain: null,
+  error_reason_translation_key: null,
+  error_reason_translation_placeholders: null,
+};
+
+export const configEntry = (
+  entryId: string,
+  domain: string,
+  title: string,
+  extra: Partial<ConfigEntry> = {}
+): ConfigEntry => ({
+  ...BASE_CONFIG_ENTRY,
+  entry_id: entryId,
+  domain,
+  title,
+  ...extra,
+});
+
+const BASE_DEVICE = {
+  config_entries_subentries: {},
+  connections: [] as [string, string][],
+  identifiers: [] as [string, string][],
+  model_id: null,
+  labels: [] as string[],
+  sw_version: null,
+  hw_version: null,
+  serial_number: null,
+  via_device_id: null,
+  area_id: null,
+  name_by_user: null,
+  disabled_by: null,
+  configuration_url: null,
+  parent_device_id: null,
+  entry_type: null,
+  created_at: 0,
+  modified_at: 0,
+};
+
+export const device = (
+  id: string,
+  name: string,
+  manufacturer: string,
+  model: string,
+  entryId: string,
+  extra: Partial<DeviceRegistryEntry> = {}
+): DeviceRegistryEntry => ({
+  ...BASE_DEVICE,
+  id,
+  name,
+  manufacturer,
+  model,
+  config_entries: [entryId],
+  primary_config_entry: entryId,
+  ...extra,
+});
+
+const BASE_REGISTRY_ENTRY = {
+  config_subentry_id: null,
+  area_id: null,
+  disabled_by: null,
+  icon: null,
+  labels: [] as string[],
+  categories: {},
+  hidden_by: null,
+  entity_category: null,
+  options: null,
+  created_at: 0,
+  modified_at: 0,
+};
+
+export const registryEntry = (
+  entityId: string,
+  deviceId: string,
+  entryId: string,
+  platform: string,
+  name?: string
+): EntityRegistryEntry => ({
+  ...BASE_REGISTRY_ENTRY,
+  entity_id: entityId,
+  id: entityId,
+  unique_id: entityId,
+  device_id: deviceId,
+  config_entry_id: entryId,
+  platform,
+  name: name ?? null,
+  has_entity_name: name === undefined,
+});
+
+/**
+ * The demo's `addEntities` builds the display entity registry from the entity
+ * inputs, so mirror each state's registry entry onto it. Panels count entities
+ * per device and per integration.
+ */
+export const withRegistryLinks = (
+  entries: EntityRegistryEntry[],
+  states: Record<string, EntityInput>
+): EntityInput[] =>
+  Object.values(states).map((state) => {
+    const entry = entries.find(
+      (candidate) => candidate.entity_id === state.entity_id
+    );
+    return entry
+      ? { ...state, device_id: entry.device_id!, platform: entry.platform }
+      : state;
+  });
+
+export const minutesAgo = (minutes: number) =>
+  new Date(Date.now() - minutes * 60000).toISOString();

--- a/demo/src/stubs/connectivity/index.ts
+++ b/demo/src/stubs/connectivity/index.ts
@@ -1,0 +1,9 @@
+import type { MockHomeAssistant } from "../../../../src/fake_data/provide_hass";
+import { mockBluetooth } from "./bluetooth/mock";
+
+// The WebSocket mocks, code-split into the config panel chunk.
+const MOCKS = [mockBluetooth];
+
+export const mockConnectivity = (hass: MockHomeAssistant) => {
+  MOCKS.forEach((mock) => mock(hass));
+};

--- a/demo/src/stubs/connectivity/subscription.ts
+++ b/demo/src/stubs/connectivity/subscription.ts
@@ -1,0 +1,10 @@
+// Mocked WebSocket subscriptions are registered synchronously, so a callback
+// invoked straight away can land before the subscriber is ready for it: pages
+// that ignore messages received before their first render drop it, and
+// `createCollection` overwrites it with the empty initial fetch. Emitting the
+// first message from a timeout matches the real backend, which always answers
+// asynchronously.
+export const emitInitial = (send: () => void): (() => void) => {
+  const timeout = window.setTimeout(send, 0);
+  return () => clearTimeout(timeout);
+};

--- a/demo/src/stubs/connectivity/types.ts
+++ b/demo/src/stubs/connectivity/types.ts
@@ -1,0 +1,33 @@
+import type { ConfigEntry } from "../../../../src/data/config_entries";
+import type { DeviceRegistryEntry } from "../../../../src/data/device/device_registry";
+import type { EntityRegistryEntry } from "../../../../src/data/entity/entity_registry";
+import type { IntegrationType } from "../../../../src/data/integration";
+import type { TranslationCategory } from "../../../../src/data/translation";
+import type { EntityInput } from "../../../../src/fake_data/entities/types";
+
+export interface DemoConfigEntry {
+  entry: ConfigEntry;
+  type: IntegrationType;
+}
+
+/**
+ * Everything one connectivity integration contributes to the demo besides its
+ * WebSocket mocks. This is loaded eagerly, together with the registries, so it
+ * must not pull in the mocks (which are code-split into the config panel
+ * chunk). Each integration owns one of these, so they stay independent.
+ */
+export interface ConnectivityFixtures {
+  /** Components to load, so the integration's panel is reachable. */
+  components: string[];
+  /** WS command prefixes served by the integration's mock, if it has one. */
+  commands?: string[];
+  configEntries?: DemoConfigEntry[];
+  devices?: DeviceRegistryEntry[];
+  entityRegistryEntries?: EntityRegistryEntry[];
+  /** States for the entities above; built lazily so timestamps stay fresh. */
+  entities?: () => EntityInput[];
+  /** Backend translations the panel looks up, by category. */
+  backendTranslations?: Partial<
+    Record<TranslationCategory, Record<string, string>>
+  >;
+}

--- a/demo/src/stubs/connectivity/types.ts
+++ b/demo/src/stubs/connectivity/types.ts
@@ -1,7 +1,10 @@
 import type { ConfigEntry } from "../../../../src/data/config_entries";
 import type { DeviceRegistryEntry } from "../../../../src/data/device/device_registry";
 import type { EntityRegistryEntry } from "../../../../src/data/entity/entity_registry";
-import type { IntegrationType } from "../../../../src/data/integration";
+import type {
+  IntegrationManifest,
+  IntegrationType,
+} from "../../../../src/data/integration";
 import type { TranslationCategory } from "../../../../src/data/translation";
 import type { EntityInput } from "../../../../src/fake_data/entities/types";
 
@@ -22,6 +25,8 @@ export interface ConnectivityFixtures {
   /** WS command prefixes served by the integration's mock, if it has one. */
   commands?: string[];
   configEntries?: DemoConfigEntry[];
+  /** Manifests for the domains above, so their integration pages open. */
+  manifests?: IntegrationManifest[];
   devices?: DeviceRegistryEntry[];
   entityRegistryEntries?: EntityRegistryEntry[];
   /** States for the entities above; built lazily so timestamps stay fresh. */

--- a/demo/src/stubs/devices.ts
+++ b/demo/src/stubs/devices.ts
@@ -1,4 +1,5 @@
 import type { DeviceRegistryEntry } from "../../../src/data/device/device_registry";
+import { connectivityDevices } from "./connectivity/fixtures";
 
 const baseDevice = {
   config_entries_subentries: {},
@@ -86,4 +87,5 @@ export const demoDevices: DeviceRegistryEntry[] = [
     entry_type: null,
     parent_device_id: "power-strip",
   },
+  ...connectivityDevices,
 ];

--- a/demo/src/stubs/integration.ts
+++ b/demo/src/stubs/integration.ts
@@ -1,19 +1,7 @@
 import type { IntegrationManifest } from "../../../src/data/integration";
 import type { MockHomeAssistant } from "../../../src/fake_data/provide_hass";
-
-const manifest = (
-  domain: string,
-  name: string,
-  overrides: Partial<IntegrationManifest> = {}
-): IntegrationManifest => ({
-  is_built_in: true,
-  domain,
-  name,
-  config_flow: true,
-  documentation: `https://www.home-assistant.io/integrations/${domain}/`,
-  iot_class: "local_push",
-  ...overrides,
-});
+import { connectivityManifests } from "./connectivity/fixtures";
+import { manifest } from "./manifest";
 
 const manifests: IntegrationManifest[] = [
   manifest("co2signal", "Electricity Maps", { iot_class: "cloud_polling" }),
@@ -62,11 +50,18 @@ const manifests: IntegrationManifest[] = [
     integration_type: "helper",
     iot_class: "local_polling",
   }),
+  ...connectivityManifests,
 ];
 
 export const mockIntegration = (hass: MockHomeAssistant) => {
   hass.mockWS("manifest/list", () => manifests);
-  hass.mockWS("manifest/get", (msg: { integration: string }) =>
-    manifests.find((m) => m.domain === msg.integration)
+  // Never answer with undefined: the integration page reads the manifest it
+  // gets back without guarding, so an unlisted domain would throw. The real
+  // backend always has a manifest for a domain that has config entries.
+  hass.mockWS(
+    "manifest/get",
+    (msg: { integration: string }) =>
+      manifests.find((m) => m.domain === msg.integration) ??
+      manifest(msg.integration, msg.integration)
   );
 };

--- a/demo/src/stubs/manifest.ts
+++ b/demo/src/stubs/manifest.ts
@@ -1,0 +1,20 @@
+import type { IntegrationManifest } from "../../../src/data/integration";
+
+/**
+ * Builds a demo integration manifest. Lives in its own module so both the
+ * manifest registry and the per-integration fixtures that feed it can use it
+ * without importing each other.
+ */
+export const manifest = (
+  domain: string,
+  name: string,
+  overrides: Partial<IntegrationManifest> = {}
+): IntegrationManifest => ({
+  is_built_in: true,
+  domain,
+  name,
+  config_flow: true,
+  documentation: `https://www.home-assistant.io/integrations/${domain}/`,
+  iot_class: "local_push",
+  ...overrides,
+});

--- a/demo/src/stubs/translations.ts
+++ b/demo/src/stubs/translations.ts
@@ -1,7 +1,26 @@
+import type { LocalizeFunc } from "../../../src/common/translations/localize";
 import type { MockHomeAssistant } from "../../../src/fake_data/provide_hass";
+import { connectivityBackendTranslations } from "./connectivity/fixtures";
 
-export const mockTranslations = (hass: MockHomeAssistant) => {
-  hass.mockWS("frontend/get_translations", (
-    /* msg: {language: string, category: string} */
-  ) => ({ resources: {} }));
+export const mockTranslations = (
+  hass: MockHomeAssistant,
+  localizePromise?: Promise<LocalizeFunc>
+) => {
+  hass.mockWS(
+    "frontend/get_translations",
+    (msg: { language: string; category?: string }) => ({
+      resources:
+        (msg.category && connectivityBackendTranslations[msg.category]) || {},
+    })
+  );
+
+  // `hass.loadBackendTranslation` is a no-op in the mocked hass, so categories
+  // that are only requested through it never reach the WebSocket mock above.
+  // Seed every category into the resources, after the fragment translations so
+  // this merges on top of them.
+  (localizePromise ?? Promise.resolve()).then(() =>
+    hass.addTranslations(
+      Object.assign({}, ...Object.values(connectivityBackendTranslations))
+    )
+  );
 };

--- a/src/fake_data/entities/base-entity.ts
+++ b/src/fake_data/entities/base-entity.ts
@@ -29,6 +29,10 @@ export class MockBaseEntity {
 
   public areaId?: string;
 
+  public deviceId?: string;
+
+  public platform?: string;
+
   public baseAttributes: EntityAttributes;
 
   public attributes: EntityAttributes;
@@ -50,6 +54,8 @@ export class MockBaseEntity {
     this.objectId = objectId;
     this.state = input.state;
     this.areaId = input.area_id;
+    this.deviceId = input.device_id;
+    this.platform = input.platform;
     this.lastChanged = randomTime();
     this.lastUpdated = randomTime();
 

--- a/src/fake_data/entities/types.ts
+++ b/src/fake_data/entities/types.ts
@@ -13,6 +13,10 @@ export type EntityInput = Pick<
 > & {
   /** Area the entity is assigned to in the mocked entity registry */
   area_id?: string;
+  /** Device the entity belongs to in the mocked entity registry */
+  device_id?: string;
+  /** Integration that provides the entity, defaults to "demo" */
+  platform?: string;
 };
 
 /**

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -50,6 +50,12 @@ import type { EntityInput } from "./entities/types";
 const ensureArray = <T>(val: T | T[]): T[] =>
   Array.isArray(val) ? val : [val];
 
+type MockServiceCallback = (
+  data: Record<string, any> | undefined,
+  target: Record<string, any> | undefined,
+  hass: MockHomeAssistant
+) => any;
+
 type MockRestCallback = (
   hass: MockHomeAssistant,
   method: string,
@@ -79,6 +85,8 @@ export interface MockHomeAssistant extends HomeAssistant {
     ) => Awaited<ReturnType<T>>
   );
   mockAPI(path: string | RegExp, callback: MockRestCallback);
+  // Registers a service that answers with data, for `callService(..., true)`.
+  mockService(domain: string, service: string, callback: MockServiceCallback);
   // Register a loader that is run (once) the first time an unmocked WS command
   // or REST path matching `shouldLoad` is received, allowing mocks to be
   // code-split into a dynamically imported chunk. The loader registers the
@@ -190,6 +198,12 @@ export const provideHass = (
 
   const wsCommands = {};
   const restResponses: [string | RegExp, MockRestCallback][] = [];
+
+  // Services that answer with data, keyed by "<domain>.<service>". Without one
+  // registered, a call that asks for a response gets none and callers that read
+  // it straight back throw.
+  const serviceMocks: Record<string, MockServiceCallback> = {};
+  const context = { id: "mock-context", user_id: null, parent_id: null };
 
   // Optional loader to lazily register mocks on first matching unmocked command.
   let lazyMatcher: ((commandOrPath: string) => boolean) | undefined;
@@ -452,19 +466,27 @@ export const provideHass = (
     kioskMode: false,
     suspendWhenHidden: false,
     // @ts-ignore
-    async callService(domain, service, data) {
-      if (data && "entity_id" in data) {
+    async callService(domain, service, data, target, _notify, returnResponse) {
+      const mock = serviceMocks[`${domain}.${service}`];
+      if (mock) {
+        const response = await mock(data, target, hass());
+        return returnResponse ? { context, response } : { context };
+      }
+      const entityIds =
+        data && "entity_id" in data ? data.entity_id : target?.entity_id;
+      if (entityIds) {
         // eslint-disable-next-line
         console.log("Entity service call", domain, service, data);
         await Promise.all(
-          ensureArray(data.entity_id).map((ent) =>
-            entities[ent].handleService(domain, service, data)
+          ensureArray(entityIds).map((ent) =>
+            entities[ent]?.handleService(domain, service, data)
           )
         );
       } else {
         // eslint-disable-next-line
         console.log("unmocked callService", domain, service, data);
       }
+      return { context };
     },
     async callApi(method, path, parameters) {
       const findResponse = () =>
@@ -523,6 +545,9 @@ export const provideHass = (
       lazyLoader = loader;
     },
     mockAPI,
+    mockService(domain, service, callback) {
+      serviceMocks[`${domain}.${service}`] = callback;
+    },
     mockEvent(event) {
       (eventListeners[event] || []).forEach((fn) => {
         fn(event);

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -297,9 +297,10 @@ export const provideHass = (
         entity_id: ent.entityId,
         name: ent.attributes.friendly_name || undefined,
         icon: undefined,
-        platform: "demo",
+        platform: ent.platform ?? "demo",
         labels: [],
         area_id: ent.areaId,
+        device_id: ent.deviceId,
       } satisfies EntityRegistryDisplayEntry;
     });
     if (replace) {

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -474,17 +474,19 @@ export const provideHass = (
       }
       const entityIds =
         data && "entity_id" in data ? data.entity_id : target?.entity_id;
+      // The service data is optional, but the entities read straight from it.
+      const serviceData = data ?? {};
       if (entityIds) {
         // eslint-disable-next-line
-        console.log("Entity service call", domain, service, data);
+        console.log("Entity service call", domain, service, serviceData);
         await Promise.all(
           ensureArray(entityIds).map((ent) =>
-            entities[ent]?.handleService(domain, service, data)
+            entities[ent]?.handleService(domain, service, serviceData)
           )
         );
       } else {
         // eslint-disable-next-line
-        console.log("unmocked callService", domain, service, data);
+        console.log("unmocked callService", domain, service, serviceData);
       }
       return { context };
     },

--- a/test/e2e/app/src/ha-test.ts
+++ b/test/e2e/app/src/ha-test.ts
@@ -183,10 +183,9 @@ export class HaTest extends HomeAssistantAppEl {
       const protocolEntries = demoConfigEntries
         .map(({ entry }) => entry)
         .concat(
-          [
-            { entry_id: "mock-bluetooth", domain: "bluetooth" },
-            { entry_id: "mock-lovelace", domain: "lovelace" },
-          ].map((entry) => ({
+          // Bluetooth entries come from the connectivity fixtures in
+          // demoConfigEntries.
+          [{ entry_id: "mock-lovelace", domain: "lovelace" }].map((entry) => ({
             disabled_by: null,
             domain: entry.domain,
             entry_id: entry.entry_id,

--- a/test/e2e/demo.spec.ts
+++ b/test/e2e/demo.spec.ts
@@ -89,6 +89,20 @@ test.describe("Home Assistant Demo", () => {
       timeout: QUICK_TIMEOUT,
     });
 
+    // The adapter page is the one that reads the scanner details subscription.
+    // Only a local adapter gets a settings button; the two proxies are known to
+    // be remote from their scanner type, so without those details all three
+    // would render one.
+    await loadDemo(page, "/#/config/bluetooth/adapter-info");
+
+    const adapters = page.locator(
+      "bluetooth-adapter-info-page ha-md-list-item"
+    );
+    await expect(adapters).toHaveCount(3, { timeout: PANEL_TIMEOUT });
+    await expect(adapters.locator("ha-icon-button")).toHaveCount(1, {
+      timeout: QUICK_TIMEOUT,
+    });
+
     expectNoPageErrors(pageErrors);
   });
 

--- a/test/e2e/demo.spec.ts
+++ b/test/e2e/demo.spec.ts
@@ -69,6 +69,29 @@ test.describe("Home Assistant Demo", () => {
     expectNoPageErrors(pageErrors);
   });
 
+  test("Bluetooth panel renders its mocked live data", async ({ page }) => {
+    // The connectivity mocks reach the panel through two mechanisms the rest of
+    // the demo suite never exercises: they are registered lazily, on the first
+    // WS command the config panel sends, and their subscriptions emit the first
+    // message from a timeout so it lands after `createCollection` has reset its
+    // store. If either breaks, the panel still renders but stays empty.
+    await loadDemo(page, "/#/config/bluetooth");
+
+    const dashboard = page.locator("bluetooth-config-dashboard");
+    await expect(dashboard).toBeAttached({ timeout: PANEL_TIMEOUT });
+
+    // Adapters come from the config entries, connections and advertisements
+    // from the subscriptions. A count of zero means the data never arrived.
+    const rows = dashboard.locator("ha-md-list-item div[slot='headline']");
+    await expect(rows).toHaveCount(3, { timeout: PANEL_TIMEOUT });
+    // Asserted over the list as a whole so a single empty count still fails.
+    await expect(dashboard.locator("ha-md-list")).not.toHaveText(/\b0\b/, {
+      timeout: QUICK_TIMEOUT,
+    });
+
+    expectNoPageErrors(pageErrors);
+  });
+
   for (const colorScheme of ["light", "dark"] as const) {
     test(`unset theme remains light with ${colorScheme} system color scheme`, async ({
       page,


### PR DESCRIPTION
## Proposed change

The Connectivity section of the demo's settings panel is empty, because none of the integrations it links to are loaded.

This loads the `bluetooth` integration and mocks its scanner, advertisement and connection subscriptions, so the Bluetooth panel and its adapter info, connection monitor, advertisement monitor and network map all render, with three scanners (a local adapter and two ESPHome proxies) and six advertising devices whose RSSI updates live.

It also adds the scaffolding the other Settings > Connectivity panels build on, so each can be added on its own afterwards:

- A per-integration fixtures contract under `demo/src/stubs/connectivity/`, plus two registries that collect components, WS command prefixes and registry data from each integration.
- `addEntities` now carries `device_id` and `platform` into the mocked display entity registry. The panels use both to count entities per device and per integration.
- Mocked subscriptions emit their first message from a timeout. Subscribing is synchronous in the mock, so an immediate callback lands before the subscriber is ready: `createCollection` overwrote it with its empty initial fetch, and pages that ignore messages received before their first render dropped it.

## Screenshots

<!-- Screenshots to be attached. -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6PpwxkMaHCWkEFA27YnLE

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6PpwxkMaHCWkEFA27YnLE)_