### PR TITLE
Send light/dark mode to mobile through externalBus

### DIFF
--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -195,6 +195,13 @@ interface EMOutgoingMessageReloadAndClearCache extends EMMessage {
   type: "frontend/reload_and_clear_cache";
 }
 
+interface EMOutgoingMessageIsAppearanceLightStatusBars extends EMMessage {
+  type: "frontend/is_appearance_light_status_bars";
+  payload: {
+    value: boolean;
+  };
+}
+
 // These types are handled internally by the Android app via postMessage.
 // They are not sent by the frontend and should not be used directly.
 // They are intentionally listed here to prevent anyone from using them unintentionally.
@@ -225,6 +232,7 @@ type EMOutgoingMessageWithoutAnswer =
   | EMOutgoingMessageAddEntityTo
   | EMOutgoingMessageFocusElement
   | EMOutgoingMessageReloadAndClearCache
+  | EMOutgoingMessageIsAppearanceLightStatusBars
   | EMOutgoingMessageAssistSettings;
 
 export interface EMIncomingMessageRestart {

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -1,4 +1,5 @@
 import type { PropertyValues } from "lit";
+import { type Color, blend, wcagLuminance } from "culori";
 import {
   applyThemesOnElement,
   invalidateThemeCache,
@@ -23,6 +24,10 @@ declare global {
 }
 
 const mql = matchMedia("(prefers-color-scheme: dark)");
+
+function isLight(color: Color | string): boolean {
+  return wcagLuminance(color) >= 0.5;
+}
 
 export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
   class extends superClass {
@@ -166,9 +171,12 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       const computedStyles = getComputedStyle(document.documentElement);
       const themeMetaColor =
         computedStyles.getPropertyValue("--app-theme-color");
+      const themePrimaryBackgroundColor = computedStyles.getPropertyValue(
+        "--primary-background-color"
+      );
 
       document.documentElement.style.backgroundColor =
-        computedStyles.getPropertyValue("--primary-background-color");
+        themePrimaryBackgroundColor;
 
       if (themeMeta) {
         if (!themeMeta.hasAttribute("default-content")) {
@@ -184,5 +192,17 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       }
 
       this.hass!.auth.external?.fireMessage({ type: "theme-update" });
+
+      const themeHeaderColor = computedStyles.getPropertyValue(
+        "--app-header-background-color"
+      );
+      const isAppearanceLightStatusBars = isLight(
+        blend([themePrimaryBackgroundColor, themeHeaderColor])
+      );
+
+      this.hass!.auth.external?.fireMessage({
+        type: "frontend/is_appearance_light_status_bars",
+        payload: { value: isAppearanceLightStatusBars },
+      });
     }
   };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Implements a message that includes the required information that the Android app needs to tint the status bar icons based on the header background. This is an initial implementation that implements a similar mechanism to what https://github.com/home-assistant/android/pull/6292 used. It includes the background color as the header color may have transparency.

The bigger picture is getting one step closer to edge-to-edge on Android.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29125
- This PR is related to issue or discussion: https://github.com/home-assistant/android/pull/6292
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
