### PR TITLE
Add timedelta_string template completion

### DIFF
--- a/src/resources/jinja_ha_completions.ts
+++ b/src/resources/jinja_ha_completions.ts
@@ -973,6 +973,11 @@ const HA_FUNCTION_DEFS: HaFunctionDef[] = [
     info: "Creates a timedelta object.",
   },
   {
+    snippet: "timedelta_string(${value}, ${precision})",
+    detail: "value, precision?",
+    info: "Formats a timedelta object as a human-readable duration.",
+  },
+  {
     snippet: 'timestamp_custom(${timestamp}, "${format}")',
     detail: "timestamp, format, local_time?",
     info: "Formats a Unix timestamp using a custom strftime format string.",


### PR DESCRIPTION
## Proposed change

Add `timedelta_string` to the template editor completions. This provides autocomplete and hover documentation for the new Core template helper.


## Screenshots

<img width="562" height="290" alt="image" src="https://github.com/user-attachments/assets/c8677df0-80bf-48bd-a74c-7722e19af233" />

and after clicking it:
<img width="513" height="208" alt="image" src="https://github.com/user-attachments/assets/aa6e5f6c-994f-479b-8149-d5fa89c9a070" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45180
- Link to developer documentation pull request: N/A
- Link to backend pull request: https://github.com/home-assistant/core/pull/169773

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] -> https://github.com/home-assistant/home-assistant.io/pull/45180

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
