### PR TITLE
Add dynamic period cost indicator chip to Energy Usage Graph

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -27,7 +27,10 @@ import {
   validateEnergyCollectionKey,
 } from "../../../../data/energy";
 import type { Statistics, StatisticsMetaData } from "../../../../data/recorder";
-import { getStatisticLabel } from "../../../../data/recorder";
+import {
+  calculateStatisticSumGrowth,
+  getStatisticLabel,
+} from "../../../../data/recorder";
 import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../../../../types";
@@ -104,6 +107,8 @@ export class HuiEnergyUsageGraphCard
 
   @state() private _total?: number;
 
+  @state() private _totalCost?: number;
+
   protected hassSubscribeRequiredHostProps = ["_config"];
 
   public hassSubscribe(): UnsubscribeFunc[] {
@@ -144,6 +149,18 @@ export class HuiEnergyUsageGraphCard
           this._config.title
             ? html` <div class="card-header">
                 <span>${this._config.title}</span>
+                ${
+                  this._totalCost !== undefined
+                    ? html`<hui-energy-graph-chip
+                        .tooltip=${this._formatTotalCost(this._totalCost)}
+                      >
+                        ${formatNumber(this._totalCost, this.hass.locale, {
+                          style: "currency",
+                          currency: this.hass.config.currency!,
+                        })}
+                      </hui-energy-graph-chip>`
+                    : nothing
+                }
                 ${
                   this._total
                     ? html`<hui-energy-graph-chip
@@ -199,6 +216,21 @@ export class HuiEnergyUsageGraphCard
       </ha-card>
     `;
   }
+
+  private _formatTotalCost = (totalCost: number) =>
+    this.hass.localize(
+      "ui.panel.lovelace.cards.energy.energy_usage_graph.total_cost",
+      {
+        num: formatNumber(totalCost, this.hass.locale, {
+          style: "currency",
+          currency: this.hass.config.currency!,
+        }),
+      }
+    ) ||
+    `Total ${formatNumber(totalCost, this.hass.locale, {
+      style: "currency",
+      currency: this.hass.config.currency!,
+    })}`;
 
   private _formatTotal = (total: number) =>
     this.hass.localize(
@@ -482,6 +514,75 @@ export class HuiEnergyUsageGraphCard
       )
     );
     this._yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax, true);
+
+    let totalCost = 0;
+    let hasCost = false;
+
+    const getMeterCost = (
+      energyStatId: string | null,
+      directCostStatId: string | null,
+      numberPrice: number | null | undefined
+    ): number | undefined => {
+      if (!energyStatId) return undefined;
+      let costStatId = directCostStatId;
+      if (!costStatId && energyData.info?.cost_sensors) {
+        costStatId = energyData.info.cost_sensors[energyStatId] || null;
+      }
+      if (costStatId && energyData.stats[costStatId]) {
+        const costStats = energyData.stats[costStatId];
+        const costGrowth = calculateStatisticSumGrowth(costStats);
+        if (costGrowth !== null && !isNaN(costGrowth)) {
+          return costGrowth;
+        }
+        const sumChange = costStats.reduce(
+          (acc, curr) => acc + (curr.change ?? 0),
+          0
+        );
+        return sumChange;
+      }
+      if (numberPrice !== null && numberPrice !== undefined) {
+        const energyStats = energyData.stats[energyStatId];
+        const energyGrowth = calculateStatisticSumGrowth(energyStats);
+        if (energyGrowth !== null && !isNaN(energyGrowth)) {
+          return energyGrowth * numberPrice;
+        }
+        if (energyStats) {
+          const sumChange = energyStats.reduce(
+            (acc, curr) => acc + (curr.change ?? 0),
+            0
+          );
+          return sumChange * numberPrice;
+        }
+      }
+      return undefined;
+    };
+
+    for (const source of energyData.prefs.energy_sources) {
+      if (source.type === "grid") {
+        const gridSource = source as GridSourceTypeEnergyPreference;
+        const importCost = getMeterCost(
+          gridSource.stat_energy_from,
+          gridSource.stat_cost,
+          gridSource.number_energy_price
+        );
+        if (importCost !== undefined) {
+          totalCost += importCost;
+          hasCost = true;
+        }
+
+        const exportCompensation = getMeterCost(
+          gridSource.stat_energy_to,
+          gridSource.stat_compensation,
+          gridSource.number_energy_price_export
+        );
+        if (exportCompensation !== undefined) {
+          totalCost -= exportCompensation;
+          hasCost = true;
+        }
+      }
+    }
+
+    this._totalCost = hasCost ? totalCost : undefined;
     this._chartData = datasets;
     this._legendData = this._getLegendData(datasets);
     this._total = this._processTotal(consumption);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9327,6 +9327,7 @@
             "energy_usage_graph": {
               "total_consumed": "Total {num} kWh",
               "total_usage": "{num} kWh",
+              "total_cost": "Total {num}",
               "combined_from_grid": "Grid",
               "consumed_solar": "Solar",
               "consumed_battery": "Battery",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR introduces a **Period Cost Indicator Chip** to the **Electricity Usage** card (`hui-energy-usage-graph-card`) on the Energy dashboard:

- **Net Grid Cost Calculation**: Evaluates configured grid energy sources and dynamically computes the period's net cost from cost statistics (`stat_cost`, `cost_sensors`) or fixed rates (`number_energy_price`).
- **Export Compensation**: Properly accounts for export compensation (`stat_energy_to`, `stat_compensation`, or `number_energy_price_export`) matching the calculation in `hui-energy-sources-table-card.ts`, allowing solar net exporters to see their net cost or earnings/credit for the selected period.
- **Card Header Chip**: Displays a dedicated `<hui-energy-graph-chip>` in the card header alongside the total usage chip, formatted with the user's localized currency (e.g. `$7.12` on day view, `$267.85` on month view).
- **Graceful degradation**: Automatically omitted if no cost sensors or price rates are configured.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
**Day View with Total Cost Chip alongside Total Usage:**
<img width="1392" height="698" alt="Day view cost chip" src="https://github.com/user-attachments/assets/5073ffc6-658d-4f48-abf7-6a3f3cf5252e" />

**Month View with Total Cost Chip alongside Total Usage:**
<img width="1398" height="689" alt="Month view cost chip" src="https://github.com/user-attachments/assets/4d0b9de8-ef1e-43f6-b8c9-bbf4c7678731" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
