### PR TITLE
Show preview images for custom dashboard strategies

### DIFF
--- a/src/data/lovelace_custom_strategies.ts
+++ b/src/data/lovelace_custom_strategies.ts
@@ -5,6 +5,11 @@ export interface CustomStrategyEntry {
   name?: string;
   description?: string;
   documentationURL?: string;
+  /**
+   * Preview shown in the new dashboard dialog, one variant per theme mode.
+   * Should be a 160x160 image, like the built-in strategy previews.
+   */
+  images?: { light: string; dark: string };
   strategyType: LovelaceStrategyConfigType;
 }
 

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -187,6 +187,8 @@ class DialogNewDashboard extends LitElement implements HassDialog {
                           <dashboard-card
                             .name=${strategy.name || strategy.type}
                             .description=${strategy.description || ""}
+                            .img=${this._customStrategyImage(strategy)}
+                            .alt=${strategy.name || strategy.type}
                             @click=${this._selected}
                             .strategy=${CUSTOM_TYPE_PREFIX + strategy.type}
                           ></dashboard-card>
@@ -252,6 +254,8 @@ class DialogNewDashboard extends LitElement implements HassDialog {
                                   <dashboard-card
                                     .name=${strategy.name || strategy.type}
                                     .description=${strategy.description || ""}
+                                    .img=${this._customStrategyImage(strategy)}
+                                    .alt=${strategy.name || strategy.type}
                                     @click=${this._selected}
                                     .strategy=${CUSTOM_TYPE_PREFIX + strategy.type}
                                   ></dashboard-card>
@@ -298,6 +302,15 @@ class DialogNewDashboard extends LitElement implements HassDialog {
       return fuse.search(filter).map((result) => result.item);
     }
   );
+
+  private _customStrategyImage(strategy: CustomStrategyEntry): string {
+    if (!strategy.images) {
+      return "";
+    }
+    return this.hass.themes.darkMode
+      ? strategy.images.dark
+      : strategy.images.light;
+  }
 
   private _filterCustomStrategies = memoizeOne(
     (


### PR DESCRIPTION
## Proposed change

Since 2026.5, custom dashboard strategies registered in `window.customStrategies` appear under "Community dashboards" in the new dashboard dialog. The built-in strategies (Overview, Map, Webpage) each show a 160x160 preview image; custom entries render name and description only, so the community row looks unfinished next to them and there is no supported way for a strategy author to supply a picture.

This adds an optional `images: { light: string; dark: string }` to `CustomStrategyEntry`, the same shape the built-in `STRATEGIES` table already uses, and passes it (plus `alt`) to `dashboard-card` in both places custom strategies are rendered (the filtered search list and the "Community dashboards" section), picking the variant by `hass.themes.darkMode` exactly like the built-ins. Entries without `images` render as before.

Example registration:

```js
window.customStrategies.push({
  type: "ultra-dashboard",
  strategyType: "dashboard",
  name: "Ultra Dashboard",
  description: "A complete dashboard built from your areas and floors.",
  images: {
    light: "data:image/svg+xml,...",
    dark: "/hacsfiles/Ultra-Card/preview-dark.svg",
  },
});
```

## Screenshots

In the current dev build the "Community dashboards" row renders a text-only tile while Overview, Map and Webpage each have a preview. With this change a community tile carrying `images` renders the same 160x160 preview slot, switching between the light and dark variant with the theme.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request: home-assistant/developers.home-assistant#3336
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io