### PR TITLE
Use a readable text color for calendar events

### DIFF
--- a/src/common/color/compute-color.ts
+++ b/src/common/color/compute-color.ts
@@ -62,12 +62,16 @@ export function computeCssColor(color: string): string {
 /**
  * Get a color from document's styles
  * @param color - Named theme color (examples: `red`, `primary-text`)
- * @returns Resolved color; initial color if not found in document's styles
+ * @param style - Styles to resolve against, defaults to the document body
+ * @returns Resolved color; initial color if not found in the styles
  */
-export function resolveThemeColor(color: string): string {
+export function resolveThemeColor(
+  color: string,
+  style?: CSSStyleDeclaration
+): string {
   const cssColor = computeCssVariableName(color);
   if (cssColor.startsWith("--")) {
-    const resolved = getComputedStyle(document.body)
+    const resolved = (style ?? getComputedStyle(document.body))
       .getPropertyValue(cssColor)
       .trim();
     return resolved || color;

--- a/src/common/color/rgb.ts
+++ b/src/common/color/rgb.ts
@@ -1,4 +1,4 @@
-import { wcagLuminance, wcagContrast } from "culori";
+import { parse, wcagLuminance, wcagContrast } from "culori";
 import { theme2hex } from "./convert-color";
 
 /**
@@ -51,11 +51,17 @@ export const getRGBContrastRatio = (
 ) => Math.round((rgbContrast(rgb1, rgb2) + Number.EPSILON) * 100) / 100;
 
 /**
- * Returns a contrasted color (black or white) based on the luminance of another color
+ * Returns a contrasted color (black or white) for another color
  * @param color - Color (HEX, rgb/rgba, named color) to calculate a contrasted color
- * @returns HEX color ("#000000" for dark backgrounds, "#ffffff" for light backgrounds)
+ * @returns HEX color, whichever of black and white has the higher contrast ratio
  */
 export const getContrastedColorHex = (color: string): string => {
-  const lum = wcagLuminance(theme2hex(color));
-  return lum > 0.5 ? "#000000" : "#ffffff";
+  const hex = theme2hex(color.trim());
+  // culori throws on a color it cannot read
+  if (!parse(hex)) {
+    return "#ffffff";
+  }
+  return wcagContrast(hex, "#000000") >= wcagContrast(hex, "#ffffff")
+    ? "#000000"
+    : "#ffffff";
 };

--- a/src/common/color/rgb.ts
+++ b/src/common/color/rgb.ts
@@ -51,6 +51,17 @@ export const getRGBContrastRatio = (
 ) => Math.round((rgbContrast(rgb1, rgb2) + Number.EPSILON) * 100) / 100;
 
 /**
+ * Tells whether a color can be measured, which a CSS function that is passed
+ * through unevaluated cannot, and whether it covers what is behind it
+ * @param color - Color (HEX, rgb/rgba, named color) to check
+ * @returns Whether a contrast against this color says anything
+ */
+export const isOpaqueColor = (color: string): boolean => {
+  const parsed = parse(color.trim());
+  return parsed !== undefined && (parsed.alpha ?? 1) === 1;
+};
+
+/**
  * Returns a contrasted color (black or white) for another color
  * @param color - Color (HEX, rgb/rgba, named color) to calculate a contrasted color
  * @returns HEX color, whichever of black and white has the higher contrast ratio

--- a/src/data/calendar.ts
+++ b/src/data/calendar.ts
@@ -4,7 +4,7 @@ import {
   resolveThemeColor,
 } from "../common/color/compute-color";
 import { getColorByIndex } from "../common/color/colors";
-import { getContrastedColorHex } from "../common/color/rgb";
+import { getContrastedColorHex, isOpaqueColor } from "../common/color/rgb";
 import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateName } from "../common/entity/compute_state_name";
 import type { HomeAssistant } from "../types";
@@ -115,19 +115,21 @@ export const getCalendarColors = (
   color: string | null | undefined,
   index: number,
   computedStyles: CSSStyleDeclaration
-): { backgroundColor: string; textColor: string } => {
+): { backgroundColor: string; textColor?: string } => {
   // Fall back to a color by index when the entity has none set
   const resolved =
     color && isValidColorString(color)
       ? color
       : getColorByIndex(index, computedStyles);
+  // A theme color stays a CSS variable in the background, so the text color
+  // comes from what that variable holds for this element.
+  const background = resolveThemeColor(resolved, computedStyles);
   return {
     backgroundColor: computeCssColor(resolved),
-    // A theme color stays a CSS variable in the background, so the text color
-    // comes from what that variable holds for this element.
-    textColor: getContrastedColorHex(
-      resolveThemeColor(resolved, computedStyles)
-    ),
+    // A background we cannot measure keeps the color fullcalendar picks itself
+    textColor: isOpaqueColor(background)
+      ? getContrastedColorHex(background)
+      : undefined,
   };
 };
 

--- a/src/data/calendar.ts
+++ b/src/data/calendar.ts
@@ -3,6 +3,7 @@ import {
   isValidColorString,
 } from "../common/color/compute-color";
 import { getColorByIndex } from "../common/color/colors";
+import { getContrastedColorHex } from "../common/color/rgb";
 import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateName } from "../common/entity/compute_state_name";
 import type { HomeAssistant } from "../types";
@@ -13,6 +14,7 @@ export interface Calendar {
   entity_id: string;
   name?: string;
   backgroundColor?: string;
+  textColor?: string;
 }
 
 /** Object used to render a calendar event in fullcalendar. */
@@ -22,6 +24,7 @@ export interface CalendarEvent {
   end?: string;
   backgroundColor?: string;
   borderColor?: string;
+  textColor?: string;
   calendar: string;
   eventData: CalendarEventData;
   [key: string]: any;
@@ -107,6 +110,22 @@ export const fetchCalendarEvents = async (
   return { events: calEvents, errors };
 };
 
+export const getCalendarColors = (
+  color: string | null | undefined,
+  index: number,
+  computedStyles: CSSStyleDeclaration
+): { backgroundColor: string; textColor: string } => {
+  // Fall back to a color by index when the entity has none set
+  const resolved =
+    color && isValidColorString(color)
+      ? color
+      : getColorByIndex(index, computedStyles);
+  return {
+    backgroundColor: computeCssColor(resolved),
+    textColor: getContrastedColorHex(resolved),
+  };
+};
+
 export const getCalendars = (
   hass: HomeAssistant,
   element: Element,
@@ -127,18 +146,10 @@ export const getCalendars = (
     .map((eid, idx) => {
       const stateObj = hass.states[eid];
       const entityColor = entityOptionsMap.get(eid)?.calendar?.color;
-      let backgroundColor: string;
-      // Validate and use the color from entity registry if valid
-      if (entityColor && isValidColorString(entityColor)) {
-        backgroundColor = computeCssColor(entityColor);
-      } else {
-        // Fall back to default color by index
-        backgroundColor = getColorByIndex(idx, computedStyles);
-      }
       return {
         ...stateObj,
         name: computeStateName(stateObj),
-        backgroundColor,
+        ...getCalendarColors(entityColor, idx, computedStyles),
       };
     });
 };
@@ -268,6 +279,7 @@ export const normalizeSubscriptionEventData = (
     title: eventData.summary,
     backgroundColor: calendar.backgroundColor,
     borderColor: calendar.backgroundColor,
+    textColor: calendar.textColor,
     calendar: calendar.entity_id,
     eventData: normalizedEventData,
   };

--- a/src/data/calendar.ts
+++ b/src/data/calendar.ts
@@ -1,6 +1,7 @@
 import {
   computeCssColor,
   isValidColorString,
+  resolveThemeColor,
 } from "../common/color/compute-color";
 import { getColorByIndex } from "../common/color/colors";
 import { getContrastedColorHex } from "../common/color/rgb";
@@ -122,7 +123,11 @@ export const getCalendarColors = (
       : getColorByIndex(index, computedStyles);
   return {
     backgroundColor: computeCssColor(resolved),
-    textColor: getContrastedColorHex(resolved),
+    // A theme color stays a CSS variable in the background, so the text color
+    // comes from what that variable holds for this element.
+    textColor: getContrastedColorHex(
+      resolveThemeColor(resolved, computedStyles)
+    ),
   };
 };
 

--- a/src/panels/lovelace/cards/hui-calendar-card.ts
+++ b/src/panels/lovelace/cards/hui-calendar-card.ts
@@ -3,11 +3,6 @@ import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { classMap } from "lit/directives/class-map";
 import { customElement, property, state } from "lit/decorators";
-import {
-  computeCssColor,
-  isValidColorString,
-} from "../../../common/color/compute-color";
-import { getColorByIndex } from "../../../common/color/colors";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import { debounce } from "../../../common/util/debounce";
@@ -20,6 +15,7 @@ import type {
   CalendarEventApiData,
 } from "../../../data/calendar";
 import {
+  getCalendarColors,
   normalizeSubscriptionEventData,
   subscribeCalendarEvents,
 } from "../../../data/calendar";
@@ -142,21 +138,14 @@ export class HuiCalendarCard
         ]) ?? []
       );
       if (this._config?.entities) {
-        this._calendars = this._config.entities.map((entity, idx) => {
-          const entityColor = entityOptionsMap.get(entity)?.calendar?.color;
-          let backgroundColor: string;
-          // Validate and use the color from entity registry if valid
-          if (entityColor && isValidColorString(entityColor)) {
-            backgroundColor = computeCssColor(entityColor);
-          } else {
-            // Fall back to default color by index
-            backgroundColor = getColorByIndex(idx, computedStyles);
-          }
-          return {
-            entity_id: entity,
-            backgroundColor,
-          };
-        });
+        this._calendars = this._config.entities.map((entity, idx) => ({
+          entity_id: entity,
+          ...getCalendarColors(
+            entityOptionsMap.get(entity)?.calendar?.color,
+            idx,
+            computedStyles
+          ),
+        }));
       }
     }
   }

--- a/test/common/color/rgb.test.ts
+++ b/test/common/color/rgb.test.ts
@@ -3,6 +3,7 @@ import {
   luminosity,
   rgbContrast,
   getRGBContrastRatio,
+  getContrastedColorHex,
 } from "../../../src/common/color/rgb";
 
 describe("luminosity", () => {
@@ -37,5 +38,35 @@ describe("getRGBContrastRatio", () => {
 
   it("calculates the correct rounded contrast ratio between red and white", () => {
     expect(getRGBContrastRatio([255, 0, 0], [255, 255, 255])).toBe(4);
+  });
+});
+
+describe("getContrastedColorHex", () => {
+  it("picks white on dark backgrounds and black on light ones", () => {
+    expect(getContrastedColorHex("#000000")).toBe("#ffffff");
+    expect(getContrastedColorHex("#ffffff")).toBe("#000000");
+  });
+
+  it("picks whichever of black and white contrasts better", () => {
+    // --color-3 and --color-8 of the default palette
+    expect(getContrastedColorHex("#ff725c")).toBe("#000000");
+    expect(getContrastedColorHex("#97bbf5")).toBe("#000000");
+    expect(getContrastedColorHex("#4269d0")).toBe("#ffffff");
+  });
+
+  it("switches sides where the two contrast ratios meet", () => {
+    expect(getContrastedColorHex("#757575")).toBe("#ffffff");
+    expect(getContrastedColorHex("#767676")).toBe("#000000");
+  });
+
+  it("falls back on a color it cannot read", () => {
+    expect(getContrastedColorHex("")).toBe("#ffffff");
+    expect(getContrastedColorHex("color-mix(in srgb, red, blue)")).toBe(
+      "#ffffff"
+    );
+  });
+
+  it("reads a color with surrounding whitespace", () => {
+    expect(getContrastedColorHex("  #ffe066 ")).toBe("#000000");
   });
 });

--- a/test/data/calendar.test.ts
+++ b/test/data/calendar.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getCalendarColors } from "../../src/data/calendar";
 
 const style = {
@@ -6,31 +6,46 @@ const style = {
 } as CSSStyleDeclaration;
 
 describe("getCalendarColors", () => {
-  test("pick dark text for a light background", () => {
+  it("picks dark text for a light background", () => {
     expect(getCalendarColors("#ffe066", 0, style)).toEqual({
       backgroundColor: "#ffe066",
       textColor: "#000000",
     });
   });
 
-  test("pick light text for a dark background", () => {
+  it("picks light text for a dark background", () => {
     expect(getCalendarColors("#00679e", 0, style)).toEqual({
       backgroundColor: "#00679e",
       textColor: "#ffffff",
     });
   });
 
-  test("fall back to the color for the index", () => {
+  it("falls back to the color for the index", () => {
     expect(getCalendarColors(undefined, 0, style)).toEqual({
       backgroundColor: "#4269d0",
       textColor: "#ffffff",
     });
+    expect(getCalendarColors("not a color", 0, style).backgroundColor).toBe(
+      "#4269d0"
+    );
   });
 
-  test("resolve a theme color", () => {
-    expect(getCalendarColors("yellow", 0, style)).toEqual({
-      backgroundColor: "var(--yellow-color)",
+  it("reads a theme color from the element it is rendered on", () => {
+    const themed = {
+      getPropertyValue: (prop: string) =>
+        prop === "--blue-color" ? "#ffe066" : "",
+    } as CSSStyleDeclaration;
+    // Resolving against the document instead would read the named color blue
+    expect(getCalendarColors("blue", 0, themed)).toEqual({
+      backgroundColor: "var(--blue-color)",
       textColor: "#000000",
     });
+  });
+
+  it("survives a palette variable that does not resolve", () => {
+    const empty = {
+      getPropertyValue: () => "",
+    } as unknown as CSSStyleDeclaration;
+    expect(getCalendarColors(undefined, 0, empty).textColor).toBe("#ffffff");
   });
 });

--- a/test/data/calendar.test.ts
+++ b/test/data/calendar.test.ts
@@ -42,10 +42,17 @@ describe("getCalendarColors", () => {
     });
   });
 
-  it("survives a palette variable that does not resolve", () => {
+  it("leaves the text color unset for a background it cannot measure", () => {
     const empty = {
       getPropertyValue: () => "",
     } as unknown as CSSStyleDeclaration;
-    expect(getCalendarColors(undefined, 0, empty).textColor).toBe("#ffffff");
+    expect(getCalendarColors(undefined, 0, empty).textColor).toBeUndefined();
+    expect(
+      getCalendarColors("color-mix(in srgb, white 90%, black)", 0, style)
+        .textColor
+    ).toBeUndefined();
+    expect(
+      getCalendarColors("rgba(255, 255, 255, 0.1)", 0, style).textColor
+    ).toBeUndefined();
   });
 });

--- a/test/data/calendar.test.ts
+++ b/test/data/calendar.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { getCalendarColors } from "../../src/data/calendar";
+
+const style = {
+  getPropertyValue: (prop: string) => (prop === "--color-1" ? "#4269d0" : ""),
+} as CSSStyleDeclaration;
+
+describe("getCalendarColors", () => {
+  test("pick dark text for a light background", () => {
+    expect(getCalendarColors("#ffe066", 0, style)).toEqual({
+      backgroundColor: "#ffe066",
+      textColor: "#000000",
+    });
+  });
+
+  test("pick light text for a dark background", () => {
+    expect(getCalendarColors("#00679e", 0, style)).toEqual({
+      backgroundColor: "#00679e",
+      textColor: "#ffffff",
+    });
+  });
+
+  test("fall back to the color for the index", () => {
+    expect(getCalendarColors(undefined, 0, style)).toEqual({
+      backgroundColor: "#4269d0",
+      textColor: "#ffffff",
+    });
+  });
+
+  test("resolve a theme color", () => {
+    expect(getCalendarColors("yellow", 0, style)).toEqual({
+      backgroundColor: "var(--yellow-color)",
+      textColor: "#000000",
+    });
+  });
+});


### PR DESCRIPTION
## Proposed change

All-day events are drawn as blocks filled with the calendar color, and FullCalendar paints their title in `--fc-event-text-color`, which is white. On a light calendar color that title is unreadable, in both themes.

Derive the text color from the calendar color instead. `getContrastedColorHex` picked black or white by a luminance threshold rather than by contrast, which returned the worse of the two for 32 of the 54 palette colors, down to 1.95:1, so it now compares the two contrast ratios. That lifts `ha-label` and `ha-qr-code` as well, and can never lower the contrast anywhere.

Only block events change. The dot events in month view and the list view keep the theme text color, since their background is the card and not the calendar.

## Screenshots

| | Before | After |
| --- | --- | --- |
| Light | <img src="https://raw.githubusercontent.com/ivenos/frontend/pr-assets/before-light.png" width="380"> | <img src="https://raw.githubusercontent.com/ivenos/frontend/pr-assets/after-light.png" width="380"> |
| Dark | <img src="https://raw.githubusercontent.com/ivenos/frontend/pr-assets/before-dark.png" width="380"> | <img src="https://raw.githubusercontent.com/ivenos/frontend/pr-assets/after-dark.png" width="380"> |

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the perfect PR recommendations.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
