### PR TITLE
Add state card feature

### DIFF
--- a/src/panels/lovelace/card-features/hui-state-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-state-card-feature.ts
@@ -1,0 +1,91 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { consumeEntityState } from "../../../common/decorators/consume-context-entry";
+import "../../../state-display/state-display";
+import type { HomeAssistant } from "../../../types";
+import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
+import type {
+  LovelaceCardFeatureContext,
+  StateCardFeatureConfig,
+} from "./types";
+
+export const supportsStateCardFeature = (
+  hass: HomeAssistant,
+  context: LovelaceCardFeatureContext
+) => !!context.entity_id && context.entity_id in hass.states;
+
+@customElement("hui-state-card-feature")
+class HuiStateCardFeature extends LitElement implements LovelaceCardFeature {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state()
+  @consumeEntityState({ entityIdPath: ["context", "entity_id"] })
+  private _stateObj?: HassEntity;
+
+  @state() private _config?: StateCardFeatureConfig;
+
+  static getStubConfig(): StateCardFeatureConfig {
+    return {
+      type: "state",
+    };
+  }
+
+  public static async getConfigElement(): Promise<LovelaceCardFeatureEditor> {
+    await import("../editor/config-elements/hui-state-card-feature-editor");
+    return document.createElement("hui-state-card-feature-editor");
+  }
+
+  public setConfig(config: StateCardFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  protected render() {
+    if (!this._config || !this.hass || !this._stateObj) {
+      return nothing;
+    }
+
+    return html`
+      <state-display
+        .hass=${this.hass}
+        .stateObj=${this._stateObj}
+        .content=${this._config.state_content}
+      ></state-display>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: var(--feature-height);
+      padding: 0 var(--ha-space-2);
+      box-sizing: border-box;
+      color: var(--primary-text-color);
+      font-size: var(--ha-font-size-l);
+      font-weight: var(--ha-font-weight-medium);
+      line-height: var(--ha-line-height-condensed);
+      text-align: center;
+      overflow: hidden;
+      pointer-events: none !important;
+    }
+    state-display {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-state-card-feature": HuiStateCardFeature;
+  }
+}

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -179,6 +179,11 @@ export interface SelectOptionsCardFeatureConfig {
   style?: "dropdown" | "buttons";
 }
 
+export interface StateCardFeatureConfig {
+  type: "state";
+  state_content?: string | string[];
+}
+
 export interface NumericInputCardFeatureConfig {
   type: "numeric-input";
   style?: "buttons" | "slider";
@@ -377,6 +382,7 @@ export type LovelaceCardFeatureConfig =
   | MediaPlayerVolumeSliderCardFeatureConfig
   | NumericInputCardFeatureConfig
   | SelectOptionsCardFeatureConfig
+  | StateCardFeatureConfig
   | TrendGraphCardFeatureConfig
   | TargetHumidityCardFeatureConfig
   | TargetTemperatureCardFeatureConfig

--- a/src/panels/lovelace/create-element/create-card-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-card-feature-element.ts
@@ -33,6 +33,7 @@ import "../card-features/hui-media-player-volume-buttons-card-feature";
 import "../card-features/hui-media-player-volume-slider-card-feature";
 import "../card-features/hui-numeric-input-card-feature";
 import "../card-features/hui-select-options-card-feature";
+import "../card-features/hui-state-card-feature";
 import "../card-features/hui-target-humidity-card-feature";
 import "../card-features/hui-target-temperature-card-feature";
 import "../card-features/hui-timer-actions-card-feature";
@@ -96,6 +97,7 @@ const TYPES = new Set<LovelaceCardFeatureConfig["type"]>([
   "numeric-input",
   "precipitation-forecast",
   "select-options",
+  "state",
   "trend-graph",
   "target-humidity",
   "target-temperature",

--- a/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
@@ -62,6 +62,7 @@ import { supportsMediaPlayerVolumeButtonsCardFeature } from "../../card-features
 import { supportsMediaPlayerVolumeSliderCardFeature } from "../../card-features/hui-media-player-volume-slider-card-feature";
 import { supportsNumericInputCardFeature } from "../../card-features/hui-numeric-input-card-feature";
 import { supportsSelectOptionsCardFeature } from "../../card-features/hui-select-options-card-feature";
+import { supportsStateCardFeature } from "../../card-features/hui-state-card-feature";
 import { supportsTargetHumidityCardFeature } from "../../card-features/hui-target-humidity-card-feature";
 import { supportsTargetTemperatureCardFeature } from "../../card-features/hui-target-temperature-card-feature";
 import { supportsTimerActionsCardFeature } from "../../card-features/hui-timer-actions-card-feature";
@@ -128,6 +129,7 @@ const UI_FEATURE_TYPES = [
   "numeric-input",
   "precipitation-forecast",
   "select-options",
+  "state",
   "trend-graph",
   "target-humidity",
   "target-temperature",
@@ -173,6 +175,7 @@ const EDITABLES_FEATURE_TYPES = new Set<UiFeatureTypes>([
   "media-player-volume-slider",
   "numeric-input",
   "select-options",
+  "state",
   "timer-actions",
   "timer-presets",
   "trend-graph",
@@ -226,6 +229,7 @@ const SUPPORTS_FEATURE_TYPES: Record<
   "numeric-input": supportsNumericInputCardFeature,
   "precipitation-forecast": supportsPrecipitationForecastCardFeature,
   "select-options": supportsSelectOptionsCardFeature,
+  state: supportsStateCardFeature,
   "trend-graph": supportsTrendGraphCardFeature,
   "target-humidity": supportsTargetHumidityCardFeature,
   "target-temperature": supportsTargetTemperatureCardFeature,

--- a/src/panels/lovelace/editor/config-elements/hui-state-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-state-card-feature-editor.ts
@@ -1,0 +1,78 @@
+import { html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../components/ha-form/types";
+import type { HomeAssistant } from "../../../../types";
+import type {
+  LovelaceCardFeatureContext,
+  StateCardFeatureConfig,
+} from "../../card-features/types";
+import type { LovelaceCardFeatureEditor } from "../../types";
+
+@customElement("hui-state-card-feature-editor")
+export class HuiStateCardFeatureEditor
+  extends LitElement
+  implements LovelaceCardFeatureEditor
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state() private _config?: StateCardFeatureConfig;
+
+  public setConfig(config: StateCardFeatureConfig): void {
+    this._config = config;
+  }
+
+  private _schema = memoizeOne(
+    (entityId?: string) =>
+      [
+        {
+          name: "state_content",
+          selector: {
+            ui_state_content: {
+              entity_id: entityId,
+              allow_context: true,
+            },
+          },
+        },
+      ] as const
+  );
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const schema = this._schema(this.context?.entity_id);
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this._config}
+        .schema=${schema}
+        .computeLabel=${this._computeLabelCallback}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    fireEvent(this, "config-changed", { config: ev.detail.value });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) =>
+    this.hass!.localize(
+      `ui.panel.lovelace.editor.features.types.state.${schema.name}`
+    );
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-state-card-feature-editor": HuiStateCardFeatureEditor;
+  }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -11009,6 +11009,10 @@
                 "options": "Options",
                 "customize_options": "Customize options"
               },
+              "state": {
+                "label": "State",
+                "state_content": "[%key:ui::panel::lovelace::editor::card::tile::state_content%]"
+              },
               "toggle": {
                 "label": "Toggle"
               },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This adds a `state` card feature. It shows the entity state, or any other state content item, in the feature area of a card.

With `features_position: inline` the value sits on the right side of a tile, next to the name. This turns a tile into a read-only indicator for a select, an input_datetime, or a sensor, without a dropdown or a button that looks tappable. In the bottom position it works as a large value display.

The feature reuses `state-display`, so the text is formatted the same way as the state under the tile name. The only option is `state_content`, and the editor uses the same picker as the tile card. The feature keeps a `hass` property because `state-display` needs it, the same way the tile card passes it.

```yaml
type: tile
entity: input_select.home_mode
hide_state: true
features_position: inline
features:
  - type: state
```

This is a smaller take on https://github.com/home-assistant/frontend/pull/51692. It has no font size or weight options, and the tile typography stays as it is. I left `time_format` out for now and can add it in a follow-up if you want it.

If you want to try it before it lands, I published the same feature as a HACS dashboard resource: https://github.com/pszypowicz/state-card-feature. Add it as a custom repository of type Dashboard and use `type: custom:state-card-feature`. That build also has the `time_format` option, so the follow-up here can reuse it.

## Screenshots

<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Light and dark theme. The first tile uses the inline position, the two middle tiles use the bottom position, and the last tile combines the inline state with a toggle feature below it.

![State feature, light theme](https://raw.githubusercontent.com/pszypowicz/frontend/pr-screenshots/screenshots/state-card-feature-light.png)

![State feature, dark theme](https://raw.githubusercontent.com/pszypowicz/frontend/pr-screenshots/screenshots/state-card-feature-dark.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/51692, https://community.home-assistant.io/t/make-it-possible-to-set-tile-card-features-in-lovelace-as-read-only-or-ignore-input-without-a-preceeding-long-press/680537
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/48005
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

