### PR TITLE
Support glass break binary sensors

### DIFF
--- a/src/common/entity/get_states.ts
+++ b/src/common/entity/get_states.ts
@@ -95,6 +95,7 @@ const FIXED_DOMAIN_ATTRIBUTE_STATES = {
       "door",
       "garage_door",
       "gas",
+      "glass_break",
       "heat",
       "light",
       "lock",

--- a/src/data/device_classes.ts
+++ b/src/data/device_classes.ts
@@ -12,6 +12,7 @@ export const DOMAIN_DEVICE_CLASSES: Record<string, string[]> = {
     "door",
     "garage_door",
     "gas",
+    "glass_break",
     "heat",
     "light",
     "lock",

--- a/src/fake_data/entity_component_icons.ts
+++ b/src/fake_data/entity_component_icons.ts
@@ -465,6 +465,9 @@ export const ENTITY_COMPONENT_ICONS: Record<string, ComponentIcons> = {
         on: "mdi:alert-circle",
       },
     },
+    glass_break: {
+      default: "mdi:glass-fragile",
+    },
     heat: {
       default: "mdi:thermometer",
       state: {

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -128,6 +128,7 @@ export const OVERRIDE_DEVICE_CLASSES = {
     [
       "smoke",
       "safety",
+      "glass_break",
       "sound",
       "problem",
       "tamper",

--- a/src/panels/security/strategies/security-alerts.ts
+++ b/src/panels/security/strategies/security-alerts.ts
@@ -10,6 +10,7 @@ import type { AlertCardConfig } from "../../lovelace/cards/types";
 const DANGER_BINARY_SENSOR_DEVICE_CLASSES = [
   "carbon_monoxide",
   "gas",
+  "glass_break",
   "moisture",
   "safety",
   "smoke",

--- a/src/panels/security/strategies/security-view-strategy.ts
+++ b/src/panels/security/strategies/security-view-strategy.ts
@@ -60,6 +60,7 @@ export const securityEntityFilters: EntityFilter[] = [
       // Safety
       "carbon_monoxide",
       "gas",
+      "glass_break",
       "moisture",
       "safety",
       "smoke",

--- a/src/resources/theme/color/color.globals.ts
+++ b/src/resources/theme/color/color.globals.ts
@@ -192,6 +192,7 @@ export const colorStyles = css`
     --state-binary_sensor-battery-on-color: var(--red-color);
     --state-binary_sensor-carbon_monoxide-on-color: var(--red-color);
     --state-binary_sensor-gas-on-color: var(--red-color);
+    --state-binary_sensor-glass_break-on-color: var(--red-color);
     --state-binary_sensor-heat-on-color: var(--red-color);
     --state-binary_sensor-lock-on-color: var(--red-color);
     --state-binary_sensor-moisture-on-color: var(--red-color);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1978,6 +1978,7 @@
               "cold": "Cold",
               "connectivity": "Connectivity",
               "gas": "Gas",
+              "glass_break": "Glass break",
               "heat": "Heat",
               "light": "Light",
               "lock": "Lock",

--- a/test/common/entity/get_states.test.ts
+++ b/test/common/entity/get_states.test.ts
@@ -138,6 +138,7 @@ describe("getStates", () => {
           "door",
           "garage_door",
           "gas",
+          "glass_break",
           "heat",
           "light",
           "lock",
@@ -160,7 +161,7 @@ describe("getStates", () => {
           "window",
         ])
       );
-      expect(result.length).toBe(28);
+      expect(result.length).toBe(29);
     });
 
     it("should return media player device classes", () => {

--- a/test/panels/security/strategies/security-alerts.test.ts
+++ b/test/panels/security/strategies/security-alerts.test.ts
@@ -48,15 +48,22 @@ describe("computeSecurityAlertCardConfig", () => {
     });
   });
 
-  it("uses the entity device class for the default severity", () => {
-    const stateObj = createMockEntityState("binary_sensor.smoke", "off", {
-      device_class: "smoke",
-    });
+  it.each(["glass_break", "smoke"])(
+    "uses the %s device class for the default severity",
+    (deviceClass) => {
+      const stateObj = createMockEntityState(
+        `binary_sensor.${deviceClass}`,
+        "off",
+        {
+          device_class: deviceClass,
+        }
+      );
 
-    expect(
-      computeSecurityAlertCardConfig(stateObj, {
-        entity: "binary_sensor.smoke",
-      }).color
-    ).toBe("red");
-  });
+      expect(
+        computeSecurityAlertCardConfig(stateObj, {
+          entity: stateObj.entity_id,
+        }).color
+      ).toBe("red");
+    }
+  );
 });

--- a/test/panels/security/strategies/security-view-strategy.test.ts
+++ b/test/panels/security/strategies/security-view-strategy.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { SecurityViewStrategy } from "../../../../src/panels/security/strategies/security-view-strategy";
-import { createMockHass } from "../../../fixtures/hass";
+import {
+  isSecurityPanelEntity,
+  SecurityViewStrategy,
+} from "../../../../src/panels/security/strategies/security-view-strategy";
+import { createMockEntityState, createMockHass } from "../../../fixtures/hass";
 
 describe("security-view-strategy", () => {
+  it("includes glass break binary sensors", () => {
+    const hass = createMockHass();
+    const stateObj = createMockEntityState("binary_sensor.glass_break", "off", {
+      device_class: "glass_break",
+    });
+    hass.states[stateObj.entity_id] = stateObj;
+
+    expect(isSecurityPanelEntity(hass, stateObj)).toBe(true);
+  });
+
   it("renders active alerts as individual cards in a visible section", async () => {
     const hass = createMockHass();
     hass.config = { ...hass.config, components: [] };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Recognize the new `glass_break` binary sensor device class as security-related. Glass-break sensors are included in the Security panel and home security summary, use alert severity and active-state coloring, and appear in the Alarm group when overriding a binary sensor device class.


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Not included in this draft. The behavior requires a backend entity using the new `glass_break` device class.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/architecture/discussions/1455
- Link to documentation pull request:
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3335
- Link to backend pull request: https://github.com/home-assistant/core/pull/181332

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr