### PR TITLE
Give the power cards and badge their own midnight-rollover collection outside the Energy panel

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -1141,6 +1141,35 @@ export const getEnergyDataCollection = (
   return collection;
 };
 
+/**
+ * Default collection key for the real-time power elements (power sources
+ * graph, power sankey, power total badge) when they are used outside the
+ * Energy panel. Like the Energy panel's own "Now" view, they get a collection
+ * of their own so their day period can roll over at midnight without changing
+ * the behavior of the statistics cards on the same dashboard.
+ */
+export const getDefaultPowerCollectionKey = (hass: HomeAssistant): string =>
+  hass.panelUrl
+    ? `${ENERGY_COLLECTION_KEY_PREFIX}${hass.panelUrl}_now`
+    : DEFAULT_POWER_COLLECTION_KEY;
+
+/**
+ * Energy data collection for the real-time power elements. An explicitly
+ * configured collection key is used as-is, sharing the period of whatever
+ * else uses that key. Without one, the elements use the dashboard's power
+ * collection, which rolls its day period over at midnight.
+ */
+export const getPowerEnergyDataCollection = (
+  hass: HomeAssistant,
+  collectionKey?: string
+): EnergyCollection =>
+  collectionKey
+    ? getEnergyDataCollection(hass, { key: collectionKey })
+    : getEnergyDataCollection(hass, {
+        key: getDefaultPowerCollectionKey(hass),
+        midnightRollover: true,
+      });
+
 export const getEnergySolarForecasts = (hass: HomeAssistant) =>
   hass.callWS<EnergySolarForecasts>({
     type: "energy/solar_forecast",

--- a/src/panels/lovelace/badges/energy/hui-power-total-badge.ts
+++ b/src/panels/lovelace/badges/energy/hui-power-total-badge.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../../data/context";
 import type { EnergyData, EnergyPreferences } from "../../../../data/energy";
 import {
-  getEnergyDataCollection,
+  getPowerEnergyDataCollection,
   getPowerFromState,
 } from "../../../../data/energy";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
@@ -54,9 +54,10 @@ export class HuiPowerTotalBadge
 
   public hassSubscribe(): UnsubscribeFunc[] {
     return [
-      getEnergyDataCollection(this.hass, {
-        key: this._config?.collection_key,
-      }).subscribe((data) => {
+      getPowerEnergyDataCollection(
+        this.hass,
+        this._config?.collection_key
+      ).subscribe((data) => {
         this._data = data;
       }),
     ];

--- a/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
@@ -9,7 +9,7 @@ import type { EnergyData, EnergyPreferences } from "../../../../data/energy";
 import {
   computeEnergyDeviceLabels,
   formatPowerShort,
-  getEnergyDataCollection,
+  getPowerEnergyDataCollection,
   getPowerFromState,
   validateEnergyCollectionKey,
 } from "../../../../data/energy";
@@ -92,9 +92,10 @@ class HuiPowerSankeyCard
 
   public hassSubscribe(): UnsubscribeFunc[] {
     return [
-      getEnergyDataCollection(this.hass, {
-        key: this._config?.collection_key,
-      }).subscribe((data) => {
+      getPowerEnergyDataCollection(
+        this.hass,
+        this._config?.collection_key
+      ).subscribe((data) => {
         this._data = data;
       }),
     ];

--- a/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
@@ -10,7 +10,7 @@ import "../../../../components/chart/ha-chart-base";
 import "../../../../components/ha-card";
 import type { EnergyData } from "../../../../data/energy";
 import {
-  getEnergyDataCollection,
+  getPowerEnergyDataCollection,
   validateEnergyCollectionKey,
 } from "../../../../data/energy";
 import type { FrontendLocaleData } from "../../../../data/translation";
@@ -66,9 +66,10 @@ export class HuiPowerSourcesGraphCard
 
   public hassSubscribe(): UnsubscribeFunc[] {
     return [
-      getEnergyDataCollection(this.hass, {
-        key: this._config?.collection_key,
-      }).subscribe((data) => this._getStatistics(data)),
+      getPowerEnergyDataCollection(
+        this.hass,
+        this._config?.collection_key
+      ).subscribe((data) => this._getStatistics(data)),
     ];
   }
 

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -24,6 +24,9 @@ import {
   getEnergyLiveDayPeriod,
   shouldFallbackEnergyPeriodToYesterday,
   getEnergyDataCollection,
+  getPowerEnergyDataCollection,
+  getDefaultPowerCollectionKey,
+  DEFAULT_POWER_COLLECTION_KEY,
   EMPTY_PREFERENCES,
 } from "../../src/data/energy";
 import type { DeviceRegistryEntry } from "../../src/data/device/device_registry";
@@ -1484,6 +1487,89 @@ describe("computeEnergyDeviceLabels", () => {
     assert.deepEqual(
       computeEnergyDeviceLabels(hass, DEVICES, undefined, "stat_rate"),
       { "sensor.washer_power": "Washer Power" }
+    );
+  });
+});
+
+describe("getPowerEnergyDataCollection", () => {
+  afterEach(() => {
+    localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  const createHass = (panelUrl?: string) => {
+    const hass = createMockHass();
+    hass.locale = energyPeriodLocale;
+    hass.config = { ...hass.config, time_zone: "America/New_York" };
+    Object.assign(hass, {
+      panelUrl,
+      connection: {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        connected: true,
+      },
+      callWS: vi.fn(async (msg: { type: string }) => {
+        if (msg.type === "energy/get_prefs") {
+          return EMPTY_PREFERENCES;
+        }
+        if (msg.type === "energy/info") {
+          return { cost_sensors: {}, solar_forecast_domains: [] };
+        }
+        return {};
+      }),
+    });
+    return hass;
+  };
+
+  it("derives a per-dashboard power collection key", () => {
+    assert.equal(
+      getDefaultPowerCollectionKey({
+        panelUrl: "master-bedroom",
+      } as HomeAssistant),
+      "energy_master-bedroom_now"
+    );
+    assert.equal(
+      getDefaultPowerCollectionKey({} as HomeAssistant),
+      DEFAULT_POWER_COLLECTION_KEY
+    );
+  });
+
+  it("uses a midnight-rolling power collection without a key", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-20T00:30:00-04:00"));
+    const hass = createHass("master-bedroom");
+
+    const collection = getPowerEnergyDataCollection(hass);
+
+    assert.strictEqual(
+      (hass.connection as any)["_energy_master-bedroom_now"],
+      collection
+    );
+    // The dashboard's default (statistics) collection is left alone.
+    assert.isUndefined((hass.connection as any)["_energy_master-bedroom"]);
+    // Live data: today from midnight, no fallback to yesterday in hour 0.
+    assert.equal(
+      collection.start.getTime(),
+      energyPeriodDay(new Date()).start.getTime()
+    );
+  });
+
+  it("keeps the statistics behavior for an explicitly configured key", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-20T00:30:00-04:00"));
+    const hass = createHass("master-bedroom");
+
+    const collection = getPowerEnergyDataCollection(hass, "energy_shared");
+
+    assert.strictEqual((hass.connection as any)._energy_shared, collection);
+    assert.strictEqual(
+      getEnergyDataCollection(hass, { key: "energy_shared" }),
+      collection
+    );
+    // Shared with statistics cards: yesterday until 01:00, as before.
+    assert.equal(
+      collection.start.getTime(),
+      energyPeriodDay(new Date(), -1).start.getTime()
     );
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The real-time power elements (`power-sources-graph`, `power-sankey`, `power-total` badge) keep showing **yesterday** between 00:00 and 01:00 when placed on a regular dashboard and only switch to the new day at 01:00. On the Energy panel's *Now* view the same elements roll over at midnight.

Cause: without a `collection_key` the elements subscribe to the dashboard's default energy collection. That collection is created with `midnightRollover: false`, which is right for the kWh cards (their hourly statistics for the new day appear at 01:00, so `shouldFallbackEnergyPeriodToYesterday()` shows yesterday until then) but wrong for elements that show live power. The *Now* view avoids it because `power-view-strategy.ts` gives it a separate collection (`energy_dashboard_now`) created with `midnightRollover: true`; the elements themselves never pass the flag, and no card option can.

This PR mirrors the *Now* view for dashboards: a new `getPowerEnergyDataCollection()` in `src/data/energy.ts` gives the three power elements a per-dashboard power collection (`energy_<panel>_now`, created with `midnightRollover: true`) when no `collection_key` is configured. The statistics cards keep using the dashboard's default collection with the 01:00 rule, so nothing changes for them, and there is no load-order dependence. An explicitly configured `collection_key` behaves exactly as before, so sharing a period with an `energy-date-selection` card still works by giving both the same key.

The Energy panel is unaffected: its strategies always pass an explicit `collection_key`, and the *Now* view's collection is already created with the flag.

Behavior change on regular dashboards: without a `collection_key` the power sources graph no longer follows an `energy-date-selection` card on the same dashboard; give both cards the same `collection_key` to link them. Documentation PR: home-assistant/home-assistant.io#48026.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a (no issue filed; reproduce by adding `type: power-sources-graph` to any dashboard and opening it between 00:00 and 01:00: it shows the previous day while the Energy panel's Now view shows the new day, and catches up at 01:00)
- This PR is related to issue or discussion: n/a
- Link to documentation pull request: home-assistant/home-assistant.io#48026
- Link to developer documentation pull request: n/a
- Link to backend pull request: n/a

Tests added to `test/data/energy.test.ts` (`getPowerEnergyDataCollection`): the default power key per dashboard; without a key the collection is `energy_<dashboard>_now`, leaves the dashboard's default collection untouched and shows today at 00:30; with an explicit key it is the shared collection and keeps the 01:00 fallback.

Also tested with `script/develop_and_serve` against a production instance: the `power-sources-graph` card on a normal dashboard renders identically to the Energy panel's Now view.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr