### PR TITLE
Use 'image_proxy' endpoint for image entity backgrounds

### DIFF
--- a/src/data/media_source.ts
+++ b/src/data/media_source.ts
@@ -69,7 +69,6 @@ export const isLocalMediaSourceContentId = (mediaId: string) =>
 export const isImageUploadMediaSourceContentId = (mediaId: string) =>
   mediaId.startsWith("media-source://image_upload");
 
-// Returns image entity ID or undefined.
 export const getImageEntityIdFromMediaSourceContentId = (
   mediaId: string
 ): string | undefined =>

--- a/src/data/media_source.ts
+++ b/src/data/media_source.ts
@@ -69,6 +69,14 @@ export const isLocalMediaSourceContentId = (mediaId: string) =>
 export const isImageUploadMediaSourceContentId = (mediaId: string) =>
   mediaId.startsWith("media-source://image_upload");
 
+// Returns image entity ID or undefined.
+export const getImageEntityIdFromMediaSourceContentId = (
+  mediaId: string
+): string | undefined =>
+  mediaId.startsWith("media-source://image/image.")
+    ? mediaId.slice("media-source://image/".length)
+    : undefined;
+
 export const uploadLocalMedia = async (
   hass: HomeAssistant,
   media_content_id: string,

--- a/src/panels/lovelace/views/hui-view-background.ts
+++ b/src/panels/lovelace/views/hui-view-background.ts
@@ -59,9 +59,10 @@ export class HUIViewBackground extends LitElement {
             await image.decode();
             const newStateObj = this.hass.states[this._entityId];
             // Discard if stale
-            if (url === computeImageUrl(newStateObj)) {
-              resolvedUrl = url;
+            if (url !== computeImageUrl(newStateObj)) {
+              return;
             }
+            resolvedUrl = url;
           } catch {
             resolvedUrl = undefined;
           }

--- a/src/panels/lovelace/views/hui-view-background.ts
+++ b/src/panels/lovelace/views/hui-view-background.ts
@@ -4,9 +4,11 @@ import { customElement, property, state } from "lit/decorators";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceViewBackgroundConfig } from "../../../data/lovelace/config/view";
 import {
+  getImageEntityIdFromMediaSourceContentId,
   isMediaSourceContentId,
   resolveMediaSourceWithCache,
 } from "../../../data/media_source";
+import { computeImageUrl } from "../../../data/image";
 
 @customElement("hui-view-background")
 export class HUIViewBackground extends LitElement {
@@ -16,6 +18,8 @@ export class HUIViewBackground extends LitElement {
     string | LovelaceViewBackgroundConfig | undefined;
 
   @state({ attribute: false }) resolvedImage?: string;
+
+  private _entityId: string | undefined = undefined;
 
   protected render() {
     return nothing;
@@ -37,17 +41,36 @@ export class HUIViewBackground extends LitElement {
     const backgroundImage = this._getBackgroundImage(this.background);
 
     if (!backgroundImage || !isMediaSourceContentId(backgroundImage)) {
+      this._entityId = undefined;
       this.resolvedImage = undefined;
       return;
     }
 
     let resolvedUrl: string | undefined;
-    try {
-      resolvedUrl = (
-        await resolveMediaSourceWithCache(this.hass, backgroundImage)
-      ).url;
-    } catch {
-      resolvedUrl = undefined;
+    this._entityId = getImageEntityIdFromMediaSourceContentId(backgroundImage);
+    if (this._entityId) {
+      const stateObj = this.hass.states[this._entityId];
+      if (stateObj) {
+        const url = computeImageUrl(stateObj);
+        if (url) {
+          const image = new Image();
+          image.src = url;
+          try {
+            await image.decode();
+            resolvedUrl = url;
+          } catch {
+            resolvedUrl = undefined;
+          }
+        }
+      }
+    } else {
+      try {
+        resolvedUrl = (
+          await resolveMediaSourceWithCache(this.hass, backgroundImage)
+        ).url;
+      } catch {
+        resolvedUrl = undefined;
+      }
     }
     // Discard if the background changed while resolving
     if (this._getBackgroundImage(this.background) === backgroundImage) {
@@ -129,6 +152,13 @@ export class HUIViewBackground extends LitElement {
         this.hass.themes !== oldHass.themes ||
         this.hass.selectedTheme !== oldHass.selectedTheme
       ) {
+        applyTheme = true;
+      }
+      if (
+        this._entityId &&
+        this.hass.states[this._entityId] !== oldHass?.states[this._entityId]
+      ) {
+        this._fetchMedia();
         applyTheme = true;
       }
     }

--- a/src/panels/lovelace/views/hui-view-background.ts
+++ b/src/panels/lovelace/views/hui-view-background.ts
@@ -57,7 +57,11 @@ export class HUIViewBackground extends LitElement {
           image.src = this.hass.hassUrl(url);
           try {
             await image.decode();
-            resolvedUrl = url;
+            const newStateObj = this.hass.states[this._entityId];
+            // Discard if stale
+            if (url === computeImageUrl(newStateObj)) {
+              resolvedUrl = url;
+            }
           } catch {
             resolvedUrl = undefined;
           }

--- a/src/panels/lovelace/views/hui-view-background.ts
+++ b/src/panels/lovelace/views/hui-view-background.ts
@@ -54,7 +54,7 @@ export class HUIViewBackground extends LitElement {
         const url = computeImageUrl(stateObj);
         if (url) {
           const image = new Image();
-          image.src = url;
+          image.src = this.hass.hassUrl(url);
           try {
             await image.decode();
             resolvedUrl = url;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When we select media for a background, and select an item backed by an image entity, we currently resolve that media against the media_source API which returns an `image_proxy_stream` url. For view backgrounds, this PR replaces this process and instead uses the `image_proxy` url from the image entity instead. This has the following advantages:

- **Better cross browser support**: According to my searching, and reported issue #54016, using an MJPEG stream as a css background property sometimes works but it is not robustly supported in all browsers (e.g. Safari just renders a blank screen).
- **More robust disconnection handling**: if we lose connection to server, current MJPEG stream just crashes and is not recovered, requiring browser refresh.
- **More robust core restart handling**: if we try to resolve the media_id too early in core's boot process, we might try to resolve before the image is setup, leading to an image 404 with no obvious recovery path. This solution robustly waits until the image itself reports it is ready, and then fetches the image. 
- **Remove unnecessary API call** - State machine already contains the image URL for an image entity. Using the media API requires waiting for an unnecessary server API call when we already have the URL.
- **Reduce open HTTP connections** - The MJPEG stream requires holding an independent HTTP connection to the server for as long as the image is displayed (and is not even immediately closed when it is no longer displayed). If we open too many connections it can block the websocket leading to frontend hang.

No disadvantages to this approach that I'm aware of.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54016 fixes #53928 
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
