### PR TITLE
Add weather temperature overlay with secondary axis to Energy Usage Graph

### DIFF
--- a/src/components/chart/chart-sonification.ts
+++ b/src/components/chart/chart-sonification.ts
@@ -256,21 +256,17 @@ export const sonifyChart = async (
     return null;
   }
   const xAxis = ensureArray(chartOptions.xAxis)?.[0] as XAXisOption | undefined;
-  const yAxis = ensureArray(chartOptions.yAxis)?.[0] as YAXisOption | undefined;
+  const yAxes = ensureArray(chartOptions.yAxis) as (YAXisOption | undefined)[];
+  const yAxis = yAxes?.[0];
+  const yAxis2 = yAxes?.[1];
 
   // Chart2Music throws while validating a group with no points, which is what
   // placeholder, legend-hidden and all-null series turn into, so only offer it
-  // the series carrying points it can read. Additionally exclude series mapped to
-  // secondary axes (yAxisIndex > 0) because Chart2Music announces all series
-  // using yAxis[0]'s unit.
+  // the series carrying points it can read.
   const allSeries = ensureArray(chartOptions.series) as (
     HaECSeriesItem | undefined
   )[];
-  const readable = allSeries.filter(
-    (s) =>
-      (!s || !("yAxisIndex" in s) || !s.yAxisIndex) &&
-      countNumericPoints(s?.data, 1)
-  );
+  const readable = allSeries.filter((s) => countNumericPoints(s?.data, 1));
   // A single point is not navigable, so it does not earn a focus stop either.
   if (countNavigablePoints(readable) < MIN_NAVIGABLE_POINTS) {
     return null;
@@ -308,6 +304,12 @@ export const sonifyChart = async (
       (isHorizontal ? xAxis?.name : yAxis?.name) ||
       localize("ui.components.history_charts.value"),
   };
+  const y2 =
+    !isHorizontal && yAxis2
+      ? {
+          label: yAxis2.name || localize("ui.components.history_charts.value"),
+        }
+      : undefined;
 
   let connection: ReturnType<typeof connect>;
   try {
@@ -319,7 +321,11 @@ export const sonifyChart = async (
         ? locale.language
         : "en",
       errorCallback: options.onError,
-      axes: { x, y },
+      axes: {
+        x,
+        y,
+        ...(y2 ? { y2 } : {}),
+      },
     });
   } catch (err) {
     options.onError(err instanceof Error ? err.message : String(err));

--- a/src/components/chart/chart-sonification.ts
+++ b/src/components/chart/chart-sonification.ts
@@ -260,25 +260,45 @@ export const sonifyChart = async (
   const yAxis = yAxes?.[0];
   const yAxis2 = yAxes?.[1];
 
+  const isTimeAxis = xAxis?.type === "time";
+  const isHorizontal = xAxis?.type === "value" && yAxis?.type === "category";
+
+  const isAxisVisible = (axis?: YAXisOption): boolean =>
+    Boolean(axis && axis.show !== false);
+
+  const hasSecondaryAxis = !isHorizontal && isAxisVisible(yAxis2);
+  const y2 = hasSecondaryAxis
+    ? {
+        label: yAxis2!.name || localize("ui.components.history_charts.value"),
+      }
+    : undefined;
+
+  const isSecondarySeries = (s: HaECSeriesItem | undefined): boolean =>
+    Boolean(
+      s &&
+      "yAxisIndex" in s &&
+      typeof s.yAxisIndex === "number" &&
+      s.yAxisIndex > 0
+    );
+
   // Chart2Music throws while validating a group with no points, which is what
   // placeholder, legend-hidden and all-null series turn into, so only offer it
-  // the series carrying points it can read.
+  // the series carrying points it can read. If a secondary axis is missing or hidden,
+  // exclude secondary-axis series so they are not announced under yAxis[0]'s unit.
   const allSeries = ensureArray(chartOptions.series) as (
     HaECSeriesItem | undefined
   )[];
-  const readable = allSeries.filter((s) => countNumericPoints(s?.data, 1));
+  const readable = allSeries.filter(
+    (s) =>
+      (hasSecondaryAxis || !isSecondarySeries(s)) &&
+      countNumericPoints(s?.data, 1)
+  );
   // A single point is not navigable, so it does not earn a focus stop either.
   if (countNavigablePoints(readable) < MIN_NAVIGABLE_POINTS) {
     return null;
   }
   const seriesIndex = readable.map((s) => allSeries.indexOf(s));
 
-  // Chart2Music always reads out an axis label, and the extension picks the wrong
-  // axis to name when there is no category axis, so label both explicitly. On a
-  // horizontal chart the announced x is the category from the y axis and the
-  // announced y is the value from the x axis, so the sources swap.
-  const isTimeAxis = xAxis?.type === "time";
-  const isHorizontal = xAxis?.type === "value" && yAxis?.type === "category";
   const valueLabels = buildValueLabels(
     isHorizontal ? yAxis : xAxis,
     readable[0],
@@ -304,12 +324,6 @@ export const sonifyChart = async (
       (isHorizontal ? xAxis?.name : yAxis?.name) ||
       localize("ui.components.history_charts.value"),
   };
-  const y2 =
-    !isHorizontal && yAxis2
-      ? {
-          label: yAxis2.name || localize("ui.components.history_charts.value"),
-        }
-      : undefined;
 
   let connection: ReturnType<typeof connect>;
   try {

--- a/src/components/chart/chart-sonification.ts
+++ b/src/components/chart/chart-sonification.ts
@@ -260,11 +260,17 @@ export const sonifyChart = async (
 
   // Chart2Music throws while validating a group with no points, which is what
   // placeholder, legend-hidden and all-null series turn into, so only offer it
-  // the series carrying points it can read.
+  // the series carrying points it can read. Additionally exclude series mapped to
+  // secondary axes (yAxisIndex > 0) because Chart2Music announces all series
+  // using yAxis[0]'s unit.
   const allSeries = ensureArray(chartOptions.series) as (
     HaECSeriesItem | undefined
   )[];
-  const readable = allSeries.filter((s) => countNumericPoints(s?.data, 1));
+  const readable = allSeries.filter(
+    (s) =>
+      (!s || !("yAxisIndex" in s) || !s.yAxisIndex) &&
+      countNumericPoints(s?.data, 1)
+  );
   // A single point is not navigable, so it does not earn a focus stop either.
   if (countNavigablePoints(readable) < MIN_NAVIGABLE_POINTS) {
     return null;

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -337,9 +337,19 @@ export class HaChartBase extends LitElement {
       this._sonificationUnavailable = false;
       // The connection is built from the series that had data at the time, so
       // drop it and let the next focus rebuild it against the current set.
+      const oldData = changedProps.get("data") as typeof this.data | undefined;
+      const seriesTopologyChanged = Boolean(
+        oldData &&
+        (oldData.length !== this.data.length ||
+          oldData.some(
+            (s, i) =>
+              (s as HaECSeriesItem)?.id !== (this.data[i] as HaECSeriesItem)?.id
+          ))
+      );
       if (
         this._sonification &&
         (changedProps.has("_hiddenDatasets") ||
+          seriesTopologyChanged ||
           !canSonifyChart(this.data, this._hiddenDatasets))
       ) {
         this._disposeSonification();
@@ -347,6 +357,20 @@ export class HaChartBase extends LitElement {
     }
     if (changedProps.has("options")) {
       chartOptions = { ...chartOptions, ...this._createOptions() };
+      const oldOptions = changedProps.get("options") as HaECOption | undefined;
+      const axesTopologyChanged = Boolean(
+        oldOptions &&
+        (ensureArray(oldOptions.yAxis).length !==
+          ensureArray(this.options?.yAxis).length ||
+          ensureArray(oldOptions.yAxis).some(
+            (axis, i) =>
+              axis?.show !== ensureArray(this.options?.yAxis)[i]?.show ||
+              axis?.name !== ensureArray(this.options?.yAxis)[i]?.name
+          ))
+      );
+      if (this._sonification && axesTopologyChanged) {
+        this._disposeSonification();
+      }
       if (
         this._compareCustomLegendOptions(
           changedProps.get("options"),

--- a/src/components/ha-selector/ha-selector-statistic.ts
+++ b/src/components/ha-selector/ha-selector-statistic.ts
@@ -24,6 +24,8 @@ export class HaStatisticSelector extends LitElement {
     if (!this.selector.statistic.multiple) {
       return html`<ha-statistic-picker
         .hass=${this.hass}
+        .includeDeviceClass=${this.selector.statistic.device_class}
+        .statisticTypes=${this.selector.statistic.statistic_types}
         .value=${this.value}
         .label=${this.label}
         .helper=${this.helper}
@@ -37,6 +39,7 @@ export class HaStatisticSelector extends LitElement {
       ${this.label ? html`<label>${this.label}</label>` : ""}
       <ha-statistics-picker
         .hass=${this.hass}
+        .includeDeviceClass=${this.selector.statistic.device_class}
         .value=${this.value}
         .helper=${this.helper}
         .disabled=${this.disabled}

--- a/src/components/ha-selector/ha-selector-statistic.ts
+++ b/src/components/ha-selector/ha-selector-statistic.ts
@@ -40,6 +40,7 @@ export class HaStatisticSelector extends LitElement {
       <ha-statistics-picker
         .hass=${this.hass}
         .includeDeviceClass=${this.selector.statistic.device_class}
+        .statisticTypes=${this.selector.statistic.statistic_types}
         .value=${this.value}
         .helper=${this.helper}
         .disabled=${this.disabled}

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -329,6 +329,7 @@ export interface StatisticSelector {
   statistic: {
     device_class?: string;
     multiple?: boolean;
+    statistic_types?: "mean" | "sum";
   };
 }
 

--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -335,9 +335,7 @@ function formatTooltip(
     const value = formatNumber(
       y,
       locale,
-      !isSecondary && y < 0.1 && y > 0
-        ? { maximumFractionDigits: 3 }
-        : undefined
+      !isSecondary && y < 0.1 ? { maximumFractionDigits: 3 } : undefined
     );
     if (!isSecondary && value === "0") {
       continue;

--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -119,7 +119,9 @@ export function getCommonOptions(
   compareEnd?: Date,
   formatTotal?: (total: number) => string,
   detailedDailyData = false,
-  yAxisFractionDigits = 1
+  yAxisFractionDigits = 1,
+  secondaryUnit?: string,
+  secondarySeriesIds?: string[]
 ): HaECOption {
   const suggestedPeriod = getSuggestedPeriod(start, end, detailedDailyData);
   let suggestedMax = getSuggestedMax(suggestedPeriod, end, detailedDailyData);
@@ -169,36 +171,53 @@ export function getCommonOptions(
     },
   };
 
+  const primaryYAxis: any = {
+    type: "value",
+    name: unit,
+    nameGap: 2,
+    nameTextStyle: {
+      align: "left",
+    },
+    ...createYAxisPrecisionBounds({
+      includeZero: true,
+      onFractionDigits: (digits) => {
+        currentFractionDigits = digits;
+      },
+    }),
+    axisLabel: {
+      formatter: createYAxisLabelFormatter(locale, () => currentFractionDigits),
+    },
+    splitLine: {
+      show: true,
+    },
+  };
+
+  const secondaryYAxis: any = secondaryUnit
+    ? {
+        type: "value",
+        name: secondaryUnit,
+        nameGap: 2,
+        nameTextStyle: {
+          align: "right",
+        },
+        position: "right",
+        splitLine: {
+          show: false,
+        },
+        axisLabel: {
+          formatter: createYAxisLabelFormatter(locale, () => 0),
+        },
+      }
+    : undefined;
+
   const options: HaECOption = {
     ...(suggestedPeriod === "month" ? monthTimeAxis : normalTimeAxis),
-    yAxis: {
-      type: "value",
-      name: unit,
-      nameGap: 2,
-      nameTextStyle: {
-        align: "left",
-      },
-      ...createYAxisPrecisionBounds({
-        includeZero: true,
-        onFractionDigits: (digits) => {
-          currentFractionDigits = digits;
-        },
-      }),
-      axisLabel: {
-        formatter: createYAxisLabelFormatter(
-          locale,
-          () => currentFractionDigits
-        ),
-      },
-      splitLine: {
-        show: true,
-      },
-    },
+    yAxis: secondaryYAxis ? [primaryYAxis, secondaryYAxis] : primaryYAxis,
     grid: {
       top: 15,
       bottom: 0,
       left: 1,
-      right: 1,
+      right: secondaryYAxis ? 12 : 1,
       containLabel: true,
     },
     tooltip: {
@@ -225,7 +244,9 @@ export function getCommonOptions(
                 compare,
                 showCompareYear,
                 unit,
-                formatTotal
+                formatTotal,
+                secondaryUnit,
+                secondarySeriesIds
               )
             )
             .filter((s): s is TemplateResult => s !== nothing);
@@ -243,7 +264,9 @@ export function getCommonOptions(
           compare,
           showCompareYear,
           unit,
-          formatTotal
+          formatTotal,
+          secondaryUnit,
+          secondarySeriesIds
         );
       },
     },
@@ -259,7 +282,9 @@ function formatTooltip(
   compare: boolean | null,
   showCompareYear: boolean,
   unit?: string,
-  formatTotal?: (total: number) => string
+  formatTotal?: (total: number) => string,
+  secondaryUnit?: string,
+  secondarySeriesIds?: string[]
 ): TemplateResult | typeof nothing {
   if (!params[0]?.value) {
     return nothing;
@@ -307,12 +332,20 @@ function formatTooltip(
       sumPositive += y;
       countPositive++;
     }
+    const isSecondary =
+      param.seriesId === "primary-weather-temperature" ||
+      (secondarySeriesIds &&
+        param.seriesId &&
+        secondarySeriesIds.includes(param.seriesId));
+    const displayUnit = isSecondary && secondaryUnit ? secondaryUnit : unit;
     rows.push(
       html`<ha-chart-tooltip-marker
           .color=${String(param.color ?? "")}
         ></ha-chart-tooltip-marker>
         ${param.seriesName}:
-        <div style="direction:ltr; display: inline;">${value} ${unit}</div>`
+        <div style="direction:ltr; display: inline;">
+          ${value} ${displayUnit}
+        </div>`
     );
   }
   if (rows.length === 0) {

--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -192,32 +192,42 @@ export function getCommonOptions(
     },
   };
 
-  const secondaryYAxis: any = secondaryUnit
-    ? {
-        type: "value",
-        name: secondaryUnit,
-        nameGap: 2,
-        nameTextStyle: {
-          align: "right",
-        },
-        position: "right",
-        splitLine: {
-          show: false,
-        },
-        axisLabel: {
-          formatter: createYAxisLabelFormatter(locale, () => 0),
-        },
-      }
-    : undefined;
+  let secondaryFractionDigits = 0;
+  const secondaryYAxis: any = {
+    type: "value",
+    show: Boolean(secondaryUnit),
+    name: secondaryUnit ?? "",
+    nameGap: 2,
+    nameTextStyle: {
+      align: "right",
+    },
+    position: "right",
+    splitLine: {
+      show: false,
+    },
+    ...createYAxisPrecisionBounds({
+      includeZero: false,
+      unit: secondaryUnit,
+      onFractionDigits: (digits) => {
+        secondaryFractionDigits = digits;
+      },
+    }),
+    axisLabel: {
+      formatter: createYAxisLabelFormatter(
+        locale,
+        () => secondaryFractionDigits
+      ),
+    },
+  };
 
   const options: HaECOption = {
     ...(suggestedPeriod === "month" ? monthTimeAxis : normalTimeAxis),
-    yAxis: secondaryYAxis ? [primaryYAxis, secondaryYAxis] : primaryYAxis,
+    yAxis: [primaryYAxis, secondaryYAxis],
     grid: {
       top: 15,
       bottom: 0,
       left: 1,
-      right: secondaryYAxis ? 12 : 1,
+      right: secondaryUnit ? 12 : 1,
       containLabel: true,
     },
     tooltip: {
@@ -317,12 +327,19 @@ function formatTooltip(
   const rows: TemplateResult[] = [];
   for (const param of params) {
     const y = param.value?.[1] as number;
+    const isSecondary =
+      param.seriesId === "primary-weather-temperature" ||
+      (secondarySeriesIds &&
+        param.seriesId &&
+        secondarySeriesIds.includes(param.seriesId));
     const value = formatNumber(
       y,
       locale,
-      y < 0.1 ? { maximumFractionDigits: 3 } : undefined
+      !isSecondary && y < 0.1 && y > 0
+        ? { maximumFractionDigits: 3 }
+        : undefined
     );
-    if (value === "0") {
+    if (!isSecondary && value === "0") {
       continue;
     }
     // Only the positive bars (consumption) are summed into a total. Negative
@@ -332,11 +349,6 @@ function formatTooltip(
       sumPositive += y;
       countPositive++;
     }
-    const isSecondary =
-      param.seriesId === "primary-weather-temperature" ||
-      (secondarySeriesIds &&
-        param.seriesId &&
-        secondarySeriesIds.includes(param.seriesId));
     const displayUnit = isSecondary && secondaryUnit ? secondaryUnit : unit;
     rows.push(
       html`<ha-chart-tooltip-marker

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -33,6 +33,7 @@ import type {
 } from "../../../../data/recorder";
 import {
   fetchStatistics,
+  getDisplayUnit,
   getStatisticLabel,
   getStatisticMetadata,
   statisticsMetaHasType,
@@ -534,17 +535,20 @@ export class HuiEnergyUsageGraphCard
 
     try {
       let targetTempEntityId: string | undefined;
+      let targetTempMetadata: StatisticsMetaData | undefined;
       if (this._config?.temperature_entity) {
-        if (this.hass.states[this._config.temperature_entity]) {
-          const statsMeta = await getStatisticMetadata(this.hass, [
-            this._config.temperature_entity,
-          ]);
-          if (this._weatherRequestToken !== requestToken || !this.isConnected) {
-            return;
-          }
-          if (statsMeta.some((meta) => statisticsMetaHasType(meta, "mean"))) {
-            targetTempEntityId = this._config.temperature_entity;
-          }
+        const statsMeta = await getStatisticMetadata(this.hass, [
+          this._config.temperature_entity,
+        ]);
+        if (this._weatherRequestToken !== requestToken || !this.isConnected) {
+          return;
+        }
+        const meta = statsMeta.find(
+          (m) => m.statistic_id === this._config!.temperature_entity
+        );
+        if (meta && statisticsMetaHasType(meta, "mean")) {
+          targetTempEntityId = this._config.temperature_entity;
+          targetTempMetadata = meta;
         }
       } else if (this._config?.weather_entity) {
         const weatherEntity = this.hass.entities?.[this._config.weather_entity];
@@ -600,6 +604,9 @@ export class HuiEnergyUsageGraphCard
             }
             if (primarySibling) {
               targetTempEntityId = primarySibling.entity_id;
+              targetTempMetadata = statsMeta.find(
+                (m) => m.statistic_id === primarySibling!.entity_id
+              );
             }
           }
         }
@@ -609,9 +616,8 @@ export class HuiEnergyUsageGraphCard
         return;
       }
 
-      const tempState = this.hass.states[targetTempEntityId];
       const rawTempUnit =
-        tempState?.attributes.unit_of_measurement ||
+        getDisplayUnit(this.hass, targetTempEntityId, targetTempMetadata) ||
         this.hass.config.unit_system.temperature;
       const tempUnit = ["°C", "°F", "K"].includes(rawTempUnit)
         ? (rawTempUnit as "°C" | "°F" | "K")

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -536,15 +536,37 @@ export class HuiEnergyUsageGraphCard
       const weatherEntity = this.hass.entities?.[this._config.weather_entity];
       const deviceId = weatherEntity?.device_id;
       if (deviceId) {
-        const sibling = Object.values(this.hass.entities).find(
+        const siblings = Object.values(this.hass.entities).filter(
           (entity) =>
             entity.device_id === deviceId &&
             entity.entity_id.startsWith("sensor.") &&
             this.hass.states[entity.entity_id]?.attributes.device_class ===
               "temperature"
         );
-        if (sibling) {
-          targetTempEntityId = sibling.entity_id;
+        const candidates = siblings.filter(
+          (entity) =>
+            !entity.entity_id.includes("apparent") &&
+            !entity.entity_id.includes("dew_point") &&
+            !entity.entity_id.includes("feels_like") &&
+            !entity.entity_id.includes("wind_chill") &&
+            !entity.entity_id.includes("wet_bulb")
+        );
+        let primarySibling: (typeof siblings)[0] | undefined;
+        if (candidates.length === 1) {
+          primarySibling = candidates[0];
+        } else if (candidates.length > 1) {
+          const exact = candidates.filter(
+            (entity) =>
+              entity.translation_key === "temperature" ||
+              entity.entity_id.endsWith("_temperature") ||
+              entity.entity_id.endsWith("_outdoor_temperature")
+          );
+          if (exact.length === 1) {
+            primarySibling = exact[0];
+          }
+        }
+        if (primarySibling) {
+          targetTempEntityId = primarySibling.entity_id;
         }
       }
     }
@@ -598,6 +620,9 @@ export class HuiEnergyUsageGraphCard
         return;
       }
 
+      const weatherColor =
+        computedStyles.getPropertyValue("--warning-color").trim() || "#ffa600";
+
       const weatherSeries: LineSeriesOption = {
         id: "primary-weather-temperature",
         name: this.hass.localize(
@@ -607,15 +632,15 @@ export class HuiEnergyUsageGraphCard
         yAxisIndex: 1,
         smooth: true,
         connectNulls: true,
-        showSymbol: false,
+        showSymbol: weatherPoints.length === 1,
         cursor: "default",
         data: weatherPoints,
         lineStyle: {
-          color: "rgba(255, 152, 0, 0.8)",
+          color: weatherColor,
           width: 2,
         },
         itemStyle: {
-          color: "rgba(255, 152, 0, 0.8)",
+          color: weatherColor,
         },
       };
 

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -5,7 +5,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import memoizeOne from "memoize-one";
-import type { BarSeriesOption } from "echarts/charts";
+import type { BarSeriesOption, LineSeriesOption } from "echarts/charts";
 import type { TopLevelFormatterParams } from "echarts/types/dist/shared";
 import { getEnergyColor } from "./common/color";
 import { formatNumber } from "../../../../common/number/format_number";
@@ -26,8 +26,12 @@ import {
   getSummedData,
   validateEnergyCollectionKey,
 } from "../../../../data/energy";
-import type { Statistics, StatisticsMetaData } from "../../../../data/recorder";
-import { getStatisticLabel } from "../../../../data/recorder";
+import type {
+  Statistics,
+  StatisticsMetaData,
+  StatisticsUnitConfiguration,
+} from "../../../../data/recorder";
+import { fetchStatistics, getStatisticLabel } from "../../../../data/recorder";
 import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../../../../types";
@@ -36,6 +40,7 @@ import type { EnergyUsageGraphCardConfig } from "../types";
 import { hasConfigChanged } from "../../common/has-changed";
 import {
   type EnergyDataPoint,
+  computeStatMidpoint,
   fillDataGapsAndRoundCaps,
   generateFillBuckets,
   getCommonOptions,
@@ -88,11 +93,15 @@ export class HuiEnergyUsageGraphCard
     };
   }
 
-  @state() private _chartData: BarSeriesOption[] = [];
+  @state() private _chartData: (BarSeriesOption | LineSeriesOption)[] = [];
 
   @state() private _yAxisFractionDigits = 1;
 
   @state() private _legendData?: CustomLegendOption["data"];
+
+  @state() private _weatherUnit?: string;
+
+  private _weatherRequestToken = 0;
 
   @state() private _start = startOfToday();
 
@@ -175,7 +184,8 @@ export class HuiEnergyUsageGraphCard
               this._compareStart,
               this._compareEnd,
               this._yAxisFractionDigits,
-              this._legendData
+              this._legendData,
+              this._weatherUnit
             )}
             chart-type="bar"
             .expandLegend=${this._config.expand_legend}
@@ -215,7 +225,8 @@ export class HuiEnergyUsageGraphCard
       compareStart: Date | undefined,
       compareEnd: Date | undefined,
       yAxisFractionDigits: number,
-      legendData?: CustomLegendOption["data"]
+      legendData?: CustomLegendOption["data"],
+      weatherUnit?: string
     ): HaECOption => {
       const commonOptions = getCommonOptions(
         start,
@@ -227,7 +238,9 @@ export class HuiEnergyUsageGraphCard
         compareEnd,
         this._formatTotal,
         false,
-        yAxisFractionDigits
+        yAxisFractionDigits,
+        weatherUnit,
+        weatherUnit ? ["primary-weather-temperature"] : undefined
       );
       const tooltip = commonOptions.tooltip;
       const baseFormatter =
@@ -250,6 +263,18 @@ export class HuiEnergyUsageGraphCard
               return nothing;
             }
             const sorted = [...params].sort((a, b) => {
+              const aIsLine =
+                a.seriesType === "line" ||
+                a.seriesId === "primary-weather-temperature";
+              const bIsLine =
+                b.seriesType === "line" ||
+                b.seriesId === "primary-weather-temperature";
+              if (aIsLine && !bIsLine) {
+                return 1;
+              }
+              if (!aIsLine && bIsLine) {
+                return -1;
+              }
               const aValue = (a.value as number[])?.[1];
               const bValue = (b.value as number[])?.[1];
               if (aValue > 0 && bValue < 0) {
@@ -482,13 +507,119 @@ export class HuiEnergyUsageGraphCard
       )
     );
     this._yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax, true);
+    this._weatherUnit = undefined;
     this._chartData = datasets;
     this._legendData = this._getLegendData(datasets);
     this._total = this._processTotal(consumption);
+
+    const requestToken = ++this._weatherRequestToken;
+
+    let targetTempEntityId: string | undefined;
+    if (this._config?.temperature_entity) {
+      if (this.hass.states[this._config.temperature_entity]) {
+        targetTempEntityId = this._config.temperature_entity;
+      }
+    } else if (this._config?.weather_entity) {
+      const weatherEntity = this.hass.entities?.[this._config.weather_entity];
+      const deviceId = weatherEntity?.device_id;
+      if (deviceId) {
+        const sibling = Object.values(this.hass.entities).find(
+          (entity) =>
+            entity.device_id === deviceId &&
+            entity.entity_id.startsWith("sensor.") &&
+            this.hass.states[entity.entity_id]?.attributes.device_class ===
+              "temperature"
+        );
+        if (sibling) {
+          targetTempEntityId = sibling.entity_id;
+        }
+      }
+    }
+
+    if (!targetTempEntityId) {
+      return;
+    }
+
+    const tempState = this.hass.states[targetTempEntityId];
+    const rawTempUnit =
+      tempState?.attributes.unit_of_measurement ||
+      this.hass.config.unit_system.temperature;
+    const tempUnit = ["°C", "°F", "K"].includes(rawTempUnit)
+      ? (rawTempUnit as "°C" | "°F" | "K")
+      : undefined;
+
+    const units: StatisticsUnitConfiguration | undefined = tempUnit
+      ? { temperature: tempUnit }
+      : undefined;
+
+    const period = getSuggestedPeriod(this._start, this._end);
+
+    try {
+      const stats = await fetchStatistics(
+        this.hass,
+        this._start,
+        this._end,
+        [targetTempEntityId],
+        period,
+        units,
+        ["mean"]
+      );
+
+      if (this._weatherRequestToken !== requestToken || !this.isConnected) {
+        return;
+      }
+
+      const tempStats = stats[targetTempEntityId];
+      if (!tempStats || tempStats.length === 0) {
+        return;
+      }
+
+      const weatherPoints: LineSeriesOption["data"] = tempStats
+        .filter((stat) => stat.mean !== null && stat.mean !== undefined)
+        .map((stat) => [
+          computeStatMidpoint(stat.start, stat.end, period),
+          stat.mean as number,
+        ]);
+
+      if (weatherPoints.length === 0) {
+        return;
+      }
+
+      const weatherSeries: LineSeriesOption = {
+        id: "primary-weather-temperature",
+        name: this.hass.localize(
+          "ui.panel.lovelace.cards.energy.energy_usage_graph.outdoor_temperature"
+        ),
+        type: "line",
+        yAxisIndex: 1,
+        smooth: true,
+        connectNulls: true,
+        showSymbol: false,
+        cursor: "default",
+        data: weatherPoints,
+        lineStyle: {
+          color: "rgba(255, 152, 0, 0.8)",
+          width: 2,
+        },
+        itemStyle: {
+          color: "rgba(255, 152, 0, 0.8)",
+        },
+      };
+
+      const updatedDatasets: (BarSeriesOption | LineSeriesOption)[] = [
+        ...datasets,
+        weatherSeries,
+      ];
+      this._chartData = updatedDatasets;
+      this._legendData = this._getLegendData(updatedDatasets);
+      this._weatherUnit = tempUnit || rawTempUnit;
+    } catch {
+      // Ignore weather stats errors
+    }
   }
 
   private _getLegendData(
-    datasets: BarSeriesOption[]
+    datasets: (BarSeriesOption | LineSeriesOption)[]
   ): CustomLegendOption["data"] {
     // Each main series gets a legend item, and its matching compare
     // series (if any) is attached as a secondary id so toggling

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -684,9 +684,10 @@ export class HuiEnergyUsageGraphCard
 
       const weatherPoints: LineSeriesOption["data"] = tempStats
         .filter((stat) => stat.mean !== null && stat.mean !== undefined)
-        .map((stat) => [
+.map((stat) => [
           computeStatMidpoint(stat.start, stat.end, period),
           stat.mean as number,
+          stat.start,
         ]);
 
       if (weatherPoints.length === 0) {

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -31,7 +31,12 @@ import type {
   StatisticsMetaData,
   StatisticsUnitConfiguration,
 } from "../../../../data/recorder";
-import { fetchStatistics, getStatisticLabel } from "../../../../data/recorder";
+import {
+  fetchStatistics,
+  getStatisticLabel,
+  getStatisticMetadata,
+  statisticsMetaHasType,
+} from "../../../../data/recorder";
 import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../../../../types";
@@ -527,69 +532,97 @@ export class HuiEnergyUsageGraphCard
 
     const requestToken = ++this._weatherRequestToken;
 
-    let targetTempEntityId: string | undefined;
-    if (this._config?.temperature_entity) {
-      if (this.hass.states[this._config.temperature_entity]) {
-        targetTempEntityId = this._config.temperature_entity;
-      }
-    } else if (this._config?.weather_entity) {
-      const weatherEntity = this.hass.entities?.[this._config.weather_entity];
-      const deviceId = weatherEntity?.device_id;
-      if (deviceId) {
-        const siblings = Object.values(this.hass.entities).filter(
-          (entity) =>
-            entity.device_id === deviceId &&
-            entity.entity_id.startsWith("sensor.") &&
-            this.hass.states[entity.entity_id]?.attributes.device_class ===
-              "temperature"
-        );
-        const candidates = siblings.filter(
-          (entity) =>
-            !entity.entity_id.includes("apparent") &&
-            !entity.entity_id.includes("dew_point") &&
-            !entity.entity_id.includes("feels_like") &&
-            !entity.entity_id.includes("wind_chill") &&
-            !entity.entity_id.includes("wet_bulb")
-        );
-        let primarySibling: (typeof siblings)[0] | undefined;
-        if (candidates.length === 1) {
-          primarySibling = candidates[0];
-        } else if (candidates.length > 1) {
-          const exact = candidates.filter(
-            (entity) =>
-              entity.translation_key === "temperature" ||
-              entity.entity_id.endsWith("_temperature") ||
-              entity.entity_id.endsWith("_outdoor_temperature")
-          );
-          if (exact.length === 1) {
-            primarySibling = exact[0];
+    try {
+      let targetTempEntityId: string | undefined;
+      if (this._config?.temperature_entity) {
+        if (this.hass.states[this._config.temperature_entity]) {
+          const statsMeta = await getStatisticMetadata(this.hass, [
+            this._config.temperature_entity,
+          ]);
+          if (this._weatherRequestToken !== requestToken || !this.isConnected) {
+            return;
+          }
+          if (statsMeta.some((meta) => statisticsMetaHasType(meta, "mean"))) {
+            targetTempEntityId = this._config.temperature_entity;
           }
         }
-        if (primarySibling) {
-          targetTempEntityId = primarySibling.entity_id;
+      } else if (this._config?.weather_entity) {
+        const weatherEntity = this.hass.entities?.[this._config.weather_entity];
+        const deviceId = weatherEntity?.device_id;
+        if (deviceId) {
+          const siblings = Object.values(this.hass.entities).filter(
+            (entity) =>
+              entity.device_id === deviceId &&
+              entity.entity_id.startsWith("sensor.") &&
+              this.hass.states[entity.entity_id]?.attributes.device_class ===
+                "temperature"
+          );
+          const candidates = siblings.filter(
+            (entity) =>
+              !entity.entity_id.includes("apparent") &&
+              !entity.entity_id.includes("dew_point") &&
+              !entity.entity_id.includes("feels_like") &&
+              !entity.entity_id.includes("wind_chill") &&
+              !entity.entity_id.includes("wet_bulb")
+          );
+          if (candidates.length) {
+            const statsMeta = await getStatisticMetadata(
+              this.hass,
+              candidates.map((c) => c.entity_id)
+            );
+            if (
+              this._weatherRequestToken !== requestToken ||
+              !this.isConnected
+            ) {
+              return;
+            }
+            const validStatIds = new Set(
+              statsMeta
+                .filter((meta) => statisticsMetaHasType(meta, "mean"))
+                .map((meta) => meta.statistic_id)
+            );
+            const validCandidates = candidates.filter((c) =>
+              validStatIds.has(c.entity_id)
+            );
+            let primarySibling: (typeof siblings)[0] | undefined;
+            if (validCandidates.length === 1) {
+              primarySibling = validCandidates[0];
+            } else if (validCandidates.length > 1) {
+              const exact = validCandidates.filter(
+                (entity) =>
+                  entity.translation_key === "temperature" ||
+                  entity.entity_id.endsWith("_temperature") ||
+                  entity.entity_id.endsWith("_outdoor_temperature")
+              );
+              if (exact.length === 1) {
+                primarySibling = exact[0];
+              }
+            }
+            if (primarySibling) {
+              targetTempEntityId = primarySibling.entity_id;
+            }
+          }
         }
       }
-    }
 
-    if (!targetTempEntityId) {
-      return;
-    }
+      if (!targetTempEntityId) {
+        return;
+      }
 
-    const tempState = this.hass.states[targetTempEntityId];
-    const rawTempUnit =
-      tempState?.attributes.unit_of_measurement ||
-      this.hass.config.unit_system.temperature;
-    const tempUnit = ["°C", "°F", "K"].includes(rawTempUnit)
-      ? (rawTempUnit as "°C" | "°F" | "K")
-      : undefined;
+      const tempState = this.hass.states[targetTempEntityId];
+      const rawTempUnit =
+        tempState?.attributes.unit_of_measurement ||
+        this.hass.config.unit_system.temperature;
+      const tempUnit = ["°C", "°F", "K"].includes(rawTempUnit)
+        ? (rawTempUnit as "°C" | "°F" | "K")
+        : undefined;
 
-    const units: StatisticsUnitConfiguration | undefined = tempUnit
-      ? { temperature: tempUnit }
-      : undefined;
+      const units: StatisticsUnitConfiguration | undefined = tempUnit
+        ? { temperature: tempUnit }
+        : undefined;
 
-    const period = getSuggestedPeriod(this._start, this._end);
+      const period = getSuggestedPeriod(this._start, this._end);
 
-    try {
       const stats = await fetchStatistics(
         this.hass,
         this._start,

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -209,7 +209,11 @@ export class HuiEnergyUsageGraphCard
             .expandLegend=${this._config.expand_legend}
           ></ha-chart-base>
           ${
-            !this._chartData.some((dataset) => dataset.data!.length)
+            !this._chartData.some(
+              (dataset) =>
+                dataset.id !== "primary-weather-temperature" &&
+                dataset.data!.length
+            )
               ? html`<div class="no-data">
                   ${
                     isToday(this._start)
@@ -530,6 +534,11 @@ export class HuiEnergyUsageGraphCard
     this._chartData = datasets;
     this._legendData = this._getLegendData(datasets);
     this._total = this._processTotal(consumption);
+
+    const hasEnergyData = datasets.some((dataset) => dataset.data?.length);
+    if (!hasEnergyData) {
+      return;
+    }
 
     const requestToken = ++this._weatherRequestToken;
 

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -103,6 +103,8 @@ export class HuiEnergyUsageGraphCard
 
   private _weatherRequestToken = 0;
 
+  private _latestEnergyData?: EnergyData;
+
   @state() private _start = startOfToday();
 
   @state() private _end = endOfToday();
@@ -131,7 +133,17 @@ export class HuiEnergyUsageGraphCard
     if (config.collection_key) {
       validateEnergyCollectionKey(config.collection_key);
     }
+    const tempConfigChanged =
+      this._config &&
+      (this._config.temperature_entity !== config.temperature_entity ||
+        this._config.weather_entity !== config.weather_entity);
     this._config = config;
+    if (tempConfigChanged) {
+      this._weatherRequestToken++;
+      if (this._latestEnergyData) {
+        this._getStatistics(this._latestEnergyData);
+      }
+    }
   }
 
   protected shouldUpdate(changedProps: PropertyValues<this>): boolean {
@@ -297,6 +309,7 @@ export class HuiEnergyUsageGraphCard
   );
 
   private async _getStatistics(energyData: EnergyData): Promise<void> {
+    this._latestEnergyData = energyData;
     if (!this.isConnected) {
       return;
     }

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -532,23 +532,26 @@ export class HuiEnergyUsageGraphCard
     this._yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax, true);
     this._total = this._processTotal(consumption);
 
+    const requestToken = ++this._weatherRequestToken;
+
+    this._chartData = datasets;
+    this._legendData = this._getLegendData(datasets);
+    this._weatherUnit = undefined;
+
     const hasEnergyData = datasets.some((dataset) => dataset.data?.length);
     const hasWeatherConfig = Boolean(
       this._config?.temperature_entity || this._config?.weather_entity
     );
 
     if (!hasEnergyData || !hasWeatherConfig) {
-      this._chartData = datasets;
-      this._legendData = this._getLegendData(datasets);
-      this._weatherUnit = undefined;
       return;
     }
-
-    const requestToken = ++this._weatherRequestToken;
 
     try {
       let targetTempEntityId: string | undefined;
       let targetTempMetadata: StatisticsMetaData | undefined;
+      let targetTempName: string | undefined;
+
       if (this._config?.temperature_entity) {
         const statsMeta = await getStatisticMetadata(this.hass, [
           this._config.temperature_entity,
@@ -566,6 +569,11 @@ export class HuiEnergyUsageGraphCard
         if (meta && statisticsMetaHasType(meta, "mean") && isTemperature) {
           targetTempEntityId = this._config.temperature_entity;
           targetTempMetadata = meta;
+          targetTempName = getStatisticLabel(
+            this.hass,
+            targetTempEntityId,
+            targetTempMetadata
+          );
         }
       } else if (this._config?.weather_entity) {
         const weatherEntity = this.hass.entities?.[this._config.weather_entity];
@@ -630,15 +638,15 @@ export class HuiEnergyUsageGraphCard
               targetTempMetadata = statsMeta.find(
                 (m) => m.statistic_id === primarySibling!.entity_id
               );
+              targetTempName = this.hass.localize(
+                "ui.panel.lovelace.cards.energy.energy_usage_graph.outdoor_temperature"
+              );
             }
           }
         }
       }
 
       if (!targetTempEntityId) {
-        this._chartData = datasets;
-        this._legendData = this._getLegendData(datasets);
-        this._weatherUnit = undefined;
         return;
       }
 
@@ -671,9 +679,6 @@ export class HuiEnergyUsageGraphCard
 
       const tempStats = stats[targetTempEntityId];
       if (!tempStats || tempStats.length === 0) {
-        this._chartData = datasets;
-        this._legendData = this._getLegendData(datasets);
-        this._weatherUnit = undefined;
         return;
       }
 
@@ -685,9 +690,6 @@ export class HuiEnergyUsageGraphCard
         ]);
 
       if (weatherPoints.length === 0) {
-        this._chartData = datasets;
-        this._legendData = this._getLegendData(datasets);
-        this._weatherUnit = undefined;
         return;
       }
 
@@ -696,9 +698,11 @@ export class HuiEnergyUsageGraphCard
 
       const weatherSeries: LineSeriesOption = {
         id: "primary-weather-temperature",
-        name: this.hass.localize(
-          "ui.panel.lovelace.cards.energy.energy_usage_graph.outdoor_temperature"
-        ),
+        name:
+          targetTempName ||
+          this.hass.localize(
+            "ui.panel.lovelace.cards.energy.energy_usage_graph.outdoor_temperature"
+          ),
         type: "line",
         yAxisIndex: 1,
         smooth: true,
@@ -723,6 +727,9 @@ export class HuiEnergyUsageGraphCard
       this._legendData = this._getLegendData(updatedDatasets);
       this._weatherUnit = tempUnit || rawTempUnit;
     } catch {
+      if (this._weatherRequestToken !== requestToken || !this.isConnected) {
+        return;
+      }
       this._chartData = datasets;
       this._legendData = this._getLegendData(datasets);
       this._weatherUnit = undefined;

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -530,13 +530,17 @@ export class HuiEnergyUsageGraphCard
       )
     );
     this._yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax, true);
-    this._weatherUnit = undefined;
-    this._chartData = datasets;
-    this._legendData = this._getLegendData(datasets);
     this._total = this._processTotal(consumption);
 
     const hasEnergyData = datasets.some((dataset) => dataset.data?.length);
-    if (!hasEnergyData) {
+    const hasWeatherConfig = Boolean(
+      this._config?.temperature_entity || this._config?.weather_entity
+    );
+
+    if (!hasEnergyData || !hasWeatherConfig) {
+      this._chartData = datasets;
+      this._legendData = this._getLegendData(datasets);
+      this._weatherUnit = undefined;
       return;
     }
 
@@ -555,7 +559,11 @@ export class HuiEnergyUsageGraphCard
         const meta = statsMeta.find(
           (m) => m.statistic_id === this._config!.temperature_entity
         );
-        if (meta && statisticsMetaHasType(meta, "mean")) {
+        const tempState = this.hass.states[this._config.temperature_entity];
+        const isTemperature =
+          meta?.unit_class === "temperature" ||
+          tempState?.attributes.device_class === "temperature";
+        if (meta && statisticsMetaHasType(meta, "mean") && isTemperature) {
           targetTempEntityId = this._config.temperature_entity;
           targetTempMetadata = meta;
         }
@@ -591,7 +599,13 @@ export class HuiEnergyUsageGraphCard
             }
             const validStatIds = new Set(
               statsMeta
-                .filter((meta) => statisticsMetaHasType(meta, "mean"))
+                .filter(
+                  (meta) =>
+                    statisticsMetaHasType(meta, "mean") &&
+                    (meta.unit_class === "temperature" ||
+                      this.hass.states[meta.statistic_id]?.attributes
+                        .device_class === "temperature")
+                )
                 .map((meta) => meta.statistic_id)
             );
             const validCandidates = candidates.filter((c) =>
@@ -622,6 +636,9 @@ export class HuiEnergyUsageGraphCard
       }
 
       if (!targetTempEntityId) {
+        this._chartData = datasets;
+        this._legendData = this._getLegendData(datasets);
+        this._weatherUnit = undefined;
         return;
       }
 
@@ -654,6 +671,9 @@ export class HuiEnergyUsageGraphCard
 
       const tempStats = stats[targetTempEntityId];
       if (!tempStats || tempStats.length === 0) {
+        this._chartData = datasets;
+        this._legendData = this._getLegendData(datasets);
+        this._weatherUnit = undefined;
         return;
       }
 
@@ -665,6 +685,9 @@ export class HuiEnergyUsageGraphCard
         ]);
 
       if (weatherPoints.length === 0) {
+        this._chartData = datasets;
+        this._legendData = this._getLegendData(datasets);
+        this._weatherUnit = undefined;
         return;
       }
 
@@ -700,7 +723,9 @@ export class HuiEnergyUsageGraphCard
       this._legendData = this._getLegendData(updatedDatasets);
       this._weatherUnit = tempUnit || rawTempUnit;
     } catch {
-      // Ignore weather stats errors
+      this._chartData = datasets;
+      this._legendData = this._getLegendData(datasets);
+      this._weatherUnit = undefined;
     }
   }
 

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -194,6 +194,8 @@ export interface EnergyUsageGraphCardConfig extends EnergyCardConfig {
   type: "energy-usage-graph";
   show_legend?: boolean;
   expand_legend?: boolean;
+  temperature_entity?: string;
+  weather_entity?: string;
 }
 
 export interface EnergySolarGraphCardConfig extends EnergyCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
@@ -173,10 +173,8 @@ export class HuiEnergyGraphCardEditor
           `ui.panel.lovelace.editor.card.power-sources-graph.${schema.name}`
         );
       case "temperature_entity":
-        return (
-          this.hass!.localize(
-            `ui.panel.lovelace.editor.card.energy-usage-graph.${schema.name}`
-          ) || "Temperature entity"
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.energy-usage-graph.${schema.name}`
         );
       default:
         return this.hass!.localize(

--- a/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
@@ -60,6 +60,17 @@ const SCHEMA: HaFormSchema[] = [
     selector: { boolean: {} },
   },
   {
+    name: "temperature_entity",
+    visible: { field: "type", value: "energy-usage-graph" },
+    required: false,
+    selector: {
+      entity: {
+        domain: "sensor",
+        device_class: "temperature",
+      },
+    },
+  },
+  {
     type: "string",
     name: "collection_key",
     required: false,
@@ -88,6 +99,8 @@ const cardConfigStruct = assign(
     show_legend: optional(boolean()),
     expand_legend: optional(boolean()),
     link_dashboard: optional(boolean()),
+    temperature_entity: optional(string()),
+    weather_entity: optional(string()),
   })
 );
 
@@ -158,6 +171,12 @@ export class HuiEnergyGraphCardEditor
       case "show_legend":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.power-sources-graph.${schema.name}`
+        );
+      case "temperature_entity":
+        return (
+          this.hass!.localize(
+            `ui.panel.lovelace.editor.card.energy-usage-graph.${schema.name}`
+          ) || "Temperature entity"
         );
       default:
         return this.hass!.localize(

--- a/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
@@ -64,9 +64,9 @@ const SCHEMA: HaFormSchema[] = [
     visible: { field: "type", value: "energy-usage-graph" },
     required: false,
     selector: {
-      entity: {
-        domain: "sensor",
+      statistic: {
         device_class: "temperature",
+        statistic_types: "mean",
       },
     },
   },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10132,7 +10132,7 @@
             "energy-usage-graph": {
               "name": "Energy usage graph",
               "description": "This card shows the amount of energy your house has consumed, and from what source this energy came.",
-              "temperature_entity": "Temperature entity"
+              "temperature_entity": "Temperature statistic"
             },
             "energy-solar-graph": {
               "name": "Solar production graph",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9327,6 +9327,7 @@
             "energy_usage_graph": {
               "total_consumed": "Total {num} kWh",
               "total_usage": "{num} kWh",
+              "outdoor_temperature": "Outdoor temperature",
               "combined_from_grid": "Grid",
               "consumed_solar": "Solar",
               "consumed_battery": "Battery",
@@ -10130,7 +10131,8 @@
             },
             "energy-usage-graph": {
               "name": "Energy usage graph",
-              "description": "This card shows the amount of energy your house has consumed, and from what source this energy came."
+              "description": "This card shows the amount of energy your house has consumed, and from what source this energy came.",
+              "temperature_entity": "Temperature entity"
             },
             "energy-solar-graph": {
               "name": "Solar production graph",

--- a/test/components/chart/chart-sonification.test.ts
+++ b/test/components/chart/chart-sonification.test.ts
@@ -423,4 +423,35 @@ describe("sonifyChart", () => {
     });
     expect(connectedAxes().x.valueLabels).toBeUndefined();
   });
+
+  it("excludes series mapped to secondary axes from sonification", async () => {
+    await sonify({
+      xAxis: [{ type: "time" }],
+      yAxis: [
+        { type: "value", name: "kWh" },
+        { type: "value", name: "°C" },
+      ],
+      series: [
+        {
+          type: "bar",
+          name: "Grid",
+          data: [
+            [1700000000000, 1.5],
+            [1700003600000, 2.0],
+          ],
+        },
+        {
+          type: "line",
+          name: "Temperature",
+          yAxisIndex: 1,
+          data: [
+            [1700000000000, 20],
+            [1700003600000, 21],
+          ],
+        },
+      ],
+    });
+
+    expect(mockedConnect.mock.lastCall![1]!.seriesIndex).toEqual([0]);
+  });
 });

--- a/test/components/chart/chart-sonification.test.ts
+++ b/test/components/chart/chart-sonification.test.ts
@@ -459,4 +459,36 @@ describe("sonifyChart", () => {
     });
     expect(mockedConnect.mock.lastCall![1]!.seriesIndex).toEqual([0, 1]);
   });
+
+  it("does not expose y2 for hidden secondary axes and excludes secondary series", async () => {
+    await sonify({
+      xAxis: [{ type: "time" }],
+      yAxis: [
+        { type: "value", name: "kWh" },
+        { type: "value", name: "", show: false },
+      ],
+      series: [
+        {
+          type: "bar",
+          name: "Grid",
+          data: [
+            [1700000000000, 1.5],
+            [1700003600000, 2.0],
+          ],
+        },
+        {
+          type: "line",
+          name: "Temperature",
+          yAxisIndex: 1,
+          data: [
+            [1700000000000, 20],
+            [1700003600000, 21],
+          ],
+        },
+      ],
+    });
+
+    expect(connectedAxes().y2).toBeUndefined();
+    expect(mockedConnect.mock.lastCall![1]!.seriesIndex).toEqual([0]);
+  });
 });

--- a/test/components/chart/chart-sonification.test.ts
+++ b/test/components/chart/chart-sonification.test.ts
@@ -424,7 +424,7 @@ describe("sonifyChart", () => {
     expect(connectedAxes().x.valueLabels).toBeUndefined();
   });
 
-  it("excludes series mapped to secondary axes from sonification", async () => {
+  it("supports secondary y axis with its own label", async () => {
     await sonify({
       xAxis: [{ type: "time" }],
       yAxis: [
@@ -452,6 +452,11 @@ describe("sonifyChart", () => {
       ],
     });
 
-    expect(mockedConnect.mock.lastCall![1]!.seriesIndex).toEqual([0]);
+    expect(connectedAxes()).toMatchObject({
+      x: { label: "ui.components.history_charts.time" },
+      y: { label: "kWh" },
+      y2: { label: "°C" },
+    });
+    expect(mockedConnect.mock.lastCall![1]!.seriesIndex).toEqual([0, 1]);
   });
 });

--- a/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
+++ b/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
@@ -1,3 +1,4 @@
+import { render } from "lit";
 import { assert, describe, it } from "vitest";
 import type { BarSeriesOption, LineSeriesOption } from "echarts/charts";
 
@@ -6,11 +7,14 @@ import {
   fillDataGapsAndRoundCaps,
   fillLineGaps,
   generateFillBuckets,
+  getCommonOptions,
   getCompareTransform,
   getPeriodMidpointOffset,
   getSuggestedMax,
   splitUntrackedConsumption,
 } from "../../../../../../src/panels/lovelace/cards/energy/common/energy-chart-options";
+import { demoConfig } from "../../../../../../src/fake_data/demo_config";
+import { mockLocale } from "../../../../../fixtures/hass";
 
 // Helper to get x value from either [x,y] or {value: [x,y]} format
 function getX(item: any): number {
@@ -1062,5 +1066,98 @@ describe("splitUntrackedConsumption", () => {
     splitUntrackedConsumption(usedTotal, deviceTotal);
     assert.deepEqual(usedTotal, usedCopy);
     assert.deepEqual(deviceTotal, deviceCopy);
+  });
+});
+
+describe("getCommonOptions secondaryUnit", () => {
+  const start = new Date("2024-03-15T00:00:00.000Z");
+  const end = new Date("2024-03-15T23:59:59.999Z");
+
+  it("creates a single yAxis when secondaryUnit is not provided", () => {
+    const options = getCommonOptions(start, end, mockLocale, demoConfig, "kWh");
+    assert.isFalse(Array.isArray(options.yAxis));
+    assert.equal((options.yAxis as any).name, "kWh");
+    assert.equal((options.grid as any).right, 1);
+  });
+
+  it("creates dual yAxes when secondaryUnit is provided", () => {
+    const options = getCommonOptions(
+      start,
+      end,
+      mockLocale,
+      demoConfig,
+      "kWh",
+      undefined,
+      undefined,
+      undefined,
+      false,
+      1,
+      "°C",
+      ["primary-weather-temperature"]
+    );
+    assert.isTrue(Array.isArray(options.yAxis));
+    const axes = options.yAxis as any[];
+    assert.equal(axes.length, 2);
+    assert.equal(axes[0].name, "kWh");
+    assert.equal(axes[1].name, "°C");
+    assert.equal(axes[1].position, "right");
+    assert.isFalse(axes[1].splitLine.show);
+    assert.equal((options.grid as any).right, 12);
+  });
+
+  it("formats tooltip with mixed primary and secondary units and excludes secondary series from total", () => {
+    const formatTotal = (val: number) => `Total: ${val} kWh`;
+    const options = getCommonOptions(
+      start,
+      end,
+      mockLocale,
+      demoConfig,
+      "kWh",
+      undefined,
+      undefined,
+      formatTotal,
+      false,
+      1,
+      "°C",
+      ["primary-weather-temperature"]
+    );
+
+    const formatter = (options.tooltip as any)?.formatter;
+    assert.isFunction(formatter);
+
+    const mockParams = [
+      {
+        componentSubType: "bar",
+        seriesId: "grid-consumption",
+        seriesName: "Grid",
+        value: [start.getTime() + 1800000, 5, start.getTime()],
+        color: "#123456",
+      },
+      {
+        componentSubType: "bar",
+        seriesId: "solar-consumption",
+        seriesName: "Solar",
+        value: [start.getTime() + 1800000, 3, start.getTime()],
+        color: "#ffc107",
+      },
+      {
+        componentSubType: "line",
+        seriesId: "primary-weather-temperature",
+        seriesName: "Outdoor temperature",
+        value: [start.getTime() + 1800000, 21.5],
+        color: "#ff9800",
+      },
+    ];
+
+    const result = formatter(mockParams);
+    const container = document.createElement("div");
+    render(result, container);
+    assert.include(container.textContent, "Grid:");
+    assert.include(container.textContent, "5 kWh");
+    assert.include(container.textContent, "Solar:");
+    assert.include(container.textContent, "3 kWh");
+    assert.include(container.textContent, "Outdoor temperature:");
+    assert.include(container.textContent, "21.5 °C");
+    assert.include(container.textContent, "Total: 8 kWh");
   });
 });

--- a/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
+++ b/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
@@ -1208,4 +1208,40 @@ describe("getCommonOptions secondaryUnit", () => {
     assert.include(container.textContent, "Outdoor temperature:");
     assert.include(container.textContent, "0 °C");
   });
+
+  it("preserves 3-decimal precision for small negative energy values", () => {
+    const options = getCommonOptions(
+      start,
+      end,
+      mockLocale,
+      demoConfig,
+      "kWh",
+      undefined,
+      undefined,
+      undefined,
+      false,
+      1,
+      "°C",
+      ["primary-weather-temperature"]
+    );
+
+    const formatter = (options.tooltip as any)?.formatter;
+    assert.isFunction(formatter);
+
+    const mockParams = [
+      {
+        componentSubType: "bar",
+        seriesId: "battery-in",
+        seriesName: "Battery in",
+        value: [start.getTime() + 1800000, -0.005, start.getTime()],
+        color: "#123456",
+      },
+    ];
+
+    const result = formatter(mockParams);
+    const container = document.createElement("div");
+    render(result, container);
+    assert.include(container.textContent, "Battery in:");
+    assert.include(container.textContent, "-0.005 kWh");
+  });
 });

--- a/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
+++ b/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
@@ -1073,14 +1073,17 @@ describe("getCommonOptions secondaryUnit", () => {
   const start = new Date("2024-03-15T00:00:00.000Z");
   const end = new Date("2024-03-15T23:59:59.999Z");
 
-  it("creates a single yAxis when secondaryUnit is not provided", () => {
+  it("creates dual yAxes with secondary yAxis hidden when secondaryUnit is not provided", () => {
     const options = getCommonOptions(start, end, mockLocale, demoConfig, "kWh");
-    assert.isFalse(Array.isArray(options.yAxis));
-    assert.equal((options.yAxis as any).name, "kWh");
+    assert.isTrue(Array.isArray(options.yAxis));
+    const axes = options.yAxis as any[];
+    assert.equal(axes.length, 2);
+    assert.equal(axes[0].name, "kWh");
+    assert.isFalse(axes[1].show);
     assert.equal((options.grid as any).right, 1);
   });
 
-  it("creates dual yAxes when secondaryUnit is provided", () => {
+  it("shows secondary yAxis with precision bounds when secondaryUnit is provided", () => {
     const options = getCommonOptions(
       start,
       end,
@@ -1099,6 +1102,7 @@ describe("getCommonOptions secondaryUnit", () => {
     const axes = options.yAxis as any[];
     assert.equal(axes.length, 2);
     assert.equal(axes[0].name, "kWh");
+    assert.isTrue(axes[1].show);
     assert.equal(axes[1].name, "°C");
     assert.equal(axes[1].position, "right");
     assert.isFalse(axes[1].splitLine.show);
@@ -1159,5 +1163,49 @@ describe("getCommonOptions secondaryUnit", () => {
     assert.include(container.textContent, "Outdoor temperature:");
     assert.include(container.textContent, "21.5 °C");
     assert.include(container.textContent, "Total: 8 kWh");
+  });
+
+  it("preserves zero readings for secondary series in tooltips while suppressing zero bars", () => {
+    const options = getCommonOptions(
+      start,
+      end,
+      mockLocale,
+      demoConfig,
+      "kWh",
+      undefined,
+      undefined,
+      undefined,
+      false,
+      1,
+      "°C",
+      ["primary-weather-temperature"]
+    );
+
+    const formatter = (options.tooltip as any)?.formatter;
+    assert.isFunction(formatter);
+
+    const mockParams = [
+      {
+        componentSubType: "bar",
+        seriesId: "grid-consumption",
+        seriesName: "Grid",
+        value: [start.getTime() + 1800000, 0, start.getTime()],
+        color: "#123456",
+      },
+      {
+        componentSubType: "line",
+        seriesId: "primary-weather-temperature",
+        seriesName: "Outdoor temperature",
+        value: [start.getTime() + 1800000, 0],
+        color: "#ff9800",
+      },
+    ];
+
+    const result = formatter(mockParams);
+    const container = document.createElement("div");
+    render(result, container);
+    assert.notInclude(container.textContent, "Grid:");
+    assert.include(container.textContent, "Outdoor temperature:");
+    assert.include(container.textContent, "0 °C");
   });
 });


### PR DESCRIPTION
## Proposed change

This PR adds an outdoor temperature overlay line with a dedicated secondary y-axis to the Energy Usage Graph card (`hui-energy-usage-graph-card`), allowing users to correlate heating and cooling energy consumption against outdoor weather conditions directly on their dashboard.

### Key Changes
- **Secondary Y-Axis & Shared Chart Options**: Extends `getCommonOptions` in `energy-chart-options.ts` with support for an optional `secondaryUnit` (e.g., `°C`, `°F`, `K`) and `secondarySeriesIds`. When enabled, adds a right-aligned secondary value axis, disables secondary grid split lines, adjusts chart grid padding, and formats tooltips with the respective units per series.
- **Tooltip Total Integrity**: Tooltip formatting ensures that line series values (temperature) display with their unit without skewing the energy consumption sum, which strictly totals positive energy bars (`kWh`).
- **Deterministic Entity Resolution**:
  - Configurable directly in the card editor via `temperature_entity` (`sensor` domain with `device_class: temperature`).
  - Supports `weather_entity` config by looking up sibling temperature sensors on the same device.
  - Does not fall back to non-deterministic first-found entities if neither is configured.
- **Unit-Aware Statistics Query**: Requests statistics with Home Assistant's `StatisticsUnitConfiguration` for `temperature` to ensure unit compatibility with the user's unit system.
- **Race Condition Guarding**: Employs monotonic request tokens (`_weatherRequestToken`) and connection status checks so fast period switches (e.g., day -> month) cleanly discard outdated async responses.
- **Legend Integration**: Weather series is integrated into `_getLegendData`, enabling users to toggle visibility.
- **Unit Tests**: Adds test coverage in `test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts` for dual-axis options and mixed primary/secondary unit tooltip rendering.

## Screenshots

**Day View (Hourly electricity usage with weather temperature overlay & secondary axis):**
<img width="1392" height="698" alt="Hourly electricity usage with weather temperature overlay and secondary axis" src="https://github.com/user-attachments/assets/5073ffc6-658d-4f48-abf7-6a3f3cf5252e" />

**Month View (Daily electricity usage with outdoor temperature trend & secondary axis):**
<img width="1398" height="689" alt="Daily electricity usage with outdoor temperature trend and secondary axis" src="https://github.com/user-attachments/assets/4d0b9de8-ef1e-43f6-b8c9-bbf4c7678731" />

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
