### PR TITLE
Add weather temperature overlay and dynamic total cost indicator to Energy Usage Graph

### DIFF
--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -119,7 +119,8 @@ export function getCommonOptions(
   compareEnd?: Date,
   formatTotal?: (total: number) => string,
   detailedDailyData = false,
-  yAxisFractionDigits = 1
+  yAxisFractionDigits = 1,
+  secondaryUnit?: string
 ): HaECOption {
   const suggestedPeriod = getSuggestedPeriod(start, end, detailedDailyData);
   let suggestedMax = getSuggestedMax(suggestedPeriod, end, detailedDailyData);
@@ -169,31 +170,46 @@ export function getCommonOptions(
     },
   };
 
+  const primaryYAxis = {
+    type: "value" as const,
+    name: unit,
+    nameGap: 2,
+    nameTextStyle: {
+      align: "left" as const,
+    },
+    ...createYAxisPrecisionBounds({
+      includeZero: true,
+      onFractionDigits: (digits) => {
+        currentFractionDigits = digits;
+      },
+    }),
+    axisLabel: {
+      formatter: createYAxisLabelFormatter(locale, () => currentFractionDigits),
+    },
+    splitLine: {
+      show: true,
+    },
+  };
+
   const options: HaECOption = {
     ...(suggestedPeriod === "month" ? monthTimeAxis : normalTimeAxis),
-    yAxis: {
-      type: "value",
-      name: unit,
-      nameGap: 2,
-      nameTextStyle: {
-        align: "left",
-      },
-      ...createYAxisPrecisionBounds({
-        includeZero: true,
-        onFractionDigits: (digits) => {
-          currentFractionDigits = digits;
-        },
-      }),
-      axisLabel: {
-        formatter: createYAxisLabelFormatter(
-          locale,
-          () => currentFractionDigits
-        ),
-      },
-      splitLine: {
-        show: true,
-      },
-    },
+    yAxis: secondaryUnit
+      ? [
+          primaryYAxis,
+          {
+            type: "value" as const,
+            name: secondaryUnit,
+            nameGap: 2,
+            nameTextStyle: {
+              align: "right" as const,
+            },
+            position: "right" as const,
+            splitLine: {
+              show: false,
+            },
+          },
+        ]
+      : primaryYAxis,
     grid: {
       top: 15,
       bottom: 0,
@@ -225,7 +241,8 @@ export function getCommonOptions(
                 compare,
                 showCompareYear,
                 unit,
-                formatTotal
+                formatTotal,
+                secondaryUnit
               )
             )
             .filter((s): s is TemplateResult => s !== nothing);
@@ -243,7 +260,8 @@ export function getCommonOptions(
           compare,
           showCompareYear,
           unit,
-          formatTotal
+          formatTotal,
+          secondaryUnit
         );
       },
     },
@@ -259,7 +277,8 @@ function formatTooltip(
   compare: boolean | null,
   showCompareYear: boolean,
   unit?: string,
-  formatTotal?: (total: number) => string
+  formatTotal?: (total: number) => string,
+  secondaryUnit?: string
 ): TemplateResult | typeof nothing {
   if (!params[0]?.value) {
     return nothing;
@@ -307,12 +326,18 @@ function formatTooltip(
       sumPositive += y;
       countPositive++;
     }
+    const isSecondary =
+      param.seriesId === "primary-weather-temperature" ||
+      (param as any).yAxisIndex === 1;
+    const displayUnit = isSecondary && secondaryUnit ? secondaryUnit : unit;
     rows.push(
       html`<ha-chart-tooltip-marker
           .color=${String(param.color ?? "")}
         ></ha-chart-tooltip-marker>
         ${param.seriesName}:
-        <div style="direction:ltr; display: inline;">${value} ${unit}</div>`
+        <div style="direction:ltr; display: inline;">
+          ${value} ${displayUnit}
+        </div>`
     );
   }
   if (rows.length === 0) {

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -5,7 +5,8 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import memoizeOne from "memoize-one";
-import type { BarSeriesOption } from "echarts/charts";
+import type { BarSeriesOption, LineSeriesOption } from "echarts/charts";
+import type { LineDataItemOption } from "echarts/types/src/chart/line/LineSeries";
 import type { TopLevelFormatterParams } from "echarts/types/dist/shared";
 import { getEnergyColor } from "./common/color";
 import { formatNumber } from "../../../../common/number/format_number";
@@ -27,7 +28,11 @@ import {
   validateEnergyCollectionKey,
 } from "../../../../data/energy";
 import type { Statistics, StatisticsMetaData } from "../../../../data/recorder";
-import { getStatisticLabel } from "../../../../data/recorder";
+import {
+  calculateStatisticSumGrowth,
+  fetchStatistics,
+  getStatisticLabel,
+} from "../../../../data/recorder";
 import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../../../../types";
@@ -36,6 +41,7 @@ import type { EnergyUsageGraphCardConfig } from "../types";
 import { hasConfigChanged } from "../../common/has-changed";
 import {
   type EnergyDataPoint,
+  computeStatMidpoint,
   fillDataGapsAndRoundCaps,
   generateFillBuckets,
   getCommonOptions,
@@ -88,7 +94,7 @@ export class HuiEnergyUsageGraphCard
     };
   }
 
-  @state() private _chartData: BarSeriesOption[] = [];
+  @state() private _chartData: (BarSeriesOption | LineSeriesOption)[] = [];
 
   @state() private _yAxisFractionDigits = 1;
 
@@ -103,6 +109,12 @@ export class HuiEnergyUsageGraphCard
   @state() private _compareEnd?: Date;
 
   @state() private _total?: number;
+
+  @state() private _totalCost?: number;
+
+  @state() private _weatherUnit?: string;
+
+  private _weatherRequestToken = 0;
 
   protected hassSubscribeRequiredHostProps = ["_config"];
 
@@ -144,18 +156,32 @@ export class HuiEnergyUsageGraphCard
           this._config.title
             ? html` <div class="card-header">
                 <span>${this._config.title}</span>
-                ${
-                  this._total
-                    ? html`<hui-energy-graph-chip
-                        .tooltip=${this._formatTotal(this._total)}
-                      >
-                        ${this.hass.localize(
-                          "ui.panel.lovelace.cards.energy.energy_usage_graph.total_usage",
-                          { num: formatNumber(this._total, this.hass.locale) }
-                        )}
-                      </hui-energy-graph-chip>`
-                    : nothing
-                }
+                <div class="chips">
+                  ${
+                    this._total
+                      ? html`<hui-energy-graph-chip
+                          .tooltip=${this._formatTotal(this._total)}
+                        >
+                          ${this.hass.localize(
+                            "ui.panel.lovelace.cards.energy.energy_usage_graph.total_usage",
+                            { num: formatNumber(this._total, this.hass.locale) }
+                          )}
+                        </hui-energy-graph-chip>`
+                      : nothing
+                  }
+                  ${
+                    this._totalCost !== undefined
+                      ? html`<hui-energy-graph-chip
+                          .tooltip=${this._formatTotalCost(this._totalCost)}
+                        >
+                          ${formatNumber(this._totalCost, this.hass.locale, {
+                            style: "currency",
+                            currency: this.hass.config.currency,
+                          })}
+                        </hui-energy-graph-chip>`
+                      : nothing
+                  }
+                </div>
               </div>`
             : nothing
         }
@@ -175,7 +201,8 @@ export class HuiEnergyUsageGraphCard
               this._compareStart,
               this._compareEnd,
               this._yAxisFractionDigits,
-              this._legendData
+              this._legendData,
+              this._weatherUnit
             )}
             chart-type="bar"
             .expandLegend=${this._config.expand_legend}
@@ -206,6 +233,21 @@ export class HuiEnergyUsageGraphCard
       { num: formatNumber(total, this.hass.locale) }
     );
 
+  private _formatTotalCost = (totalCost: number) =>
+    this.hass.localize(
+      "ui.panel.lovelace.cards.energy.energy_usage_graph.total_cost",
+      {
+        num: formatNumber(totalCost, this.hass.locale, {
+          style: "currency",
+          currency: this.hass.config.currency,
+        }),
+      }
+    ) ||
+    `Total ${formatNumber(totalCost, this.hass.locale, {
+      style: "currency",
+      currency: this.hass.config.currency,
+    })}`;
+
   private _createOptions = memoizeOne(
     (
       start: Date,
@@ -215,7 +257,8 @@ export class HuiEnergyUsageGraphCard
       compareStart: Date | undefined,
       compareEnd: Date | undefined,
       yAxisFractionDigits: number,
-      legendData?: CustomLegendOption["data"]
+      legendData?: CustomLegendOption["data"],
+      weatherUnit?: string
     ): HaECOption => {
       const commonOptions = getCommonOptions(
         start,
@@ -227,7 +270,8 @@ export class HuiEnergyUsageGraphCard
         compareEnd,
         this._formatTotal,
         false,
-        yAxisFractionDigits
+        yAxisFractionDigits,
+        weatherUnit
       );
       const tooltip = commonOptions.tooltip;
       const baseFormatter =
@@ -482,13 +526,219 @@ export class HuiEnergyUsageGraphCard
       )
     );
     this._yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax, true);
+
+    let totalCost = 0;
+    let hasCost = false;
+
+    const getMeterCost = (
+      energyStatId: string | null,
+      directCostStatId: string | null,
+      numberPrice: number | null | undefined
+    ): number | undefined => {
+      if (!energyStatId) return undefined;
+      let costStatId = directCostStatId;
+      if (!costStatId && energyData.info?.cost_sensors) {
+        costStatId = energyData.info.cost_sensors[energyStatId] || null;
+      }
+      if (costStatId && energyData.stats[costStatId]) {
+        const costStats = energyData.stats[costStatId];
+        const costGrowth = calculateStatisticSumGrowth(costStats);
+        if (costGrowth !== null && !isNaN(costGrowth)) {
+          return costGrowth;
+        }
+        const sumChange = costStats.reduce(
+          (acc, curr) => acc + (curr.change ?? 0),
+          0
+        );
+        return sumChange;
+      }
+      if (numberPrice !== null && numberPrice !== undefined) {
+        const energyStats = energyData.stats[energyStatId];
+        const energyGrowth = calculateStatisticSumGrowth(energyStats);
+        if (energyGrowth !== null && !isNaN(energyGrowth)) {
+          return energyGrowth * numberPrice;
+        }
+        if (energyStats) {
+          const sumChange = energyStats.reduce(
+            (acc, curr) => acc + (curr.change ?? 0),
+            0
+          );
+          return sumChange * numberPrice;
+        }
+      }
+      return undefined;
+    };
+
+    for (const source of energyData.prefs.energy_sources) {
+      if (source.type === "grid") {
+        const gridSource = source as GridSourceTypeEnergyPreference;
+        const importCost = getMeterCost(
+          gridSource.stat_energy_from,
+          gridSource.stat_cost,
+          gridSource.number_energy_price
+        );
+        if (importCost !== undefined) {
+          totalCost += importCost;
+          hasCost = true;
+        }
+
+        const exportCompensation = getMeterCost(
+          gridSource.stat_energy_to,
+          gridSource.stat_compensation,
+          gridSource.number_energy_price_export
+        );
+        if (exportCompensation !== undefined) {
+          totalCost -= exportCompensation;
+          hasCost = true;
+        }
+      }
+    }
+
+    this._totalCost = hasCost ? totalCost : undefined;
+
+    // Immediately commit the base energy datasets without waiting for supplemental weather
+    this._weatherUnit = undefined;
     this._chartData = datasets;
     this._legendData = this._getLegendData(datasets);
     this._total = this._processTotal(consumption);
+
+    const requestToken = ++this._weatherRequestToken;
+
+    let targetTempEntityId: string | undefined;
+
+    if (
+      this._config?.temperature_entity &&
+      this.hass.states[this._config.temperature_entity]
+    ) {
+      targetTempEntityId = this._config.temperature_entity;
+    } else {
+      const weatherEntityId =
+        this._config?.weather_entity ||
+        Object.keys(this.hass.states).find((eid) => eid.startsWith("weather."));
+
+      if (weatherEntityId && this.hass.entities?.[weatherEntityId]?.device_id) {
+        const deviceId = this.hass.entities[weatherEntityId].device_id;
+        const matchingEntry = Object.values(this.hass.entities).find(
+          (entry) =>
+            entry.device_id === deviceId &&
+            entry.entity_id.startsWith("sensor.") &&
+            (entry.translation_key === "temperature" ||
+              this.hass.states[entry.entity_id]?.attributes.device_class ===
+                "temperature")
+        );
+        if (matchingEntry && this.hass.states[matchingEntry.entity_id]) {
+          targetTempEntityId = matchingEntry.entity_id;
+        }
+      }
+
+      if (!targetTempEntityId) {
+        const outdoorSensor = Object.keys(this.hass.states).find(
+          (eid) =>
+            eid.startsWith("sensor.") &&
+            this.hass.states[eid]?.attributes.device_class === "temperature" &&
+            (eid.includes("outdoor") ||
+              eid.includes("outside") ||
+              (this.hass.states[eid]?.attributes.friendly_name
+                ?.toLowerCase()
+                .includes("outdoor") ??
+                false) ||
+              (this.hass.states[eid]?.attributes.friendly_name
+                ?.toLowerCase()
+                .includes("outside") ??
+                false))
+        );
+        if (outdoorSensor) {
+          targetTempEntityId = outdoorSensor;
+        }
+      }
+    }
+
+    if (targetTempEntityId && this.hass.states[targetTempEntityId]) {
+      const tempState = this.hass.states[targetTempEntityId];
+      const tempUnit =
+        (tempState.attributes.unit_of_measurement as string | undefined) ||
+        this.hass.config.unit_system.temperature ||
+        "°C";
+
+      try {
+        const period = getSuggestedPeriod(this._start, this._end);
+        const weatherStats = await fetchStatistics(
+          this.hass,
+          this._start,
+          this._end,
+          [targetTempEntityId],
+          period
+        );
+
+        if (this._weatherRequestToken !== requestToken) {
+          return;
+        }
+
+        const stats = weatherStats?.[targetTempEntityId];
+        if (stats && stats.length > 0) {
+          const weatherData: LineDataItemOption[] = [];
+          stats.forEach((stat) => {
+            const temp = stat.mean ?? stat.state;
+            if (temp !== null && temp !== undefined) {
+              const displayX = computeStatMidpoint(
+                stat.start,
+                stat.end,
+                period
+              );
+              weatherData.push({
+                value: [displayX, temp, stat.start],
+              });
+            }
+          });
+
+          if (weatherData.length > 0) {
+            const weatherColor =
+              computedStyles
+                .getPropertyValue("--energy-temperature-color")
+                .trim() ||
+              computedStyles
+                .getPropertyValue("--state-climate-heat-color")
+                .trim() ||
+              computedStyles.getPropertyValue("--warning-color").trim() ||
+              "#ff7b00";
+
+            const weatherSeries: LineSeriesOption = {
+              id: "primary-weather-temperature",
+              name:
+                this.hass.localize(
+                  "ui.panel.lovelace.cards.energy.energy_usage_graph.outdoor_temperature"
+                ) || "Outdoor temperature",
+              type: "line",
+              yAxisIndex: 1,
+              smooth: true,
+              showSymbol: false,
+              lineStyle: {
+                width: 2.5,
+                color: weatherColor,
+              },
+              itemStyle: {
+                color: weatherColor,
+              },
+              data: weatherData,
+            };
+
+            this._weatherUnit = tempUnit;
+            const allDatasets: (BarSeriesOption | LineSeriesOption)[] = [
+              ...datasets,
+              weatherSeries,
+            ];
+            this._chartData = allDatasets;
+            this._legendData = this._getLegendData(allDatasets);
+          }
+        }
+      } catch {
+        // Silently ignore supplemental weather fetching failure
+      }
+    }
   }
 
   private _getLegendData(
-    datasets: BarSeriesOption[]
+    datasets: (BarSeriesOption | LineSeriesOption)[]
   ): CustomLegendOption["data"] {
     // Each main series gets a legend item, and its matching compare
     // series (if any) is attached as a secondary id so toggling
@@ -501,7 +751,9 @@ export class HuiEnergyUsageGraphCard
     return datasets
       .filter(
         (dataset) =>
-          dataset.id && !(dataset.id as string).startsWith("compare-")
+          dataset.id &&
+          dataset.id !== "compare-placeholder" &&
+          !(dataset.id as string).startsWith("compare-")
       )
       .map((dataset) => {
         const id = dataset.id as string;
@@ -694,6 +946,11 @@ export class HuiEnergyUsageGraphCard
       justify-content: space-between;
       align-items: center;
       padding-bottom: 0;
+    }
+    .chips {
+      display: flex;
+      gap: 8px;
+      align-items: center;
     }
     .content {
       padding: 16px;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -194,6 +194,8 @@ export interface EnergyUsageGraphCardConfig extends EnergyCardConfig {
   type: "energy-usage-graph";
   show_legend?: boolean;
   expand_legend?: boolean;
+  temperature_entity?: string;
+  weather_entity?: string;
 }
 
 export interface EnergySolarGraphCardConfig extends EnergyCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
@@ -60,6 +60,17 @@ const SCHEMA: HaFormSchema[] = [
     selector: { boolean: {} },
   },
   {
+    name: "temperature_entity",
+    visible: { field: "type", value: "energy-usage-graph" },
+    required: false,
+    selector: {
+      entity: {
+        domain: "sensor",
+        device_class: "temperature",
+      },
+    },
+  },
+  {
     type: "string",
     name: "collection_key",
     required: false,
@@ -88,6 +99,8 @@ const cardConfigStruct = assign(
     show_legend: optional(boolean()),
     expand_legend: optional(boolean()),
     link_dashboard: optional(boolean()),
+    temperature_entity: optional(string()),
+    weather_entity: optional(string()),
   })
 );
 
@@ -158,6 +171,12 @@ export class HuiEnergyGraphCardEditor
       case "show_legend":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.power-sources-graph.${schema.name}`
+        );
+      case "temperature_entity":
+        return (
+          this.hass!.localize(
+            `ui.panel.lovelace.editor.card.energy-usage-graph.${schema.name}`
+          ) || "Temperature entity"
         );
       default:
         return this.hass!.localize(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9327,6 +9327,8 @@
             "energy_usage_graph": {
               "total_consumed": "Total {num} kWh",
               "total_usage": "{num} kWh",
+              "total_cost": "Total {num}",
+              "outdoor_temperature": "Outdoor temperature",
               "combined_from_grid": "Grid",
               "consumed_solar": "Solar",
               "consumed_battery": "Battery",
@@ -10130,7 +10132,8 @@
             },
             "energy-usage-graph": {
               "name": "Energy usage graph",
-              "description": "This card shows the amount of energy your house has consumed, and from what source this energy came."
+              "description": "This card shows the amount of energy your house has consumed, and from what source this energy came.",
+              "temperature_entity": "Temperature entity"
             },
             "energy-solar-graph": {
               "name": "Solar production graph",

--- a/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
+++ b/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "vitest";
+import { render } from "lit";
 import type { BarSeriesOption, LineSeriesOption } from "echarts/charts";
 
 import {
@@ -6,6 +7,7 @@ import {
   fillDataGapsAndRoundCaps,
   fillLineGaps,
   generateFillBuckets,
+  getCommonOptions,
   getCompareTransform,
   getPeriodMidpointOffset,
   getSuggestedMax,
@@ -1062,5 +1064,153 @@ describe("splitUntrackedConsumption", () => {
     splitUntrackedConsumption(usedTotal, deviceTotal);
     assert.deepEqual(usedTotal, usedCopy);
     assert.deepEqual(deviceTotal, deviceCopy);
+  });
+});
+
+describe("getCommonOptions secondaryUnit", () => {
+  const dummyLocale: any = {
+    language: "en",
+    number_format: "language",
+    time_format: "language",
+    date_format: "language",
+    first_weekday: "language",
+    time_zone: "local",
+  };
+  const dummyConfig: any = {
+    currency: "USD",
+    unit_system: {
+      temperature: "°F",
+      length: "mi",
+      mass: "lb",
+      pressure: "psi",
+      volume: "gal",
+      wind_speed: "mph",
+      accumulated_precipitation: "in",
+    },
+  };
+  const start = new Date("2026-08-30T00:00:00.000Z");
+  const end = new Date("2026-08-30T23:59:59.000Z");
+
+  it("returns single primary yAxis when secondaryUnit is omitted", () => {
+    const options = getCommonOptions(
+      start,
+      end,
+      dummyLocale,
+      dummyConfig,
+      "kWh"
+    );
+    assert.isObject(options.yAxis);
+    assert.isFalse(Array.isArray(options.yAxis));
+    assert.equal((options.yAxis as any).name, "kWh");
+  });
+
+  it("returns dual yAxes array when secondaryUnit is provided", () => {
+    const options = getCommonOptions(
+      start,
+      end,
+      dummyLocale,
+      dummyConfig,
+      "kWh",
+      undefined,
+      undefined,
+      undefined,
+      false,
+      1,
+      "°F"
+    );
+    assert.isArray(options.yAxis);
+    const axes = options.yAxis as any[];
+    assert.equal(axes.length, 2);
+    assert.equal(axes[0].name, "kWh");
+    assert.equal(axes[1].name, "°F");
+    assert.equal(axes[1].position, "right");
+    assert.isFalse(axes[1].splitLine.show);
+  });
+
+  it("formats mixed bar and temperature series with respective primary and secondary units in tooltip", () => {
+    const options = getCommonOptions(
+      start,
+      end,
+      dummyLocale,
+      dummyConfig,
+      "kWh",
+      undefined,
+      undefined,
+      undefined,
+      false,
+      1,
+      "°F"
+    );
+
+    assert.isFunction((options.tooltip as any)?.formatter);
+    const formatter = (options.tooltip as any).formatter as (
+      ...args: any[]
+    ) => any;
+
+    const barParam = {
+      seriesId: "grid-consumption",
+      seriesName: "Grid consumption",
+      componentSubType: "bar",
+      value: [start.getTime(), 4.25, start.toISOString()],
+      color: "#0000ff",
+    };
+
+    const tempParam = {
+      seriesId: "primary-weather-temperature",
+      seriesName: "Outdoor temperature",
+      componentSubType: "line",
+      yAxisIndex: 1,
+      value: [start.getTime(), 72.5, start.toISOString()],
+      color: "#ff7b00",
+    };
+
+    const tooltipResult = formatter([barParam, tempParam]);
+    assert.isNotNull(tooltipResult);
+
+    const container = document.createElement("div");
+    render(tooltipResult, container);
+
+    const text = container.textContent || "";
+    assert.include(text, "Grid consumption");
+    assert.include(text, "4.25 kWh");
+    assert.include(text, "Outdoor temperature");
+    assert.include(text, "72.5 °F");
+  });
+
+  it("formats secondary unit for any series with yAxisIndex === 1", () => {
+    const options = getCommonOptions(
+      start,
+      end,
+      dummyLocale,
+      dummyConfig,
+      "kWh",
+      undefined,
+      undefined,
+      undefined,
+      false,
+      1,
+      "°C"
+    );
+
+    const formatter = (options.tooltip as any).formatter as (
+      ...args: any[]
+    ) => any;
+
+    const customSeriesParam = {
+      seriesId: "custom-sensor",
+      seriesName: "Ambient sensor",
+      componentSubType: "line",
+      yAxisIndex: 1,
+      value: [start.getTime(), 21.4, start.toISOString()],
+      color: "#ff0000",
+    };
+
+    const tooltipResult = formatter([customSeriesParam]);
+    const container = document.createElement("div");
+    render(tooltipResult, container);
+
+    const text = container.textContent || "";
+    assert.include(text, "Ambient sensor");
+    assert.include(text, "21.4 °C");
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR introduces two enhancements to the **Electricity Usage** card (`hui-energy-usage-graph-card`) on the Energy dashboard:

1. **Weather Overlay with Secondary Y-Axis**:
   - Automatically resolves outdoor temperature statistics associated with the configured weather entity via entity registry device lookup (`this.hass.entities[weatherEntityId].device_id`), or an explicitly configured `temperature_entity` (configurable via card editor UI).
   - Renders a smooth spline curve (`--energy-temperature-color`, falling back to climate heat / warning color) plotted on a secondary right-aligned Y-axis (`°F` or `°C`).
   - Supplemental weather statistics are requested asynchronously with request-generation tokens and do not block initial graph rendering.
   - Automatically aligns data points with bar midpoints (`computeStatMidpoint`) and integrates temperature values into the hover tooltip using the secondary unit.
   - **Graceful degradation**: If no weather/temperature sensor or statistics are present, the card seamlessly omits the line series and secondary axis with zero impact on existing functionality.

2. **Period-Synced Total Cost Indicator Chip**:
   - Evaluates configured grid energy sources and dynamically computes the period's net cost from cost statistics (`stat_cost`, `cost_sensors`) or fixed rates (`number_energy_price`), while factoring in export compensation (`stat_to` / `stat_compensation` / `number_energy_price_export`) matching `hui-energy-sources-table-card.ts`.
   - Displays a dedicated `<hui-energy-graph-chip>` in the card header displaying the localized currency amount (e.g. `$7.12` on day view, `$267.85` on month view, or negative credit for net exporters).
   - **Graceful degradation**: Automatically omitted if no cost sensors or price rates are configured.

3. **Multi-Axis Options & Test Coverage (`energy-chart-options.ts`)**:
   - Extended `getCommonOptions()` to support optional `secondaryUnit` and dual Y-axis formatting.
   - Added unit test cases verifying dual-axis shape and mixed bar/temperature tooltip formatting.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
**Day View (Hourly electricity usage with weather overlay & cost chip):**
* Shows hourly electricity bars, `$7.12` total cost chip alongside `81.53 kWh`, and outdoor temperature spline with right-hand `°F` axis (`0 - 120 °F`).
<img width="1392" height="698" alt="image" src="https://github.com/user-attachments/assets/5073ffc6-658d-4f48-abf7-6a3f3cf5252e" />

**Month View (Daily electricity usage with monthly weather trend & cost chip):**
* Shows daily electricity bars, `$267.85` total cost chip alongside `2,607.6 kWh`, and daily mean temperature spline with right-hand `°F` axis (`0 - 100 °F`).
<img width="1398" height="689" alt="image" src="https://github.com/user-attachments/assets/4d0b9de8-ef1e-43f6-b8c9-bbf4c7678731" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Supersedes and squashes PR #53915 into a single clean commit rebased on current dev.
- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
