### PR TITLE
Fix frozen and phantom energy distribution flow dots

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
@@ -39,6 +39,20 @@ import { formatNumber } from "../../../../common/number/format_number";
 
 const CIRCLE_CIRCUMFERENCE = 238.76104;
 
+export const MIN_FLOW_DURATION = 1;
+export const MAX_FLOW_DURATION = 6;
+
+// Summing hourly statistics leaves float residue, so sources that cancel out
+// exactly still yield a tiny non-zero flow. Anything this small is not real.
+export const FLOW_EPSILON = 1e-6;
+
+export const hasFlow = (value: number | null | undefined): value is number =>
+  (value ?? 0) > FLOW_EPSILON;
+
+// A flow's share of all flows sets its speed; a sole flow sits at MIN.
+export const flowDuration = (value: number, total: number): number =>
+  MAX_FLOW_DURATION - (value / total) * (MAX_FLOW_DURATION - MIN_FLOW_DURATION);
+
 const periodIncludesNow = (data: EnergyData): boolean =>
   !data.end || data.end.getTime() >= Date.now();
 
@@ -843,8 +857,8 @@ class HuiEnergyDistrubutionCard
                       ? svg`<path
                           id="battery-grid"
                           class=${classMap({
-                            "battery-from-grid": Boolean(batteryFromGrid),
-                            "battery-to-grid": Boolean(batteryToGrid),
+                            "battery-from-grid": hasFlow(batteryFromGrid),
+                            "battery-to-grid": hasFlow(batteryToGrid),
                           })}
                           d="M45,100 v-15 c0,-35 -10,-30 -30,-30 h-20"
                           vector-effect="non-scaling-stroke"
@@ -875,14 +889,14 @@ class HuiEnergyDistrubutionCard
                   : nothing
               }
               ${
-                solarToGrid && this._animate
+                hasFlow(solarToGrid) && this._animate
                   ? svg`<circle
                     r="1"
                     class="return"
                     vector-effect="non-scaling-stroke"
                   >
                     <animateMotion
-                      dur="${6 - (solarToGrid / totalLines) * 6}s"
+                      dur="${flowDuration(solarToGrid, totalLines)}s"
                       repeatCount="indefinite"
                       calcMode="linear"
                     >
@@ -892,14 +906,14 @@ class HuiEnergyDistrubutionCard
                   : ""
               }
               ${
-                solarConsumption && this._animate
+                hasFlow(solarConsumption) && this._animate
                   ? svg`<circle
                     r="1"
                     class="solar"
                     vector-effect="non-scaling-stroke"
                   >
                     <animateMotion
-                      dur="${6 - (solarConsumption / totalLines) * 5}s"
+                      dur="${flowDuration(solarConsumption, totalLines)}s"
                       repeatCount="indefinite"
                       calcMode="linear"
                     >
@@ -909,14 +923,14 @@ class HuiEnergyDistrubutionCard
                   : ""
               }
               ${
-                gridConsumption && this._animate
+                hasFlow(gridConsumption) && this._animate
                   ? svg`<circle
                     r="1"
                     class="grid"
                     vector-effect="non-scaling-stroke"
                   >
                     <animateMotion
-                      dur="${6 - (gridConsumption / totalLines) * 5}s"
+                      dur="${flowDuration(gridConsumption, totalLines)}s"
                       repeatCount="indefinite"
                       calcMode="linear"
                     >
@@ -926,14 +940,14 @@ class HuiEnergyDistrubutionCard
                   : ""
               }
               ${
-                solarToBattery && this._animate
+                hasFlow(solarToBattery) && this._animate
                   ? svg`<circle
                     r="1"
                     class="battery-solar"
                     vector-effect="non-scaling-stroke"
                   >
                     <animateMotion
-                      dur="${6 - (solarToBattery / totalLines) * 5}s"
+                      dur="${flowDuration(solarToBattery, totalLines)}s"
                       repeatCount="indefinite"
                       calcMode="linear"
                     >
@@ -943,14 +957,14 @@ class HuiEnergyDistrubutionCard
                   : ""
               }
               ${
-                batteryConsumption && this._animate
+                hasFlow(batteryConsumption) && this._animate
                   ? svg`<circle
                     r="1"
                     class="battery-house"
                     vector-effect="non-scaling-stroke"
                   >
                     <animateMotion
-                      dur="${6 - (batteryConsumption / totalLines) * 5}s"
+                      dur="${flowDuration(batteryConsumption, totalLines)}s"
                       repeatCount="indefinite"
                       calcMode="linear"
                     >
@@ -960,14 +974,14 @@ class HuiEnergyDistrubutionCard
                   : ""
               }
               ${
-                batteryFromGrid && this._animate
+                hasFlow(batteryFromGrid) && this._animate
                   ? svg`<circle
                     r="1"
                     class="battery-from-grid"
                     vector-effect="non-scaling-stroke"
                   >
                     <animateMotion
-                      dur="${6 - (batteryFromGrid / totalLines) * 5}s"
+                      dur="${flowDuration(batteryFromGrid, totalLines)}s"
                       repeatCount="indefinite"
                       keyPoints="1;0" keyTimes="0;1"
                       calcMode="linear"
@@ -978,14 +992,14 @@ class HuiEnergyDistrubutionCard
                   : ""
               }
               ${
-                batteryToGrid && this._animate
+                hasFlow(batteryToGrid) && this._animate
                   ? svg`<circle
                     r="1"
                     class="battery-to-grid"
                     vector-effect="non-scaling-stroke"
                   >
                     <animateMotion
-                      dur="${6 - (batteryToGrid / totalLines) * 5}s"
+                      dur="${flowDuration(batteryToGrid, totalLines)}s"
                       repeatCount="indefinite"
                       calcMode="linear"
                     >

--- a/test/panels/lovelace/cards/energy/hui-energy-distribution-card.test.ts
+++ b/test/panels/lovelace/cards/energy/hui-energy-distribution-card.test.ts
@@ -1,0 +1,61 @@
+import { assert, describe, it } from "vitest";
+
+import {
+  FLOW_EPSILON,
+  MAX_FLOW_DURATION,
+  MIN_FLOW_DURATION,
+  flowDuration,
+  hasFlow,
+} from "../../../../../src/panels/lovelace/cards/energy/hui-energy-distribution-card";
+
+describe("flowDuration", () => {
+  it("returns MIN_FLOW_DURATION when a flow is the only one", () => {
+    // A full feed-in setup has solar->grid as its sole flow every day, so the
+    // share is exactly 1. This used to evaluate to 0s, which is not a valid
+    // SMIL duration and left the dot frozen instead of animating.
+    assert.strictEqual(flowDuration(35.18, 35.18), MIN_FLOW_DURATION);
+  });
+
+  it("approaches MAX_FLOW_DURATION as a flow's share approaches zero", () => {
+    assert.strictEqual(flowDuration(0, 100), MAX_FLOW_DURATION);
+    assert.closeTo(flowDuration(0.001, 100), MAX_FLOW_DURATION, 0.001);
+  });
+
+  it("stays within the duration bounds across the whole share range", () => {
+    for (let share = 0; share <= 1; share += 0.01) {
+      const duration = flowDuration(share, 1);
+      assert.isAtLeast(duration, MIN_FLOW_DURATION);
+      assert.isAtMost(duration, MAX_FLOW_DURATION);
+    }
+  });
+
+  it("makes a larger share faster than a smaller one", () => {
+    assert.isBelow(flowDuration(90, 100), flowDuration(10, 100));
+  });
+});
+
+describe("hasFlow", () => {
+  it("rejects float residue left by summing statistics", () => {
+    // Measured on a full feed-in instance where solar and export cancel out:
+    // used_solar accumulated to this instead of a clean 0, which is truthy and
+    // drew a phantom solar->home dot for energy displayed as "0 kWh".
+    assert.isFalse(hasFlow(4.334310688136611e-13));
+    assert.isFalse(hasFlow(7.105427357601002e-15));
+  });
+
+  it("rejects absent and zero flows", () => {
+    assert.isFalse(hasFlow(null));
+    assert.isFalse(hasFlow(undefined));
+    assert.isFalse(hasFlow(0));
+  });
+
+  it("accepts real flows", () => {
+    assert.isTrue(hasFlow(0.5));
+    assert.isTrue(hasFlow(35.18));
+  });
+
+  it("treats FLOW_EPSILON itself as no flow", () => {
+    assert.isFalse(hasFlow(FLOW_EPSILON));
+    assert.isTrue(hasFlow(FLOW_EPSILON * 2));
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The solar to grid dot scaled its duration by 6 while the other six flows scaled by 5, so its
range was 6s to 0s instead of 6s to 1s. At a share of 1 it became `dur="0s"`, which is not a
valid SMIL duration, and the dot froze. I extracted the formula into `flowDuration()` with
explicit MIN/MAX constants so all seven flows share the same range.

Flows were also gated on truthiness, so float residue left by summing statistics
(`used_solar` of 4.3e-13 kWh) drew a phantom solar to home dot. I replaced those guards with
`hasFlow()`, a type predicate so they still narrow `number | null`.

Only the solar to grid line changes behaviour; the other six compute what they did before.

`FLOW_EPSILON` could instead live in `computeConsumptionSingle`, which would clamp the residue
for every consumer rather than this card alone. That felt broader than the bug warranted, but
happy to move it.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
Before:
<img width="700" height="316" alt="before" src="https://github.com/user-attachments/assets/eb041762-96cf-4607-a3be-0bdc81970666" />
After:
<img width="700" height="316" alt="after" src="https://github.com/user-attachments/assets/e37bed75-fcf2-4d8a-8489-28032db202d8" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54057
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
