### PR TITLE
Add parent device to entity ID format

### DIFF
--- a/src/components/chips/ha-filter-chip.ts
+++ b/src/components/chips/ha-filter-chip.ts
@@ -35,6 +35,14 @@ export class HaFilterChip extends FilterChip {
     `,
   ];
 
+  protected getContainerClasses() {
+    const classes = super.getContainerClasses();
+    if (this.noLeadingIcon) {
+      classes["has-icon"] = false;
+    }
+    return classes;
+  }
+
   protected renderLeadingIcon() {
     if (this.noLeadingIcon) {
       // eslint-disable-next-line lit/prefer-nothing

--- a/src/data/entity_id_format.ts
+++ b/src/data/entity_id_format.ts
@@ -1,5 +1,6 @@
-export type EntityIdPart =
-  "area" | "parent_device" | "device" | "entity" | "floor";
+import type { EntityNameType } from "../common/entity/compute_entity_name_display";
+
+export type EntityIdPart = EntityNameType;
 
 export type EntityIdFormat = EntityIdPart[];
 

--- a/src/data/entity_id_format.ts
+++ b/src/data/entity_id_format.ts
@@ -1,9 +1,11 @@
-export type EntityIdPart = "area" | "device" | "entity" | "floor";
+export type EntityIdPart =
+  "area" | "parent_device" | "device" | "entity" | "floor";
 
 export type EntityIdFormat = EntityIdPart[];
 
 export const DEFAULT_ENTITY_ID_FORMAT: EntityIdFormat = [
   "area",
+  "parent_device",
   "device",
   "entity",
 ];

--- a/src/panels/config/core/ha-config-entity-id-format.ts
+++ b/src/panels/config/core/ha-config-entity-id-format.ts
@@ -10,6 +10,8 @@ import type { LocalizeFunc } from "../../../common/translations/localize";
 import { debounce } from "../../../common/util/debounce";
 import type { HaProgressButton } from "../../../components/buttons/ha-progress-button";
 import "../../../components/buttons/ha-progress-button";
+import "../../../components/chips/ha-chip-set";
+import "../../../components/chips/ha-filter-chip";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
 import "../../../components/ha-card";
@@ -59,6 +61,8 @@ export class HaConfigEntityIdFormat extends LitElement {
   @state() private _previews?: string[];
 
   @state() private _previewError = false;
+
+  @state() private _selectedExample = 0;
 
   protected async firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
@@ -193,7 +197,6 @@ export class HaConfigEntityIdFormat extends LitElement {
                     )}
                     @value-changed=${this._formatChanged}
                   ></ha-entity-id-format-editor>
-                  ${this._renderPreview()}
                 `
               : nothing
           }
@@ -216,63 +219,80 @@ export class HaConfigEntityIdFormat extends LitElement {
           </ha-progress-button>
         </div>
       </ha-card>
+      ${this._format ? this._renderExamples() : nothing}
     `;
   }
 
-  private _renderPreview() {
+  private _renderExamples() {
+    const examples = this._examples(this._localize);
+    const example = examples[this._selectedExample];
+    const parts = ENTITY_NAME_TYPES.filter((part) => example.parts[part]);
     return html`
-      <div class="preview">
-        <h2 class="preview-label">
-          ${this._localize("ui.panel.config.entity_id_format.card.preview")}
-        </h2>
-        ${
-          this._previewError
-            ? html`<ha-alert alert-type="error">
-                ${this._localize(
-                  "ui.panel.config.entity_id_format.card.preview_error"
-                )}
-              </ha-alert>`
-            : nothing
-        }
-        ${this._examples(this._localize).map((example, index) => {
-          const parts = ENTITY_NAME_TYPES.filter((part) => example.parts[part]);
-          return html`
-            <section class="example" aria-labelledby=${`example-${index}`}>
-              <h3 id=${`example-${index}`}>${example.name}</h3>
-              ${
-                this._previewError
-                  ? nothing
-                  : html`<code
-                      >${EXAMPLE_DOMAIN}.${this._previews?.[index] ?? "…"}</code
-                    >`
-              }
-              <dl>
-                ${parts.map((part) => {
-                  const used = this._format!.includes(part);
-                  return html`
-                    <dt>
-                      ${this._localize(
-                        `ui.components.entity.entity-name-picker.types.${part}`
-                      )}
-                    </dt>
-                    <dd class=${used ? "" : "unused"}>
-                      ${
-                        used
-                          ? example.parts[part]
-                          : this._localize(
-                              "ui.panel.config.entity_id_format.card.unused_part",
-                              { name: example.parts[part] }
-                            )
-                      }
-                    </dd>
-                  `;
-                })}
-              </dl>
-            </section>
-          `;
-        })}
-      </div>
+      <ha-card
+        outlined
+        .header=${this._localize(
+          "ui.panel.config.entity_id_format.card.preview"
+        )}
+      >
+        <div class="card-content examples">
+          <ha-chip-set>
+            ${examples.map(
+              (item, index) => html`
+                <ha-filter-chip
+                  no-leading-icon
+                  data-index=${index}
+                  .selected=${index === this._selectedExample}
+                  .label=${item.name}
+                  @click=${this._selectExample}
+                ></ha-filter-chip>
+              `
+            )}
+          </ha-chip-set>
+          ${
+            this._previewError
+              ? html`<ha-alert alert-type="error">
+                  ${this._localize(
+                    "ui.panel.config.entity_id_format.card.preview_error"
+                  )}
+                </ha-alert>`
+              : html`<code
+                  >${EXAMPLE_DOMAIN}.${
+                    this._previews?.[this._selectedExample] ?? "…"
+                  }</code
+                >`
+          }
+          <dl>
+            ${parts.map((part) => {
+              const used = this._format!.includes(part);
+              return html`
+                <dt>
+                  ${this._localize(
+                    `ui.components.entity.entity-name-picker.types.${part}`
+                  )}
+                </dt>
+                <dd class=${used ? "" : "unused"}>
+                  ${
+                    used
+                      ? example.parts[part]
+                      : this._localize(
+                          "ui.panel.config.entity_id_format.card.unused_part",
+                          { name: example.parts[part] }
+                        )
+                  }
+                </dd>
+              `;
+            })}
+          </dl>
+        </div>
+      </ha-card>
     `;
+  }
+
+  private _selectExample(ev: Event) {
+    ev.preventDefault();
+    this._selectedExample = Number(
+      (ev.currentTarget as HTMLElement).dataset.index
+    );
   }
 
   private _formatChanged(ev: CustomEvent) {
@@ -309,50 +329,34 @@ export class HaConfigEntityIdFormat extends LitElement {
     haStyle,
     css`
       :host {
-        display: block;
+        display: flex;
+        flex-direction: column;
+        gap: var(--ha-space-5);
       }
       .description {
         margin-top: 0;
         color: var(--secondary-text-color);
       }
-      .preview {
+      .examples {
         display: flex;
         flex-direction: column;
         gap: var(--ha-space-3);
-        margin-top: var(--ha-space-5);
       }
-      .preview-label,
-      .example h3 {
-        margin: 0;
-        font-size: var(--ha-font-size-m);
-      }
-      .example {
-        display: flex;
-        flex-direction: column;
-        gap: var(--ha-space-2);
-      }
-      .example + .example {
-        border-block-start: 1px solid var(--divider-color);
-        padding-block-start: var(--ha-space-3);
-      }
-      .example dl {
+      .examples dl {
         display: grid;
         grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
         column-gap: var(--ha-space-3);
         margin: 0;
         overflow-wrap: anywhere;
       }
-      .example dt,
-      .example .unused {
+      .examples dt,
+      .examples .unused {
         color: var(--secondary-text-color);
       }
-      .example dd {
+      .examples dd {
         margin: 0;
       }
-      .preview-label {
-        font-weight: 500;
-      }
-      .preview code {
+      .examples code {
         display: block;
         padding: var(--ha-space-2);
         border-radius: var(--ha-border-radius-md);

--- a/src/panels/config/core/ha-config-entity-id-format.ts
+++ b/src/panels/config/core/ha-config-entity-id-format.ts
@@ -30,7 +30,19 @@ import { documentationUrl } from "../../../util/documentation-url";
 import "./ha-entity-id-format-editor";
 
 const EXAMPLE_DOMAIN = "sensor";
+const EXAMPLE_CONTEXT_PARTS: EntityIdPart[] = [
+  "floor",
+  "area",
+  "parent_device",
+  "device",
+  "entity",
+];
 const PREVIEW_DEBOUNCE_MS = 200;
+
+interface EntityIdExample {
+  name: string;
+  parts: Record<EntityIdPart, string>;
+}
 
 @customElement("ha-config-entity-id-format")
 export class HaConfigEntityIdFormat extends LitElement {
@@ -79,16 +91,13 @@ export class HaConfigEntityIdFormat extends LitElement {
   }
 
   private _examples = memoizeOne(
-    (localize: LocalizeFunc): Record<EntityIdPart, string>[] => {
-      const area = localize(
-        "ui.panel.config.entity_id_format.card.examples.area"
-      );
-      const floor = localize(
-        "ui.panel.config.entity_id_format.card.examples.floor"
-      );
-      return [
-        {
-          area,
+    (localize: LocalizeFunc): EntityIdExample[] => [
+      {
+        name: localize(
+          "ui.panel.config.entity_id_format.card.examples.thermostat"
+        ),
+        parts: {
+          area: localize("ui.panel.config.entity_id_format.card.examples.area"),
           parent_device: "",
           device: localize(
             "ui.panel.config.entity_id_format.card.examples.device"
@@ -96,10 +105,19 @@ export class HaConfigEntityIdFormat extends LitElement {
           entity: localize(
             "ui.panel.config.entity_id_format.card.examples.entity"
           ),
-          floor,
+          floor: localize(
+            "ui.panel.config.entity_id_format.card.examples.floor"
+          ),
         },
-        {
-          area,
+      },
+      {
+        name: localize(
+          "ui.panel.config.entity_id_format.card.examples.power_strip.name"
+        ),
+        parts: {
+          area: localize(
+            "ui.panel.config.entity_id_format.card.examples.power_strip.area"
+          ),
           parent_device: localize(
             "ui.panel.config.entity_id_format.card.examples.power_strip.parent_device"
           ),
@@ -109,10 +127,12 @@ export class HaConfigEntityIdFormat extends LitElement {
           entity: localize(
             "ui.panel.config.entity_id_format.card.examples.power_strip.entity"
           ),
-          floor,
+          floor: localize(
+            "ui.panel.config.entity_id_format.card.examples.power_strip.floor"
+          ),
         },
-      ];
-    }
+      },
+    ]
   );
 
   private _debouncedUpdatePreview = debounce(
@@ -125,7 +145,7 @@ export class HaConfigEntityIdFormat extends LitElement {
     try {
       this._previews = await Promise.all(
         examples.map(async (example) => {
-          const fullName = this._format!.map((part) => example[part])
+          const fullName = this._format!.map((part) => example.parts[part])
             .filter(Boolean)
             .join(" ");
           const { slug } = await fetchSlug(this._api, fullName);
@@ -207,9 +227,9 @@ export class HaConfigEntityIdFormat extends LitElement {
   private _renderPreview() {
     return html`
       <div class="preview">
-        <span class="preview-label">
+        <h2 class="preview-label">
           ${this._localize("ui.panel.config.entity_id_format.card.preview")}
-        </span>
+        </h2>
         ${
           this._previewError
             ? html`<ha-alert alert-type="error">
@@ -217,10 +237,46 @@ export class HaConfigEntityIdFormat extends LitElement {
                   "ui.panel.config.entity_id_format.card.preview_error"
                 )}
               </ha-alert>`
-            : (this._previews ?? ["…"]).map(
-                (preview) => html`<code>${EXAMPLE_DOMAIN}.${preview}</code>`
-              )
+            : nothing
         }
+        ${this._examples(this._localize).map(
+          (example, index) => html`
+            <section class="example" aria-labelledby=${`example-${index}`}>
+              <h3 id=${`example-${index}`}>${example.name}</h3>
+              ${
+                this._previewError
+                  ? nothing
+                  : html`<code
+                      >${EXAMPLE_DOMAIN}.${this._previews?.[index] ?? "…"}</code
+                    >`
+              }
+              <dl>
+                ${EXAMPLE_CONTEXT_PARTS.filter(
+                  (part) => example.parts[part]
+                ).map((part) => {
+                  const used = this._format!.includes(part);
+                  return html`
+                    <dt>
+                      ${this._localize(
+                        `ui.components.entity.entity-name-picker.types.${part}`
+                      )}
+                    </dt>
+                    <dd class=${used ? "" : "unused"}>
+                      ${
+                        used
+                          ? example.parts[part]
+                          : this._localize(
+                              "ui.panel.config.entity_id_format.card.unused_part",
+                              { name: example.parts[part] }
+                            )
+                      }
+                    </dd>
+                  `;
+                })}
+              </dl>
+            </section>
+          `
+        )}
       </div>
     `;
   }
@@ -268,15 +324,43 @@ export class HaConfigEntityIdFormat extends LitElement {
       .preview {
         display: flex;
         flex-direction: column;
-        gap: var(--ha-space-1);
+        gap: var(--ha-space-3);
         margin-top: var(--ha-space-5);
+      }
+      .preview-label,
+      .example h3 {
+        margin: 0;
+        font-size: var(--ha-font-size-m);
+      }
+      .example {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ha-space-2);
+      }
+      .example + .example {
+        border-block-start: 1px solid var(--divider-color);
+        padding-block-start: var(--ha-space-3);
+      }
+      .example dl {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+        column-gap: var(--ha-space-3);
+        margin: 0;
+        overflow-wrap: anywhere;
+      }
+      .example dt,
+      .example .unused {
+        color: var(--secondary-text-color);
+      }
+      .example dd {
+        margin: 0;
       }
       .preview-label {
         font-weight: 500;
       }
       .preview code {
         display: block;
-        padding: var(--ha-space-3);
+        padding: var(--ha-space-2);
         border-radius: var(--ha-border-radius-md);
         background-color: var(--secondary-background-color);
         font-family: var(--ha-font-family-code);
@@ -286,6 +370,7 @@ export class HaConfigEntityIdFormat extends LitElement {
         display: flex;
         justify-content: space-between;
         align-items: center;
+        padding-block-end: var(--ha-space-4);
       }
     `,
   ];

--- a/src/panels/config/core/ha-config-entity-id-format.ts
+++ b/src/panels/config/core/ha-config-entity-id-format.ts
@@ -5,6 +5,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { consumeLocalize } from "../../../common/decorators/consume-context-entry";
+import { ENTITY_NAME_TYPES } from "../../../common/entity/compute_entity_name_display";
 import type { LocalizeFunc } from "../../../common/translations/localize";
 import { debounce } from "../../../common/util/debounce";
 import type { HaProgressButton } from "../../../components/buttons/ha-progress-button";
@@ -30,18 +31,11 @@ import { documentationUrl } from "../../../util/documentation-url";
 import "./ha-entity-id-format-editor";
 
 const EXAMPLE_DOMAIN = "sensor";
-const EXAMPLE_CONTEXT_PARTS: EntityIdPart[] = [
-  "floor",
-  "area",
-  "parent_device",
-  "device",
-  "entity",
-];
 const PREVIEW_DEBOUNCE_MS = 200;
 
 interface EntityIdExample {
   name: string;
-  parts: Record<EntityIdPart, string>;
+  parts: Partial<Record<EntityIdPart, string>>;
 }
 
 @customElement("ha-config-entity-id-format")
@@ -94,19 +88,20 @@ export class HaConfigEntityIdFormat extends LitElement {
     (localize: LocalizeFunc): EntityIdExample[] => [
       {
         name: localize(
-          "ui.panel.config.entity_id_format.card.examples.thermostat"
+          "ui.panel.config.entity_id_format.card.examples.thermostat.name"
         ),
         parts: {
-          area: localize("ui.panel.config.entity_id_format.card.examples.area"),
-          parent_device: "",
+          floor: localize(
+            "ui.panel.config.entity_id_format.card.examples.thermostat.floor"
+          ),
+          area: localize(
+            "ui.panel.config.entity_id_format.card.examples.thermostat.area"
+          ),
           device: localize(
-            "ui.panel.config.entity_id_format.card.examples.device"
+            "ui.panel.config.entity_id_format.card.examples.thermostat.device"
           ),
           entity: localize(
-            "ui.panel.config.entity_id_format.card.examples.entity"
-          ),
-          floor: localize(
-            "ui.panel.config.entity_id_format.card.examples.floor"
+            "ui.panel.config.entity_id_format.card.examples.thermostat.entity"
           ),
         },
       },
@@ -115,6 +110,9 @@ export class HaConfigEntityIdFormat extends LitElement {
           "ui.panel.config.entity_id_format.card.examples.power_strip.name"
         ),
         parts: {
+          floor: localize(
+            "ui.panel.config.entity_id_format.card.examples.power_strip.floor"
+          ),
           area: localize(
             "ui.panel.config.entity_id_format.card.examples.power_strip.area"
           ),
@@ -126,9 +124,6 @@ export class HaConfigEntityIdFormat extends LitElement {
           ),
           entity: localize(
             "ui.panel.config.entity_id_format.card.examples.power_strip.entity"
-          ),
-          floor: localize(
-            "ui.panel.config.entity_id_format.card.examples.power_strip.floor"
           ),
         },
       },
@@ -239,8 +234,9 @@ export class HaConfigEntityIdFormat extends LitElement {
               </ha-alert>`
             : nothing
         }
-        ${this._examples(this._localize).map(
-          (example, index) => html`
+        ${this._examples(this._localize).map((example, index) => {
+          const parts = ENTITY_NAME_TYPES.filter((part) => example.parts[part]);
+          return html`
             <section class="example" aria-labelledby=${`example-${index}`}>
               <h3 id=${`example-${index}`}>${example.name}</h3>
               ${
@@ -251,9 +247,7 @@ export class HaConfigEntityIdFormat extends LitElement {
                     >`
               }
               <dl>
-                ${EXAMPLE_CONTEXT_PARTS.filter(
-                  (part) => example.parts[part]
-                ).map((part) => {
+                ${parts.map((part) => {
                   const used = this._format!.includes(part);
                   return html`
                     <dt>
@@ -275,8 +269,8 @@ export class HaConfigEntityIdFormat extends LitElement {
                 })}
               </dl>
             </section>
-          `
-        )}
+          `;
+        })}
       </div>
     `;
   }

--- a/src/panels/config/core/ha-config-entity-id-format.ts
+++ b/src/panels/config/core/ha-config-entity-id-format.ts
@@ -50,7 +50,7 @@ export class HaConfigEntityIdFormat extends LitElement {
 
   @state() private _error?: string;
 
-  @state() private _preview?: string;
+  @state() private _previews?: string[];
 
   @state() private _previewError = false;
 
@@ -79,12 +79,40 @@ export class HaConfigEntityIdFormat extends LitElement {
   }
 
   private _examples = memoizeOne(
-    (localize: LocalizeFunc): Record<EntityIdPart, string> => ({
-      area: localize("ui.panel.config.entity_id_format.card.examples.area"),
-      device: localize("ui.panel.config.entity_id_format.card.examples.device"),
-      entity: localize("ui.panel.config.entity_id_format.card.examples.entity"),
-      floor: localize("ui.panel.config.entity_id_format.card.examples.floor"),
-    })
+    (localize: LocalizeFunc): Record<EntityIdPart, string>[] => {
+      const area = localize(
+        "ui.panel.config.entity_id_format.card.examples.area"
+      );
+      const floor = localize(
+        "ui.panel.config.entity_id_format.card.examples.floor"
+      );
+      return [
+        {
+          area,
+          parent_device: "",
+          device: localize(
+            "ui.panel.config.entity_id_format.card.examples.device"
+          ),
+          entity: localize(
+            "ui.panel.config.entity_id_format.card.examples.entity"
+          ),
+          floor,
+        },
+        {
+          area,
+          parent_device: localize(
+            "ui.panel.config.entity_id_format.card.examples.power_strip.parent_device"
+          ),
+          device: localize(
+            "ui.panel.config.entity_id_format.card.examples.power_strip.device"
+          ),
+          entity: localize(
+            "ui.panel.config.entity_id_format.card.examples.power_strip.entity"
+          ),
+          floor,
+        },
+      ];
+    }
   );
 
   private _debouncedUpdatePreview = debounce(
@@ -94,12 +122,16 @@ export class HaConfigEntityIdFormat extends LitElement {
 
   private async _updatePreview() {
     const examples = this._examples(this._localize);
-    const fullName = this._format!.map((part) => examples[part])
-      .filter(Boolean)
-      .join(" ");
     try {
-      const { slug } = await fetchSlug(this._api, fullName);
-      this._preview = slug;
+      this._previews = await Promise.all(
+        examples.map(async (example) => {
+          const fullName = this._format!.map((part) => example[part])
+            .filter(Boolean)
+            .join(" ");
+          const { slug } = await fetchSlug(this._api, fullName);
+          return slug;
+        })
+      );
       this._previewError = false;
     } catch (_err: any) {
       this._previewError = true;
@@ -185,7 +217,9 @@ export class HaConfigEntityIdFormat extends LitElement {
                   "ui.panel.config.entity_id_format.card.preview_error"
                 )}
               </ha-alert>`
-            : html`<code>${EXAMPLE_DOMAIN}.${this._preview ?? "…"}</code>`
+            : (this._previews ?? ["…"]).map(
+                (preview) => html`<code>${EXAMPLE_DOMAIN}.${preview}</code>`
+              )
         }
       </div>
     `;

--- a/src/panels/config/core/ha-entity-id-format-editor.ts
+++ b/src/panels/config/core/ha-entity-id-format-editor.ts
@@ -6,6 +6,7 @@ import { repeat } from "lit/directives/repeat";
 import memoizeOne from "memoize-one";
 import { consumeLocalize } from "../../../common/decorators/consume-context-entry";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { ENTITY_NAME_TYPES } from "../../../common/entity/compute_entity_name_display";
 import type { LocalizeFunc } from "../../../common/translations/localize";
 import "../../../components/chips/ha-assist-chip";
 import "../../../components/chips/ha-chip-set";
@@ -22,14 +23,6 @@ import type {
 } from "../../../data/entity_id_format";
 import type { ValueChangedEvent } from "../../../types";
 
-const STRUCTURAL_TYPES = [
-  "floor",
-  "area",
-  "parent_device",
-  "device",
-  "entity",
-] as const;
-
 const REQUIRED_TYPES: readonly EntityIdPart[] = ["device", "entity"];
 
 const rowRenderer: RenderItemFunction<PickerComboBoxItem> = (item) => html`
@@ -45,7 +38,7 @@ const decodeType = (value: string): EntityIdPart | undefined => {
     value.startsWith("___") && value.endsWith("___")
       ? value.slice(3, -3)
       : value;
-  return (STRUCTURAL_TYPES as readonly string[]).includes(type)
+  return (ENTITY_NAME_TYPES as readonly string[]).includes(type)
     ? (type as EntityIdPart)
     : undefined;
 };
@@ -228,7 +221,7 @@ export class HaEntityIdFormatEditor extends LitElement {
 
   private _getItems = memoizeOne(
     (localize: LocalizeFunc): PickerComboBoxItem[] =>
-      STRUCTURAL_TYPES.map((type) => {
+      ENTITY_NAME_TYPES.map((type) => {
         const primary = localize(
           `ui.components.entity.entity-name-picker.types.${type}`
         );

--- a/src/panels/config/core/ha-entity-id-format-editor.ts
+++ b/src/panels/config/core/ha-entity-id-format-editor.ts
@@ -22,7 +22,13 @@ import type {
 } from "../../../data/entity_id_format";
 import type { ValueChangedEvent } from "../../../types";
 
-const STRUCTURAL_TYPES = ["area", "device", "entity", "floor"] as const;
+const STRUCTURAL_TYPES = [
+  "area",
+  "parent_device",
+  "device",
+  "entity",
+  "floor",
+] as const;
 
 const REQUIRED_TYPES: readonly EntityIdPart[] = ["device", "entity"];
 

--- a/src/panels/config/core/ha-entity-id-format-editor.ts
+++ b/src/panels/config/core/ha-entity-id-format-editor.ts
@@ -23,11 +23,11 @@ import type {
 import type { ValueChangedEvent } from "../../../types";
 
 const STRUCTURAL_TYPES = [
+  "floor",
   "area",
   "parent_device",
   "device",
   "entity",
-  "floor",
 ] as const;
 
 const REQUIRED_TYPES: readonly EntityIdPart[] = ["device", "entity"];
@@ -71,6 +71,7 @@ export class HaEntityIdFormatEditor extends LitElement {
       <div class="container">
         ${this.label ? html`<label>${this.label}</label>` : nothing}
         <ha-generic-picker
+          no-sort
           .disabled=${this.disabled}
           .getItems=${this._getFilteredItems}
           .rowRenderer=${rowRenderer}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8928,7 +8928,12 @@
               "area": "Living room",
               "device": "Thermostat",
               "entity": "Temperature",
-              "floor": "Ground floor"
+              "floor": "Ground floor",
+              "power_strip": {
+                "parent_device": "Power strip",
+                "device": "Outlet 1",
+                "entity": "Power"
+              }
             },
             "editor": {
               "label": "Format",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8919,20 +8919,25 @@
           "description": "Manage the format of newly created entity IDs",
           "card": {
             "header": "Entity ID format for new entities",
-            "description": "Entity IDs are used to reference entities in automations, scripts, and dashboards. This format only applies when a new entity is created. Using it is optional, and you can still rename each entity ID afterwards in its settings",
+            "description": "Entity IDs are used to reference entities in automations, scripts, and dashboards. This format only applies when a new entity is created. Using it is optional, and you can still rename each entity ID afterwards in its settings. Parts without a value are omitted from the entity ID.",
             "learn_more": "Learn more",
-            "preview": "Preview",
+            "preview": "Examples",
             "preview_error": "Failed to generate preview",
+            "unused_part": "{name} (not used in format)",
             "reset": "Reset to default",
             "examples": {
+              "thermostat": "Thermostat temperature",
               "area": "Living room",
               "device": "Thermostat",
               "entity": "Temperature",
               "floor": "Ground floor",
               "power_strip": {
+                "name": "Power strip outlet power",
+                "area": "Office",
                 "parent_device": "Power strip",
                 "device": "Outlet 1",
-                "entity": "Power"
+                "entity": "Power",
+                "floor": "First floor"
               }
             },
             "editor": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8926,18 +8926,20 @@
             "unused_part": "{name} (not used in format)",
             "reset": "Reset to default",
             "examples": {
-              "thermostat": "Thermostat temperature",
-              "area": "Living room",
-              "device": "Thermostat",
-              "entity": "Temperature",
-              "floor": "Ground floor",
+              "thermostat": {
+                "name": "Thermostat temperature",
+                "floor": "Ground floor",
+                "area": "Living room",
+                "device": "Thermostat",
+                "entity": "Temperature"
+              },
               "power_strip": {
                 "name": "Power strip outlet power",
+                "floor": "First floor",
                 "area": "Office",
                 "parent_device": "Power strip",
                 "device": "Outlet 1",
-                "entity": "Power",
-                "floor": "First floor"
+                "entity": "Power"
               }
             },
             "editor": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8927,14 +8927,14 @@
             "reset": "Reset to default",
             "examples": {
               "thermostat": {
-                "name": "Thermostat temperature",
+                "name": "Thermostat",
                 "floor": "Ground floor",
                 "area": "Living room",
                 "device": "Thermostat",
                 "entity": "Temperature"
               },
               "power_strip": {
-                "name": "Power strip outlet power",
+                "name": "Power strip",
                 "floor": "First floor",
                 "area": "Office",
                 "parent_device": "Power strip",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adds the parent device as a part of the entity ID format, between the area and the device, and includes it in the default format. The examples on the settings page now show 2 different devices (one with parent device, one without)

Stacked on #53766, which adds the parent device to the entity context.

## Screenshots

<img width="634" height="687" alt="CleanShot 2026-09-08 at 14 28 52" src="https://github.com/user-attachments/assets/31e10fcb-6042-4e8a-9b12-8791a1089260" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: home-assistant/core#179996

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
