### PR TITLE
Add show_values toggle to all Sankey cards

### DIFF
--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -181,6 +181,7 @@ export interface EnergyCardSankeyConfig extends EnergyCardConfig {
   group_by_floor?: boolean;
   group_by_area?: boolean;
   max_devices?: number;
+  show_values?: boolean;
 }
 
 export interface EnergyDateSelectorCardConfig extends EnergyCardBaseConfig {
@@ -259,12 +260,10 @@ export interface PowerSourcesGraphCardConfig extends EnergyCardConfig {
 
 export interface EnergySankeyCardConfig extends EnergyCardSankeyConfig {
   type: "energy-sankey";
-  show_values?: boolean;
 }
 
 export interface PowerSankeyCardConfig extends EnergyCardSankeyConfig {
   type: "power-sankey";
-  show_values?: boolean;
 }
 
 export interface WaterSankeyCardConfig extends EnergyCardSankeyConfig {

--- a/src/panels/lovelace/cards/water/hui-water-flow-sankey-card.ts
+++ b/src/panels/lovelace/cards/water/hui-water-flow-sankey-card.ts
@@ -306,8 +306,10 @@ class HuiWaterFlowSankeyCard
           ${
             hasData
               ? html`<ha-sankey-chart
+                  .hass=${this.hass}
                   .data=${{ nodes, links }}
                   .vertical=${vertical}
+                  .showValues=${this._config.show_values === true}
                   .valueFormatter=${this._valueFormatter}
                   @node-click=${this._handleNodeClick}
                 ></ha-sankey-chart>`

--- a/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
+++ b/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
@@ -291,6 +291,7 @@ class HuiWaterSankeyCard
                   .hass=${this.hass}
                   .data=${{ nodes, links }}
                   .vertical=${vertical}
+                  .showValues=${this._config.show_values === true}
                   .valueFormatter=${this._valueFormatter}
                   @node-click=${this._handleNodeClick}
                 ></ha-sankey-chart>`

--- a/src/panels/lovelace/editor/config-elements/hui-energy-sankey-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-sankey-card-editor.ts
@@ -58,79 +58,70 @@ export class HuiEnergySankeyCardEditor
     this._config = config;
   }
 
-  private _schema = memoizeOne(
-    (localize: LocalizeFunc, showValuesSupported: boolean) => {
-      const schema: HaFormSchema[] = [
-        { name: "title", selector: { text: {} } },
-        {
-          name: "",
-          type: "grid",
-          schema: [
-            {
-              name: "layout",
-              required: false,
-              selector: {
-                select: {
-                  options: layoutDirections.map((direction) => ({
-                    value: direction,
-                    label: localize(
-                      `ui.panel.lovelace.editor.card.energy-sankey.layout_directions.${direction}`
-                    ),
-                  })),
-                },
+  private _schema = memoizeOne((localize: LocalizeFunc) => {
+    const schema: HaFormSchema[] = [
+      { name: "title", selector: { text: {} } },
+      {
+        name: "",
+        type: "grid",
+        schema: [
+          {
+            name: "layout",
+            required: false,
+            selector: {
+              select: {
+                options: layoutDirections.map((direction) => ({
+                  value: direction,
+                  label: localize(
+                    `ui.panel.lovelace.editor.card.energy-sankey.layout_directions.${direction}`
+                  ),
+                })),
               },
             },
-            {
-              name: "",
-              type: "grid",
-              schema: [
-                {
-                  name: "group_by_floor",
-                  required: false,
-                  selector: { boolean: {} },
-                },
-                {
-                  name: "group_by_area",
-                  required: false,
-                  selector: { boolean: {} },
-                },
-                ...(showValuesSupported
-                  ? [
-                      {
-                        name: "show_values",
-                        required: false,
-                        selector: { boolean: {} },
-                      } as const,
-                    ]
-                  : []),
-              ],
-            },
-            {
-              name: "max_devices",
-              required: false,
-              selector: { number: { min: 1, mode: "box" } },
-            },
-            {
-              type: "string",
-              name: "collection_key",
-              required: false,
-            },
-          ],
-        },
-      ];
-      return schema;
-    }
-  );
+          },
+          {
+            name: "",
+            type: "grid",
+            schema: [
+              {
+                name: "group_by_floor",
+                required: false,
+                selector: { boolean: {} },
+              },
+              {
+                name: "group_by_area",
+                required: false,
+                selector: { boolean: {} },
+              },
+              {
+                name: "show_values",
+                required: false,
+                selector: { boolean: {} },
+              },
+            ],
+          },
+          {
+            name: "max_devices",
+            required: false,
+            selector: { number: { min: 1, mode: "box" } },
+          },
+          {
+            type: "string",
+            name: "collection_key",
+            required: false,
+          },
+        ],
+      },
+    ];
+    return schema;
+  });
 
   protected render() {
     if (!this.hass || !this._config) {
       return nothing;
     }
 
-    const showValuesSupported =
-      this._config.type === "energy-sankey" ||
-      this._config.type === "power-sankey";
-    const schema = this._schema(this.hass.localize, showValuesSupported);
+    const schema = this._schema(this.hass.localize);
 
     const data = {
       ...this._config,

--- a/src/panels/lovelace/editor/get-dashboard-documentation-url.ts
+++ b/src/panels/lovelace/editor/get-dashboard-documentation-url.ts
@@ -25,6 +25,9 @@ const NON_STANDARD_CARD_URLS = {
   "energy-devices-graph": "energy/#devices-energy-graph",
   "energy-devices-detail-graph": "energy/#detail-devices-energy-graph",
   "energy-sankey": "energy/#sankey-energy-graph",
+  "power-sankey": "energy/#power-flow-sankey-graph",
+  "water-sankey": "energy/#water-sankey-graph",
+  "water-flow-sankey": "energy/#water-flow-sankey-graph",
   "power-sources-graph": "energy/#power-sources-graph",
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Expose the `show_values` option on water Sankey cards so every Sankey card can show node values, not only energy and power.

#53925 added `show_values` for `energy-sankey` and `power-sankey`. This follow-up:

- Moves `show_values` onto the shared Sankey card config
- Shows the existing "Show values" editor toggle for all four Sankey card types
- Passes `showValues` through on `water-sankey` and `water-flow-sankey`

The chart already supports value labels; water cards now use the same opt-in as energy and power.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Water Sankey with values:

![Water Sankey graph showing liters on each node](https://cursor.com/artifacts/c/art-384e538b-7bb6-4a50-8383-e226b97943ea)

Water Sankey editor with the Show values toggle:

![Water Sankey card editor with Show values enabled](https://cursor.com/artifacts/c/art-994da57b-45ad-4aca-8368-4363831c58bf)

Power and water-flow Sankey cards with values:

![Current power flow and current water flow Sankey cards with values](https://cursor.com/artifacts/c/art-fb48ed06-ddcb-4182-b535-e4af6737756e)

Energy Sankey with values:

![Energy flow Sankey graph showing kWh on each node](https://cursor.com/artifacts/c/art-4b2b0da0-9571-447d-8035-638cda306cbc)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/53925
- Link to documentation pull request: home-assistant/home-assistant.io#48028 (water Sankey cards; energy/power `show_values` in home-assistant/home-assistant.io#47789)
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fc4f374-ee5a-46b3-84f7-0f2a50ea653b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fc4f374-ee5a-46b3-84f7-0f2a50ea653b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


