### PR TITLE
Serial: send consumers to their own config panel

### DIFF
--- a/src/data/integration.ts
+++ b/src/data/integration.ts
@@ -18,6 +18,19 @@ export const integrationsWithPanel = {
   zwave_js: "config/zwave_js/dashboard",
 };
 
+/**
+ * The panel an integration is configured in, if it has one of its own.
+ *
+ * An integration can register a panel at runtime; the built-in ones above are
+ * the fallback for those that do not.
+ */
+export const getConfigPanelPath = (
+  domain: string,
+  panels: HomeAssistant["panels"]
+): string | undefined =>
+  Object.values(panels).find((panel) => panel.config_panel_domain === domain)
+    ?.url_path || integrationsWithPanel[domain];
+
 export type IntegrationType =
   "device" | "helper" | "hub" | "service" | "hardware" | "entity" | "system";
 

--- a/src/panels/config/integrations/ha-config-entry-row.ts
+++ b/src/panels/config/integrations/ha-config-entry-row.ts
@@ -51,7 +51,7 @@ import type { IntegrationManifest } from "../../../data/integration";
 import {
   domainToName,
   fetchIntegrationManifest,
-  integrationsWithPanel,
+  getConfigPanelPath,
 } from "../../../data/integration";
 import { showConfigEntrySystemOptionsDialog } from "../../../dialogs/config-entry-system-options/show-dialog-config-entry-system-options";
 import { showConfigFlowDialog } from "../../../dialogs/config-flow/show-dialog-config-flow";
@@ -530,12 +530,7 @@ export class HaConfigEntryRow extends LitElement {
     </ha-md-list>`;
   }
 
-  private _configPanel = memoizeOne(
-    (domain: string, panels: HomeAssistant["panels"]): string | undefined =>
-      Object.values(panels).find(
-        (panel) => panel.config_panel_domain === domain
-      )?.url_path || integrationsWithPanel[domain]
-  );
+  private _configPanel = memoizeOne(getConfigPanelPath);
 
   private _getEntities = (): EntityRegistryEntry[] =>
     this.entities.filter(

--- a/src/panels/config/integrations/integration-panels/serial/serial-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/serial/serial-config-dashboard.ts
@@ -23,7 +23,10 @@ import "../../../../../components/ha-md-list";
 import "../../../../../components/ha-md-list-item";
 import "../../../../../components/ha-spinner";
 import "../../../../../components/ha-svg-icon";
-import { domainToName } from "../../../../../data/integration";
+import {
+  domainToName,
+  getConfigPanelPath,
+} from "../../../../../data/integration";
 import type {
   SerialPort,
   SerialPortConsumer,
@@ -204,11 +207,25 @@ export class SerialConfigDashboard extends LitElement {
     />`;
   }
 
+  // Where the port's use is managed: the integration's own panel when it has
+  // one and is running, otherwise its entry on the integration page
+  private _consumerHref(consumer: SerialPortConsumer): string {
+    if (consumer.kind !== "config_entry") {
+      return `/config/app/${consumer.slug}/info`;
+    }
+
+    const configPanel =
+      consumer.active && consumer.domain
+        ? getConfigPanelPath(consumer.domain, this.hass.panels)
+        : undefined;
+
+    return configPanel
+      ? `/${configPanel}?config_entry=${consumer.config_entry_id}`
+      : `/config/integrations/integration/${consumer.domain}#config_entry=${consumer.config_entry_id}`;
+  }
+
   private _renderConsumer(consumer: SerialPortConsumer): TemplateResult {
-    const href =
-      consumer.kind === "config_entry"
-        ? `/config/integrations/integration/${consumer.domain}#config_entry=${consumer.config_entry_id}`
-        : `/config/app/${consumer.slug}/info`;
+    const href = this._consumerHref(consumer);
 
     return html`
       <ha-md-list-item type="link" href=${href} class="consumer">

--- a/src/panels/config/integrations/integration-panels/serial/serial-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/serial/serial-config-dashboard.ts
@@ -14,6 +14,7 @@ import type { CSSResultGroup, TemplateResult } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import { isComponentLoaded } from "../../../../../common/config/is_component_loaded";
 import { caseInsensitiveStringCompare } from "../../../../../common/string/compare";
 import "../../../../../components/ha-alert";
 import "../../../../../components/ha-card";
@@ -54,6 +55,12 @@ const TYPE_ICONS: Record<SerialPortType, string> = {
   usb: mdiUsb,
   embedded: mdiMemory,
   unnamed: mdiMemory,
+};
+
+// A Thread radio is held by the Open Thread Border Router app rather than by a
+// config entry, so its panel is found through the integration behind the app
+const APP_INTEGRATIONS: Record<string, string> = {
+  core_openthread_border_router: "thread",
 };
 
 const getPortType = (port: SerialPort): SerialPortType => {
@@ -207,20 +214,35 @@ export class SerialConfigDashboard extends LitElement {
     />`;
   }
 
-  // Where the port's use is managed: the integration's own panel when it has
-  // one and is running, otherwise its entry on the integration page
-  private _consumerHref(consumer: SerialPortConsumer): string {
-    if (consumer.kind !== "config_entry") {
-      return `/config/app/${consumer.slug}/info`;
+  // The panel the integration behind this consumer is configured in, if it has
+  // one. A stopped consumer has no panel loaded to send the user to.
+  private _consumerPanel(consumer: SerialPortConsumer): string | undefined {
+    if (!consumer.active) {
+      return undefined;
     }
 
-    const configPanel =
-      consumer.active && consumer.domain
-        ? getConfigPanelPath(consumer.domain, this.hass.panels)
-        : undefined;
+    const domain =
+      consumer.kind === "config_entry"
+        ? consumer.domain
+        : consumer.slug && APP_INTEGRATIONS[consumer.slug];
 
-    return configPanel
-      ? `/${configPanel}?config_entry=${consumer.config_entry_id}`
+    if (!domain || !isComponentLoaded(this.hass.config, domain)) {
+      return undefined;
+    }
+
+    return getConfigPanelPath(domain, this.hass.panels);
+  }
+
+  // Where the port's use is managed, falling back to the consumer's own page
+  private _consumerHref(consumer: SerialPortConsumer): string {
+    const panel = this._consumerPanel(consumer);
+
+    if (consumer.kind !== "config_entry") {
+      return panel ? `/${panel}` : `/config/app/${consumer.slug}/info`;
+    }
+
+    return panel
+      ? `/${panel}?config_entry=${consumer.config_entry_id}`
       : `/config/integrations/integration/${consumer.domain}#config_entry=${consumer.config_entry_id}`;
   }
 


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Serial consumers linked to the integration's entry on the integration page — a device list, not where the radio on that port is managed. They now link to the integration's own panel when it has one, so a Zigbee stick opens the Zigbee panel, a Z-Wave stick the Z-Wave panel, and a Thread radio the Thread panel.

`ha-config-entry-row` already resolved which panel that is, from the panels an integration registers falling back to `integrationsWithPanel`. That moves to `getConfigPanelPath` so both callers stay in step.

A Thread radio is held by the Open Thread Border Router app rather than by a config entry, so `APP_INTEGRATIONS` maps the app to the integration behind it and the panel is looked up from there. A panel is only offered when its integration is loaded, which an app being started does not imply; a consumer that is not running keeps its own page.

## Screenshots

<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

The Serial panel itself is unchanged; the Zigbee and Z-Wave rows now land on their panels instead of the `zha` / `zwave_js` integration page. Both can be followed end to end in the demo, which already mocks all three panels. The Thread panel has no demo mocks yet, so that row is not shown there.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjmjZsxhdj9ekGmhFHXg3p