### PR TITLE
Fix multi-source energy graph colors

### DIFF
--- a/src/panels/lovelace/cards/energy/common/color.ts
+++ b/src/panels/lovelace/cards/energy/common/color.ts
@@ -7,6 +7,34 @@ import {
 } from "../../../../../common/color/convert-color";
 import { labBrighten, labDarken } from "../../../../../common/color/lab";
 
+/**
+ * Series indices below this keep the legacy lightness stepping, so dashboards
+ * with only a few sources of a kind look exactly like before.
+ */
+const HUE_ROTATION_START_IDX = 3;
+
+/** Hue offset per additional series, in degrees (golden angle). */
+const GOLDEN_ANGLE_DEG = 137.5;
+
+/**
+ * Below this chroma the base color is effectively grey, and a hue rotation
+ * alone cannot separate the series. Bump chroma so rotation has an effect.
+ */
+const GREYISH_CHROMA_THRESHOLD = 8;
+const FALLBACK_CHROMA = 25;
+
+/**
+ * Keep the lightness of rotated series inside a readable band; lightness
+ * laddering has already collapsed by the time we rotate, so walk gently back
+ * toward the base instead of compounding the old +-18/index steps.
+ */
+const LIGHTNESS_BAND_MIN = 35;
+const LIGHTNESS_BAND_MAX = 75;
+const LIGHTNESS_STEP_PER_INDEX = 4;
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
 export function getEnergyColor(
   computedStyles: CSSStyleDeclaration,
   darkMode: boolean,
@@ -27,16 +55,44 @@ export function getEnergyColor(
   let hexColor = theme2hex(themeColor);
 
   if (themeIdxColor.length === 0 && idx) {
-    // Brighten or darken the color based on set position.
-    // Skip if theme already provides a color for this set.
+    if (idx < HUE_ROTATION_START_IDX) {
+      // Legacy behaviour: lightness stepping for the first two extra series.
+      // Identical output to the previous implementation.
+      hexColor = rgb2hex(
+        lab2rgb(
+          darkMode
+            ? labBrighten(rgb2lab(hex2rgb(hexColor)), idx)
+            : labDarken(rgb2lab(hex2rgb(hexColor)), idx)
+        )
+      );
+    } else {
+      // Three or more sources of a kind: lightness alone is no longer
+      // distinguishable. Separate additional series by hue instead, spaced
+      // by the golden angle so any number of series stays well separated.
+      // Chroma is inherited from the base color (respecting muted themes),
+      // only rescued from near-grey so rotation has an effect. Lightness
+      // walks gently back toward the base inside a readable band.
+      const rotationIndex = idx - (HUE_ROTATION_START_IDX - 1);
+      const [l, a, b] = rgb2lab(hex2rgb(hexColor));
 
-    hexColor = rgb2hex(
-      lab2rgb(
-        darkMode
-          ? labBrighten(rgb2lab(hex2rgb(hexColor)), idx)
-          : labDarken(rgb2lab(hex2rgb(hexColor)), idx)
-      )
-    );
+      let chroma = Math.hypot(a, b);
+      if (chroma < GREYISH_CHROMA_THRESHOLD) {
+        chroma = FALLBACK_CHROMA;
+      }
+
+      const hue =
+        Math.atan2(b, a) + (rotationIndex * GOLDEN_ANGLE_DEG * Math.PI) / 180;
+
+      const targetL = clamp(
+        l + (darkMode ? 1 : -1) * LIGHTNESS_STEP_PER_INDEX * rotationIndex,
+        LIGHTNESS_BAND_MIN,
+        LIGHTNESS_BAND_MAX
+      );
+
+      hexColor = rgb2hex(
+        lab2rgb([targetL, chroma * Math.cos(hue), chroma * Math.sin(hue)])
+      );
+    }
   }
 
   if (compare) {

--- a/test/panels/lovelace/cards/energy/common/color.test.ts
+++ b/test/panels/lovelace/cards/energy/common/color.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import {
+  hex2rgb,
+  lab2rgb,
+  rgb2hex,
+  rgb2lab,
+} from "../../../../../../src/common/color/convert-color";
+import { labBrighten, labDarken } from "../../../../../../src/common/color/lab";
+import { getEnergyColor } from "../../../../../../src/panels/lovelace/cards/energy/common/color";
+
+const createStyles = (vars: Record<string, string> = {}): CSSStyleDeclaration =>
+  ({
+    getPropertyValue: (name: string) => vars[name] ?? "",
+  }) as unknown as CSSStyleDeclaration;
+
+const SOLAR_COLOR = "#ff9800"; // typical theme value for --energy-solar-color
+
+// Muted khaki: stays inside the sRGB gamut after L-shifts and hue rotations,
+// so geometry tests measure the algorithm, not gamut clipping.
+const GEOMETRY_BASE = "#9c8a55";
+
+const stylesWithBase = (base: string = SOLAR_COLOR) =>
+  createStyles({ "--energy-solar-color": base });
+
+/** Lab lightness of a hex color. */
+const lightness = (hex: string) => rgb2lab(hex2rgb(stripAlpha(hex)))[0];
+
+/** Chroma (sqrt(a^2 + b^2)) of a hex color. */
+const chroma = (hex: string) => {
+  const [, a, b] = rgb2lab(hex2rgb(stripAlpha(hex)));
+  return Math.hypot(a, b);
+};
+
+/** Hue angle in degrees of a hex color. */
+const hueDeg = (hex: string) => {
+  const [, a, b] = rgb2lab(hex2rgb(stripAlpha(hex)));
+  return (Math.atan2(b, a) * 180) / Math.PI;
+};
+
+const stripAlpha = (hex: string) => (hex.length === 9 ? hex.slice(0, 7) : hex);
+
+describe("getEnergyColor", () => {
+  it("returns the theme color with background alpha", () => {
+    const out = getEnergyColor(
+      stylesWithBase(),
+      false,
+      true,
+      false,
+      "--energy-solar-color"
+    );
+    expect(out).toBe(SOLAR_COLOR + "7F");
+  });
+
+  it("applies compare alpha modifiers", () => {
+    const out = getEnergyColor(
+      stylesWithBase(),
+      false,
+      false,
+      true,
+      "--energy-solar-color"
+    );
+    expect(out).toBe(SOLAR_COLOR + "7F");
+    const outBg = getEnergyColor(
+      stylesWithBase(),
+      false,
+      true,
+      true,
+      "--energy-solar-color"
+    );
+    expect(outBg).toBe(SOLAR_COLOR + "32");
+  });
+
+  it("prefers an indexed theme color and does not modify it", () => {
+    const styles = createStyles({
+      "--energy-solar-color": SOLAR_COLOR,
+      "--energy-solar-color-4": "#abcdef",
+    });
+    const out = getEnergyColor(
+      styles,
+      false,
+      true,
+      false,
+      "--energy-solar-color",
+      4
+    );
+    expect(out).toBe("#abcdef7F");
+  });
+
+  describe("legacy lightness stepping (idx 1 and 2)", () => {
+    it.each([[1], [2]])("idx %i matches the previous implementation", (idx) => {
+      const styles = stylesWithBase();
+      for (const darkMode of [false, true]) {
+        const expected =
+          rgb2hex(
+            lab2rgb(
+              darkMode
+                ? labBrighten(rgb2lab(hex2rgb(SOLAR_COLOR)), idx)
+                : labDarken(rgb2lab(hex2rgb(SOLAR_COLOR)), idx)
+            )
+          ) + "7F";
+        const out = getEnergyColor(
+          styles,
+          darkMode,
+          true,
+          false,
+          "--energy-solar-color",
+          idx
+        );
+        expect(out).toBe(expected);
+      }
+    });
+
+    it("differs from the base color only in lightness", () => {
+      const out = getEnergyColor(
+        createStyles({ "--energy-solar-color": GEOMETRY_BASE }),
+        true,
+        false,
+        false,
+        "--energy-solar-color",
+        1
+      );
+      // Values survive an 8-bit round-trip, so allow a few degrees / units.
+      expect(Math.abs(hueDeg(out) - hueDeg(GEOMETRY_BASE))).toBeLessThan(5);
+      expect(Math.abs(chroma(out) - chroma(GEOMETRY_BASE))).toBeLessThan(3);
+      expect(lightness(out)).toBeGreaterThan(lightness(GEOMETRY_BASE));
+    });
+  });
+
+  describe("hue rotation (idx >= 3)", () => {
+    it("rotates hue away from the base color", () => {
+      const out = getEnergyColor(
+        createStyles({ "--energy-solar-color": GEOMETRY_BASE }),
+        false,
+        false,
+        false,
+        "--energy-solar-color",
+        3
+      );
+      // Gamut clipping may reduce chroma, but the series must stay visibly
+      // colorful and clearly re-hued.
+      expect(chroma(out)).toBeGreaterThan(chroma(GEOMETRY_BASE) * 0.5);
+      const delta = Math.abs(hueDeg(out) - hueDeg(GEOMETRY_BASE));
+      expect(delta).toBeGreaterThan(90);
+      expect(delta).toBeLessThan(270);
+    });
+
+    it("spaces consecutive rotated series by the golden angle", () => {
+      const base = createStyles({ "--energy-solar-color": GEOMETRY_BASE });
+      const s3 = getEnergyColor(
+        base,
+        false,
+        false,
+        false,
+        "--energy-solar-color",
+        3
+      );
+      const s4 = getEnergyColor(
+        base,
+        false,
+        false,
+        false,
+        "--energy-solar-color",
+        4
+      );
+      // Allow slack for 8-bit quantization and mild gamut clipping.
+      const delta = Math.abs(((hueDeg(s4) - hueDeg(s3) + 540) % 360) - 180);
+      expect(Math.abs(delta - 137.5)).toBeLessThan(15);
+    });
+
+    it("rescues near-grey base colors so rotation is visible", () => {
+      const out = getEnergyColor(
+        stylesWithBase("#808080"),
+        false,
+        false,
+        false,
+        "--energy-solar-color",
+        3
+      );
+      expect(chroma(out)).toBeGreaterThanOrEqual(20);
+    });
+
+    it("clamps rotated lightness into the readable band", () => {
+      // Very light base in light mode: must not converge to white.
+      const out = getEnergyColor(
+        stylesWithBase("#f5f5f5"),
+        false,
+        false,
+        false,
+        "--energy-solar-color",
+        7
+      );
+      expect(lightness(out)).toBeLessThanOrEqual(75);
+      // Very dark base in dark mode: must not converge to black.
+      const outDark = getEnergyColor(
+        stylesWithBase("#0a0a0a"),
+        true,
+        false,
+        false,
+        "--energy-solar-color",
+        7
+      );
+      expect(lightness(outDark)).toBeGreaterThanOrEqual(35);
+    });
+
+    it("produces distinct colors for many series", () => {
+      const colors = Array.from({ length: 8 }, (_, idx) =>
+        getEnergyColor(
+          stylesWithBase(),
+          false,
+          false,
+          false,
+          "--energy-solar-color",
+          idx
+        ).replace(/(..)$/, "")
+      );
+      expect(new Set(colors).size).toBe(colors.length);
+    });
+  });
+});


### PR DESCRIPTION
Colors for sources beyond the first are no longer distinguished by lightness alone, which became indistinguishable with three or more sources of a kind. Series with idx >= 3 are now spaced by the golden angle in hue, inheriting chroma and a readable lightness band from the theme. Dashboards with up to three sources per type render identically to before.

Fixes #54039

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Brief: Energy graphs become unreadable with more than three sources of a kind
(all batteries, solar arrays, etc.) because the fallback in `getEnergyColor`
differentiates series by lightness only, converging to near-white/near-black.
This adds golden-angle hue rotation for series indices >= 3, while <= 3
sources render byte-identically to before.


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
Before:
<img width="893" height="1224" alt="default_theme_before_change_blurred" src="https://github.com/user-attachments/assets/3c577b50-4b42-43a7-904d-29105d2325e1" />
After:
<img width="897" height="1229" alt="default_theme_after_change_blurred" src="https://github.com/user-attachments/assets/3086dd33-df2c-4bbf-9795-fcfdd717c20c" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54039
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
