### PR TITLE
Add Matter to the demo

### DIFF
--- a/demo/src/stubs/connectivity/fixtures.ts
+++ b/demo/src/stubs/connectivity/fixtures.ts
@@ -1,10 +1,14 @@
 import { bluetoothFixtures } from "./bluetooth/fixtures";
+import { matterFixtures } from "./matter/fixtures";
 import type { ConnectivityFixtures } from "./types";
 
 // Every integration reachable from Settings > Connectivity that has frontend
 // data to mock. Each owns its own fixtures, so they can be added and removed
 // one at a time.
-const INTEGRATIONS: ConnectivityFixtures[] = [bluetoothFixtures];
+const INTEGRATIONS: ConnectivityFixtures[] = [
+  bluetoothFixtures,
+  matterFixtures,
+];
 
 const collect = <T>(
   pick: (fixtures: ConnectivityFixtures) => T[] | undefined

--- a/demo/src/stubs/connectivity/index.ts
+++ b/demo/src/stubs/connectivity/index.ts
@@ -1,8 +1,9 @@
 import type { MockHomeAssistant } from "../../../../src/fake_data/provide_hass";
 import { mockBluetooth } from "./bluetooth/mock";
+import { mockMatter } from "./matter/mock";
 
 // The WebSocket mocks, code-split into the config panel chunk.
-const MOCKS = [mockBluetooth];
+const MOCKS = [mockBluetooth, mockMatter];
 
 export const mockConnectivity = (hass: MockHomeAssistant) => {
   MOCKS.forEach((mock) => mock(hass));

--- a/demo/src/stubs/connectivity/matter/fixtures.ts
+++ b/demo/src/stubs/connectivity/matter/fixtures.ts
@@ -1,0 +1,124 @@
+import { manifest } from "../../manifest";
+import {
+  configEntry,
+  device,
+  registryEntry,
+  withRegistryLinks,
+} from "../helpers";
+import type { ConnectivityFixtures } from "../types";
+
+const ENTRY_ID = "mock-matter";
+
+const DEVICES = [
+  device(
+    "matter-kitchen-light",
+    "Kitchen ceiling",
+    "Nanoleaf",
+    "Essentials A19",
+    ENTRY_ID,
+    { area_id: "kitchen", sw_version: "3.5.7" }
+  ),
+  device(
+    "matter-front-door-lock",
+    "Front door lock",
+    "Aqara",
+    "Smart Lock U100",
+    ENTRY_ID,
+    { sw_version: "1.2.0" }
+  ),
+  device("matter-office-plug", "Office plug", "Eve", "Energy", ENTRY_ID, {
+    area_id: "office",
+    sw_version: "3.2.0",
+  }),
+  device("matter-garden-sensor", "Garden sensor", "Eve", "Weather", ENTRY_ID, {
+    area_id: "garden",
+    sw_version: "3.2.1",
+  }),
+];
+
+const REGISTRY_ENTRIES = [
+  registryEntry(
+    "light.kitchen_ceiling",
+    "matter-kitchen-light",
+    ENTRY_ID,
+    "matter"
+  ),
+  registryEntry(
+    "lock.front_door",
+    "matter-front-door-lock",
+    ENTRY_ID,
+    "matter"
+  ),
+  registryEntry("switch.office_plug", "matter-office-plug", ENTRY_ID, "matter"),
+  registryEntry(
+    "sensor.office_plug_power",
+    "matter-office-plug",
+    ENTRY_ID,
+    "matter"
+  ),
+  registryEntry(
+    "sensor.garden_temperature",
+    "matter-garden-sensor",
+    ENTRY_ID,
+    "matter"
+  ),
+];
+
+export const matterFixtures: ConnectivityFixtures = {
+  components: ["matter"],
+  commands: ["matter/"],
+  manifests: [manifest("matter", "Matter", { integration_type: "hub" })],
+  configEntries: [
+    {
+      type: "hub",
+      entry: configEntry(ENTRY_ID, "matter", "Matter", {
+        supports_remove_device: true,
+      }),
+    },
+  ],
+  devices: DEVICES,
+  entityRegistryEntries: REGISTRY_ENTRIES,
+  entities: () =>
+    withRegistryLinks(REGISTRY_ENTRIES, {
+      "light.kitchen_ceiling": {
+        entity_id: "light.kitchen_ceiling",
+        state: "on",
+        attributes: {
+          friendly_name: "Kitchen ceiling",
+          supported_color_modes: ["color_temp"],
+          color_mode: "color_temp",
+          brightness: 204,
+        },
+      },
+      "lock.front_door": {
+        entity_id: "lock.front_door",
+        state: "locked",
+        attributes: { friendly_name: "Front door lock" },
+      },
+      "switch.office_plug": {
+        entity_id: "switch.office_plug",
+        state: "on",
+        attributes: { friendly_name: "Office plug" },
+      },
+      "sensor.office_plug_power": {
+        entity_id: "sensor.office_plug_power",
+        state: "42.5",
+        attributes: {
+          friendly_name: "Office plug power",
+          device_class: "power",
+          state_class: "measurement",
+          unit_of_measurement: "W",
+        },
+      },
+      "sensor.garden_temperature": {
+        entity_id: "sensor.garden_temperature",
+        state: "14.2",
+        attributes: {
+          friendly_name: "Garden temperature",
+          device_class: "temperature",
+          state_class: "measurement",
+          unit_of_measurement: "°C",
+        },
+      },
+    }),
+};

--- a/demo/src/stubs/connectivity/matter/fixtures.ts
+++ b/demo/src/stubs/connectivity/matter/fixtures.ts
@@ -19,8 +19,8 @@ const DEVICES = [
     { area_id: "kitchen", sw_version: "3.5.7" }
   ),
   device(
-    "matter-front-door-lock",
-    "Front door lock",
+    "matter-side-door-lock",
+    "Side door lock",
     "Aqara",
     "Smart Lock U100",
     ENTRY_ID,
@@ -30,7 +30,7 @@ const DEVICES = [
     area_id: "office",
     sw_version: "3.2.0",
   }),
-  device("matter-garden-sensor", "Garden sensor", "Eve", "Weather", ENTRY_ID, {
+  device("matter-patio-sensor", "Patio sensor", "Eve", "Weather", ENTRY_ID, {
     area_id: "garden",
     sw_version: "3.2.1",
   }),
@@ -43,12 +43,7 @@ const REGISTRY_ENTRIES = [
     ENTRY_ID,
     "matter"
   ),
-  registryEntry(
-    "lock.front_door",
-    "matter-front-door-lock",
-    ENTRY_ID,
-    "matter"
-  ),
+  registryEntry("lock.side_door", "matter-side-door-lock", ENTRY_ID, "matter"),
   registryEntry("switch.office_plug", "matter-office-plug", ENTRY_ID, "matter"),
   registryEntry(
     "sensor.office_plug_power",
@@ -57,8 +52,8 @@ const REGISTRY_ENTRIES = [
     "matter"
   ),
   registryEntry(
-    "sensor.garden_temperature",
-    "matter-garden-sensor",
+    "sensor.patio_temperature",
+    "matter-patio-sensor",
     ENTRY_ID,
     "matter"
   ),
@@ -90,10 +85,10 @@ export const matterFixtures: ConnectivityFixtures = {
           brightness: 204,
         },
       },
-      "lock.front_door": {
-        entity_id: "lock.front_door",
+      "lock.side_door": {
+        entity_id: "lock.side_door",
         state: "locked",
-        attributes: { friendly_name: "Front door lock" },
+        attributes: { friendly_name: "Side door lock" },
       },
       "switch.office_plug": {
         entity_id: "switch.office_plug",
@@ -110,11 +105,11 @@ export const matterFixtures: ConnectivityFixtures = {
           unit_of_measurement: "W",
         },
       },
-      "sensor.garden_temperature": {
-        entity_id: "sensor.garden_temperature",
+      "sensor.patio_temperature": {
+        entity_id: "sensor.patio_temperature",
         state: "14.2",
         attributes: {
-          friendly_name: "Garden temperature",
+          friendly_name: "Patio temperature",
           device_class: "temperature",
           state_class: "measurement",
           unit_of_measurement: "°C",

--- a/demo/src/stubs/connectivity/matter/mock.ts
+++ b/demo/src/stubs/connectivity/matter/mock.ts
@@ -10,6 +10,7 @@ import { NetworkType, NodeType } from "../../../../../src/data/matter";
 import type {
   MatterLockInfo,
   MatterLockUsersResponse,
+  SetMatterLockCredentialResult,
 } from "../../../../../src/data/matter-lock";
 import type { MockHomeAssistant } from "../../../../../src/fake_data/provide_hass";
 import { emitInitial } from "../subscription";
@@ -294,6 +295,12 @@ export const mockMatter = (hass: MockHomeAssistant) => {
   }));
   hass.mockService("matter", "set_lock_user", () => ({}));
   hass.mockService("matter", "clear_lock_user", () => ({}));
-  hass.mockService("matter", "set_lock_credential", () => ({}));
-  hass.mockService("matter", "clear_lock_credential", () => ({}));
+  // Read back straight after saving a user, unlike the two above.
+  hass.mockService("matter", "set_lock_credential", (data, target) => ({
+    [target!.entity_id]: {
+      credential_index: (data?.credential_index as number) ?? 3,
+      user_index: (data?.user_index as number) ?? LOCK_USERS.users.length + 1,
+      next_credential_index: null,
+    } satisfies SetMatterLockCredentialResult,
+  }));
 };

--- a/demo/src/stubs/connectivity/matter/mock.ts
+++ b/demo/src/stubs/connectivity/matter/mock.ts
@@ -1,0 +1,179 @@
+import type {
+  MatterNetworkTopology,
+  MatterNetworkTopologyConnection,
+  MatterNetworkTopologyNode,
+  MatterNodeDiagnostics,
+} from "../../../../../src/data/matter";
+import { NetworkType, NodeType } from "../../../../../src/data/matter";
+import type { MockHomeAssistant } from "../../../../../src/fake_data/provide_hass";
+import { emitInitial } from "../subscription";
+
+const EXT_PAN_ID = "dead00beef00cafe";
+const THREAD_NETWORK = "ha-thread";
+
+const NODES: MatterNetworkTopologyNode[] = [
+  {
+    id: "otbr",
+    kind: "border_router",
+    network_type: "thread",
+    ha_device_id: null,
+    role: "leader",
+    available: true,
+    ext_address: "f6a1c30d2b4e5f61",
+    rloc16: 0x4000,
+    ext_pan_id: EXT_PAN_ID,
+    network_name: THREAD_NETWORK,
+    host_name: "homeassistant",
+    vendor_name: "Home Assistant",
+    model_name: "OpenThread Border Router",
+  },
+  {
+    id: "wifi-ap",
+    kind: "wifi_ap",
+    network_type: "wifi",
+    ha_device_id: null,
+    available: true,
+    ssid: "Home",
+    bssid: "3c:37:86:11:22:33",
+    vendor_name: "Ubiquiti",
+    model_name: "U6 Pro",
+  },
+  {
+    id: "node-1",
+    kind: "matter",
+    network_type: "thread",
+    node_id: 1,
+    ha_device_id: "matter-kitchen-light",
+    available: true,
+    role: "router",
+    ext_address: "10a2b3c4d5e6f708",
+    rloc16: 0x8401,
+    ext_pan_id: EXT_PAN_ID,
+    network_name: THREAD_NETWORK,
+    vendor_name: "Nanoleaf",
+    model_name: "Essentials A19",
+  },
+  {
+    id: "node-2",
+    kind: "matter",
+    network_type: "thread",
+    node_id: 2,
+    ha_device_id: "matter-front-door-lock",
+    available: true,
+    role: "sleepy_end_device",
+    ext_address: "20b3c4d5e6f70819",
+    rloc16: 0x8402,
+    ext_pan_id: EXT_PAN_ID,
+    network_name: THREAD_NETWORK,
+    vendor_name: "Aqara",
+    model_name: "Smart Lock U100",
+  },
+  {
+    id: "node-3",
+    kind: "matter",
+    network_type: "wifi",
+    node_id: 3,
+    ha_device_id: "matter-office-plug",
+    available: true,
+    ssid: "Home",
+    vendor_name: "Eve",
+    model_name: "Energy",
+  },
+  {
+    id: "node-4",
+    kind: "matter",
+    network_type: "thread",
+    node_id: 4,
+    ha_device_id: "matter-garden-sensor",
+    available: false,
+    role: "end_device",
+    ext_address: "30c4d5e6f708192a",
+    rloc16: 0x8403,
+    ext_pan_id: EXT_PAN_ID,
+    network_name: THREAD_NETWORK,
+    vendor_name: "Eve",
+    model_name: "Weather",
+  },
+  {
+    id: "thread-unknown-1",
+    kind: "thread_unknown",
+    network_type: "thread",
+    available: true,
+    role: "end_device",
+    ext_address: "40d5e6f708192a3b",
+    rloc16: 0x8404,
+    ext_pan_id: EXT_PAN_ID,
+    network_name: THREAD_NETWORK,
+  },
+];
+
+const connection = (
+  source: string,
+  target: string,
+  network: string,
+  strength: MatterNetworkTopologyConnection["strength"],
+  lqi?: number,
+  rssi?: number
+): MatterNetworkTopologyConnection => ({
+  source,
+  target,
+  network,
+  strength,
+  source_to_target: { strength, lqi: lqi ?? null, rssi: rssi ?? null },
+  target_to_source: { strength, lqi: lqi ?? null, rssi: rssi ?? null },
+  via_route_table: false,
+  path_cost: null,
+});
+
+const CONNECTIONS: MatterNetworkTopologyConnection[] = [
+  connection("otbr", "node-1", "thread", "strong", 245, -42),
+  connection("otbr", "node-2", "thread", "medium", 160, -68),
+  connection("node-1", "node-4", "thread", "weak", 84, -86),
+  connection("node-1", "thread-unknown-1", "thread", "medium", 172, -63),
+  connection("wifi-ap", "node-3", "wifi", "strong", undefined, -47),
+];
+
+const TOPOLOGY: MatterNetworkTopology = {
+  collected_at: Date.now() / 1000,
+  nodes: NODES,
+  connections: CONNECTIONS,
+};
+
+const buildTopology = (): MatterNetworkTopology => ({
+  ...TOPOLOGY,
+  collected_at: Date.now() / 1000,
+});
+
+const NODE_DIAGNOSTICS: MatterNodeDiagnostics = {
+  node_id: 1,
+  network_type: NetworkType.THREAD,
+  node_type: NodeType.ROUTING_END_DEVICE,
+  network_name: THREAD_NETWORK,
+  ip_adresses: ["fd11:22:0:0:1234:5678:9abc:def0"],
+  mac_address: "10:a2:b3:c4:d5:e6",
+  available: true,
+  active_fabrics: [
+    {
+      fabric_id: 1,
+      vendor_id: 4939,
+      fabric_index: 1,
+      fabric_label: "Home Assistant",
+      vendor_name: "Home Assistant",
+    },
+  ],
+  active_fabric_index: 1,
+};
+
+export const mockMatter = (hass: MockHomeAssistant) => {
+  hass.mockWS("matter/network_topology", () => buildTopology());
+
+  hass.mockWS("matter/subscribe_network_topology", (_msg, _hass, onChange) =>
+    emitInitial(() => onChange?.(buildTopology()))
+  );
+
+  hass.mockWS("matter/node_diagnostics", () => NODE_DIAGNOSTICS);
+  hass.mockWS("matter/ping_node", () => ({
+    "fd11:22:0:0:1234:5678:9abc:def0": true,
+  }));
+  hass.mockWS("matter/interview_node", () => undefined);
+};

--- a/demo/src/stubs/connectivity/matter/mock.ts
+++ b/demo/src/stubs/connectivity/matter/mock.ts
@@ -1,4 +1,5 @@
 import type {
+  MatterCommissioningParameters,
   MatterFabricData,
   MatterNetworkTopology,
   MatterNetworkTopologyConnection,
@@ -59,7 +60,7 @@ const NODES: MatterNetworkTopologyNode[] = [
     kind: "matter",
     network_type: "thread",
     node_id: 2,
-    ha_device_id: "matter-front-door-lock",
+    ha_device_id: "matter-side-door-lock",
     available: true,
     role: "sleepy_end_device",
     ext_address: "20b3c4d5e6f70819",
@@ -85,7 +86,7 @@ const NODES: MatterNetworkTopologyNode[] = [
     kind: "matter",
     network_type: "thread",
     node_id: 4,
-    ha_device_id: "matter-garden-sensor",
+    ha_device_id: "matter-patio-sensor",
     available: false,
     role: "end_device",
     ext_address: "30c4d5e6f708192a",
@@ -216,4 +217,18 @@ export const mockMatter = (hass: MockHomeAssistant) => {
   });
 
   hass.mockWS("matter/interview_node", () => undefined);
+
+  // Actions the device page offers for an available node. Without these the
+  // dialogs behind them fail with `command_not_mocked`.
+  hass.mockWS(
+    "matter/open_commissioning_window",
+    (): MatterCommissioningParameters => ({
+      setup_pin_code: 34970112332,
+      setup_manual_code: "34970112332",
+      setup_qr_code: "MT:Y.K9042C00KA0648G00",
+    })
+  );
+  hass.mockWS("matter/remove_matter_fabric", () => undefined);
+  hass.mockWS("matter/set_wifi_credentials", () => undefined);
+  hass.mockWS("matter/set_thread", () => undefined);
 };

--- a/demo/src/stubs/connectivity/matter/mock.ts
+++ b/demo/src/stubs/connectivity/matter/mock.ts
@@ -1,4 +1,5 @@
 import type {
+  MatterFabricData,
   MatterNetworkTopology,
   MatterNetworkTopologyConnection,
   MatterNetworkTopologyNode,
@@ -144,25 +145,53 @@ const buildTopology = (): MatterNetworkTopology => ({
   collected_at: Date.now() / 1000,
 });
 
-const NODE_DIAGNOSTICS: MatterNodeDiagnostics = {
-  node_id: 1,
-  network_type: NetworkType.THREAD,
-  node_type: NodeType.ROUTING_END_DEVICE,
-  network_name: THREAD_NETWORK,
-  ip_adresses: ["fd11:22:0:0:1234:5678:9abc:def0"],
-  mac_address: "10:a2:b3:c4:d5:e6",
-  available: true,
-  active_fabrics: [
-    {
-      fabric_id: 1,
-      vendor_id: 4939,
-      fabric_index: 1,
-      fabric_label: "Home Assistant",
-      vendor_name: "Home Assistant",
-    },
-  ],
-  active_fabric_index: 1,
+const FABRICS: MatterFabricData[] = [
+  {
+    fabric_id: 1,
+    vendor_id: 4939,
+    fabric_index: 1,
+    fabric_label: "Home Assistant",
+    vendor_name: "Home Assistant",
+  },
+];
+
+const NODE_TYPE_BY_ROLE: Record<string, NodeType> = {
+  router: NodeType.ROUTING_END_DEVICE,
+  sleepy_end_device: NodeType.SLEEPY_END_DEVICE,
+  end_device: NodeType.END_DEVICE,
 };
+
+const NODES_BY_DEVICE_ID = new Map(
+  NODES.filter((node) => node.ha_device_id).map((node) => [
+    node.ha_device_id!,
+    node,
+  ])
+);
+
+const nodeIpAddress = (node: MatterNetworkTopologyNode): string =>
+  node.network_type === "thread"
+    ? `fd11:2233:4455:6677::${(node.node_id ?? 0).toString(16)}`
+    : `192.168.1.${100 + (node.node_id ?? 0)}`;
+
+// Diagnostics are derived from the topology so a device's transport,
+// availability and node type match the map. The device page reads them per
+// device, and gates its actions on `available` and `network_type`.
+const buildNodeDiagnostics = (
+  node: MatterNetworkTopologyNode
+): MatterNodeDiagnostics => ({
+  node_id: node.node_id!,
+  network_type:
+    node.network_type === "thread" ? NetworkType.THREAD : NetworkType.WIFI,
+  node_type: node.is_bridge
+    ? NodeType.BRIDGE
+    : (NODE_TYPE_BY_ROLE[node.role ?? ""] ?? NodeType.END_DEVICE),
+  network_name: node.network_name ?? node.ssid ?? undefined,
+  ip_adresses: [nodeIpAddress(node)],
+  mac_address: node.ext_address?.match(/.{2}/g)?.join(":"),
+  available: node.available !== false,
+  active_fabrics: FABRICS,
+  active_fabric_index: 1,
+});
 
 export const mockMatter = (hass: MockHomeAssistant) => {
   hass.mockWS("matter/network_topology", () => buildTopology());
@@ -171,9 +200,20 @@ export const mockMatter = (hass: MockHomeAssistant) => {
     emitInitial(() => onChange?.(buildTopology()))
   );
 
-  hass.mockWS("matter/node_diagnostics", () => NODE_DIAGNOSTICS);
-  hass.mockWS("matter/ping_node", () => ({
-    "fd11:22:0:0:1234:5678:9abc:def0": true,
-  }));
+  hass.mockWS("matter/node_diagnostics", (msg: { device_id: string }) => {
+    const node = NODES_BY_DEVICE_ID.get(msg.device_id);
+    return node
+      ? buildNodeDiagnostics(node)
+      : Promise.reject({
+          code: "node_not_found",
+          message: `No Matter node for device ${msg.device_id}`,
+        });
+  });
+
+  hass.mockWS("matter/ping_node", (msg: { device_id: string }) => {
+    const node = NODES_BY_DEVICE_ID.get(msg.device_id);
+    return node ? { [nodeIpAddress(node)]: node.available !== false } : {};
+  });
+
   hass.mockWS("matter/interview_node", () => undefined);
 };

--- a/demo/src/stubs/connectivity/matter/mock.ts
+++ b/demo/src/stubs/connectivity/matter/mock.ts
@@ -7,6 +7,10 @@ import type {
   MatterNodeDiagnostics,
 } from "../../../../../src/data/matter";
 import { NetworkType, NodeType } from "../../../../../src/data/matter";
+import type {
+  MatterLockInfo,
+  MatterLockUsersResponse,
+} from "../../../../../src/data/matter-lock";
 import type { MockHomeAssistant } from "../../../../../src/fake_data/provide_hass";
 import { emitInitial } from "../subscription";
 
@@ -194,6 +198,61 @@ const buildNodeDiagnostics = (
   active_fabric_index: 1,
 });
 
+// The backend resolves the device before acting, so both node commands answer
+// the same way when it cannot.
+const nodeNotFound = (deviceId: string) =>
+  Promise.reject({
+    code: "node_not_found",
+    message: `No Matter node for device ${deviceId}`,
+  });
+
+// The manual and QR codes below are the Matter test payload for passcode
+// 20202021 with discriminator 3840; the three have to agree.
+const COMMISSIONING_PARAMETERS: MatterCommissioningParameters = {
+  setup_pin_code: 20202021,
+  setup_manual_code: "34970112332",
+  setup_qr_code: "MT:Y.K9042C00KA0648G00",
+};
+
+const LOCK_INFO: MatterLockInfo = {
+  supports_user_management: true,
+  supported_credential_types: ["pin"],
+  max_users: 10,
+  max_pin_users: 10,
+  max_rfid_users: null,
+  max_credentials_per_user: 2,
+  min_pin_length: 4,
+  max_pin_length: 8,
+  min_rfid_length: null,
+  max_rfid_length: null,
+};
+
+const LOCK_USERS: MatterLockUsersResponse = {
+  max_users: 10,
+  users: [
+    {
+      user_index: 1,
+      user_name: "Anne",
+      user_unique_id: 1,
+      user_status: "occupied_enabled",
+      user_type: "unrestricted_user",
+      credential_rule: "single",
+      credentials: [{ type: "pin", index: 1 }],
+      next_user_index: 2,
+    },
+    {
+      user_index: 2,
+      user_name: "Cleaner",
+      user_unique_id: 2,
+      user_status: "occupied_disabled",
+      user_type: "week_day_schedule_user",
+      credential_rule: "single",
+      credentials: [{ type: "pin", index: 2 }],
+      next_user_index: null,
+    },
+  ],
+};
+
 export const mockMatter = (hass: MockHomeAssistant) => {
   hass.mockWS("matter/network_topology", () => buildTopology());
 
@@ -203,17 +262,14 @@ export const mockMatter = (hass: MockHomeAssistant) => {
 
   hass.mockWS("matter/node_diagnostics", (msg: { device_id: string }) => {
     const node = NODES_BY_DEVICE_ID.get(msg.device_id);
-    return node
-      ? buildNodeDiagnostics(node)
-      : Promise.reject({
-          code: "node_not_found",
-          message: `No Matter node for device ${msg.device_id}`,
-        });
+    return node ? buildNodeDiagnostics(node) : nodeNotFound(msg.device_id);
   });
 
   hass.mockWS("matter/ping_node", (msg: { device_id: string }) => {
     const node = NODES_BY_DEVICE_ID.get(msg.device_id);
-    return node ? { [nodeIpAddress(node)]: node.available !== false } : {};
+    return node
+      ? { [nodeIpAddress(node)]: node.available !== false }
+      : nodeNotFound(msg.device_id);
   });
 
   hass.mockWS("matter/interview_node", () => undefined);
@@ -222,13 +278,22 @@ export const mockMatter = (hass: MockHomeAssistant) => {
   // dialogs behind them fail with `command_not_mocked`.
   hass.mockWS(
     "matter/open_commissioning_window",
-    (): MatterCommissioningParameters => ({
-      setup_pin_code: 34970112332,
-      setup_manual_code: "34970112332",
-      setup_qr_code: "MT:Y.K9042C00KA0648G00",
-    })
+    () => COMMISSIONING_PARAMETERS
   );
   hass.mockWS("matter/remove_matter_fabric", () => undefined);
   hass.mockWS("matter/set_wifi_credentials", () => undefined);
   hass.mockWS("matter/set_thread", () => undefined);
+
+  // The lock device exposes "Manage lock", whose dialog reads back the response
+  // of these services.
+  hass.mockService("matter", "get_lock_info", (_data, target) => ({
+    [target!.entity_id]: LOCK_INFO,
+  }));
+  hass.mockService("matter", "get_lock_users", (_data, target) => ({
+    [target!.entity_id]: LOCK_USERS,
+  }));
+  hass.mockService("matter", "set_lock_user", () => ({}));
+  hass.mockService("matter", "clear_lock_user", () => ({}));
+  hass.mockService("matter", "set_lock_credential", () => ({}));
+  hass.mockService("matter", "clear_lock_credential", () => ({}));
 };

--- a/demo/src/stubs/connectivity/matter/mock.ts
+++ b/demo/src/stubs/connectivity/matter/mock.ts
@@ -9,6 +9,7 @@ import type {
 import { NetworkType, NodeType } from "../../../../../src/data/matter";
 import type {
   MatterLockInfo,
+  MatterLockUser,
   MatterLockUsersResponse,
   SetMatterLockCredentialResult,
 } from "../../../../../src/data/matter-lock";
@@ -228,30 +229,50 @@ const LOCK_INFO: MatterLockInfo = {
   max_rfid_length: null,
 };
 
-const LOCK_USERS: MatterLockUsersResponse = {
-  max_users: 10,
-  users: [
-    {
-      user_index: 1,
-      user_name: "Anne",
-      user_unique_id: 1,
-      user_status: "occupied_enabled",
-      user_type: "unrestricted_user",
-      credential_rule: "single",
-      credentials: [{ type: "pin", index: 1 }],
-      next_user_index: 2,
-    },
-    {
-      user_index: 2,
-      user_name: "Cleaner",
-      user_unique_id: 2,
-      user_status: "occupied_disabled",
-      user_type: "week_day_schedule_user",
-      credential_rule: "single",
-      credentials: [{ type: "pin", index: 2 }],
-      next_user_index: null,
-    },
-  ],
+const initialLockUsers = (): MatterLockUser[] => [
+  {
+    user_index: 1,
+    user_name: "Anne",
+    user_unique_id: 1,
+    user_status: "occupied_enabled",
+    user_type: "unrestricted_user",
+    credential_rule: "single",
+    credentials: [{ type: "pin", index: 1 }],
+    next_user_index: 2,
+  },
+  {
+    user_index: 2,
+    user_name: "Cleaner",
+    user_unique_id: 2,
+    user_status: "occupied_disabled",
+    user_type: "week_day_schedule_user",
+    credential_rule: "single",
+    credentials: [{ type: "pin", index: 2 }],
+    next_user_index: null,
+  },
+];
+
+// The manage dialog reloads the list after every add, edit and delete, so the
+// mocked services keep the lock's users rather than answering from a constant,
+// which would make every change look like it was reverted.
+const lockUsers = new Map<string, MatterLockUser[]>();
+
+const usersFor = (entityId: string): MatterLockUser[] => {
+  let users = lockUsers.get(entityId);
+  if (!users) {
+    users = initialLockUsers();
+    lockUsers.set(entityId, users);
+  }
+  return users;
+};
+
+// Lowest free slot, the way a lock hands out user and credential indexes.
+const nextFreeIndex = (taken: number[]): number => {
+  let index = 1;
+  while (taken.includes(index)) {
+    index += 1;
+  }
+  return index;
 };
 
 export const mockMatter = (hass: MockHomeAssistant) => {
@@ -291,16 +312,93 @@ export const mockMatter = (hass: MockHomeAssistant) => {
     [target!.entity_id]: LOCK_INFO,
   }));
   hass.mockService("matter", "get_lock_users", (_data, target) => ({
-    [target!.entity_id]: LOCK_USERS,
-  }));
-  hass.mockService("matter", "set_lock_user", () => ({}));
-  hass.mockService("matter", "clear_lock_user", () => ({}));
-  // Read back straight after saving a user, unlike the two above.
-  hass.mockService("matter", "set_lock_credential", (data, target) => ({
+    // Copied, the way a real response would be: the dialog assigns the list to
+    // reactive state, so handing back the same array leaves it unchanged and
+    // the list never rerenders.
     [target!.entity_id]: {
-      credential_index: (data?.credential_index as number) ?? 3,
-      user_index: (data?.user_index as number) ?? LOCK_USERS.users.length + 1,
-      next_credential_index: null,
-    } satisfies SetMatterLockCredentialResult,
+      max_users: LOCK_INFO.max_users!,
+      users: usersFor(target!.entity_id).map((user) => ({
+        ...user,
+        credentials: user.credentials.map((credential) => ({ ...credential })),
+      })),
+    } satisfies MatterLockUsersResponse,
   }));
+
+  // Renames the user the credential below created, or edits an existing one.
+  hass.mockService("matter", "set_lock_user", (data, target) => {
+    const user = usersFor(target!.entity_id).find(
+      (candidate) => candidate.user_index === data?.user_index
+    );
+    if (user) {
+      if (data?.user_name !== undefined) {
+        user.user_name = data.user_name;
+      }
+      if (data?.user_type !== undefined) {
+        user.user_type = data.user_type;
+      }
+      if (data?.credential_rule !== undefined) {
+        user.credential_rule = data.credential_rule;
+      }
+    }
+    return {};
+  });
+
+  hass.mockService("matter", "clear_lock_user", (data, target) => {
+    const users = usersFor(target!.entity_id);
+    const index = users.findIndex(
+      (candidate) => candidate.user_index === data?.user_index
+    );
+    if (index !== -1) {
+      users.splice(index, 1);
+    }
+    return {};
+  });
+
+  // Adding a user starts here: the credential creates it, and the dialog reads
+  // the assigned index straight back to name it.
+  hass.mockService("matter", "set_lock_credential", (data, target) => {
+    const users = usersFor(target!.entity_id);
+    const userIndex =
+      (data?.user_index as number | null | undefined) ??
+      nextFreeIndex(
+        users
+          .map((user) => user.user_index)
+          .filter((i): i is number => i !== null)
+      );
+    const credentialIndex =
+      (data?.credential_index as number | null | undefined) ??
+      nextFreeIndex(
+        users.flatMap((user) =>
+          user.credentials
+            .map((credential) => credential.index)
+            .filter((i): i is number => i !== null)
+        )
+      );
+    const credential = {
+      type: (data?.credential_type as string) ?? "pin",
+      index: credentialIndex,
+    };
+    const user = users.find((candidate) => candidate.user_index === userIndex);
+    if (user) {
+      user.credentials = [...user.credentials, credential];
+    } else {
+      users.push({
+        user_index: userIndex,
+        user_name: null,
+        user_unique_id: userIndex,
+        user_status: data?.user_status ?? "occupied_enabled",
+        user_type: data?.user_type ?? "unrestricted_user",
+        credential_rule: "single",
+        credentials: [credential],
+        next_user_index: null,
+      });
+    }
+    return {
+      [target!.entity_id]: {
+        credential_index: credentialIndex,
+        user_index: userIndex,
+        next_credential_index: null,
+      } satisfies SetMatterLockCredentialResult,
+    };
+  });
 };

--- a/src/panels/config/devices/device-detail/integration-elements/matter/device-actions.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/matter/device-actions.ts
@@ -5,6 +5,7 @@ import {
   mdiChatQuestion,
   mdiExportVariant,
 } from "@mdi/js";
+import { isComponentLoaded } from "../../../../../../common/config/is_component_loaded";
 import { navigate } from "../../../../../../common/navigate";
 import type { DeviceRegistryEntry } from "../../../../../../data/device/device_registry";
 import {
@@ -91,7 +92,10 @@ export const getMatterDeviceActions = async (
     });
   }
 
-  if (nodeDiagnostics.network_type === NetworkType.THREAD) {
+  if (
+    nodeDiagnostics.network_type === NetworkType.THREAD &&
+    isComponentLoaded(hass.config, "thread")
+  ) {
     actions.push({
       label: hass.localize(
         "ui.panel.config.matter.device_actions.view_thread_network"

--- a/test/e2e/demo.spec.ts
+++ b/test/e2e/demo.spec.ts
@@ -106,6 +106,45 @@ test.describe("Home Assistant Demo", () => {
     expectNoPageErrors(pageErrors);
   });
 
+  test("Matter panel renders its mocked topology", async ({ page }) => {
+    // Same lazily registered mocks and deferred subscription delivery as the
+    // Bluetooth test above, reached through the topology this time.
+    await loadDemo(page, "/#/config/matter");
+
+    const dashboard = page.locator("matter-config-dashboard");
+    await expect(dashboard).toBeAttached({ timeout: PANEL_TIMEOUT });
+    // Only filled in once the topology reports a node that is both a Matter
+    // device and unavailable, so it covers the fetch reaching the panel.
+    await expect(dashboard.locator("small.offline")).not.toBeEmpty({
+      timeout: PANEL_TIMEOUT,
+    });
+    // The device and entity counts come from the registries; a zero means the
+    // fixtures did not reach them.
+    await expect(dashboard.locator("ha-md-list").first()).not.toHaveText(
+      /\b0\b/,
+      { timeout: QUICK_TIMEOUT }
+    );
+
+    // The map reads the topology over a subscription rather than a fetch.
+    await loadDemo(page, "/#/config/matter/visualization");
+
+    const graph = page.locator("matter-network-visualization ha-network-graph");
+    await expect(graph).toBeAttached({ timeout: PANEL_TIMEOUT });
+    await expect
+      .poll(
+        () =>
+          graph.evaluate(
+            (element) =>
+              (element as HTMLElement & { data?: { nodes?: unknown[] } }).data
+                ?.nodes?.length ?? 0
+          ),
+        { timeout: PANEL_TIMEOUT }
+      )
+      .toBeGreaterThan(0);
+
+    expectNoPageErrors(pageErrors);
+  });
+
   for (const colorScheme of ["light", "dark"] as const) {
     test(`unset theme remains light with ${colorScheme} system color scheme`, async ({
       page,

--- a/test/e2e/demo.spec.ts
+++ b/test/e2e/demo.spec.ts
@@ -142,6 +142,35 @@ test.describe("Home Assistant Demo", () => {
       )
       .toBeGreaterThan(0);
 
+    // Diagnostics are per device: the Wi-Fi plug and the offline sensor must
+    // not report the Thread router's node. Read over the connection, because
+    // the device page only renders a subset of them.
+    const diagnostics = await page.evaluate(async () => {
+      const demo = document.querySelector("ha-demo") as HTMLElement & {
+        hass: { connection: { sendMessagePromise: (msg: unknown) => any } };
+      };
+      const read = (device_id: string) =>
+        demo.hass.connection
+          .sendMessagePromise({ type: "matter/node_diagnostics", device_id })
+          .then(
+            (result: { network_type: string; available: boolean }) =>
+              `${result.network_type}:${result.available}`,
+            () => "rejected"
+          );
+      return {
+        thread: await read("matter-kitchen-light"),
+        wifi: await read("matter-office-plug"),
+        offline: await read("matter-patio-sensor"),
+        unknown: await read("not-a-matter-device"),
+      };
+    });
+    expect(diagnostics).toEqual({
+      thread: "thread:true",
+      wifi: "wifi:true",
+      offline: "thread:false",
+      unknown: "rejected",
+    });
+
     expectNoPageErrors(pageErrors);
   });
 


### PR DESCRIPTION
## Proposed change

Loads the `matter` integration and mocks its network topology, node diagnostics and device actions, so the Matter panel and its network map render in the demo. The topology mixes Thread and Wi-Fi and includes a border router, an unknown Thread device and an offline node, so the map shows a real mesh rather than a star.

Diagnostics are derived from that same topology, so each device's node ID, transport, node type and availability match the map — the device page gates its actions on those.

Also gates the device page's "View Thread network" action on the Thread integration being loaded, matching the guard `matter-config-dashboard` already had on the same link.

Based on #53967, which carries the connectivity scaffolding.

## Screenshots

<!-- Screenshots to be attached. -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ```''https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure''```
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6PpwxkMaHCWkEFA27YnLE