### PR TITLE
Fix accessible names for analytics consent switches

### DIFF
--- a/src/components/ha-analytics.ts
+++ b/src/components/ha-analytics.ts
@@ -50,7 +50,11 @@ export class HaAnalytics extends LitElement {
           .preference=${"base"}
           .disabled=${loading}
           name="base"
-        ></ha-switch>
+        >
+          ${this.localize(
+            `ui.panel.${this.translationKeyPanel}.analytics.preferences.base.title`
+          )}
+        </ha-switch>
       </ha-row-item>
       ${ADDITIONAL_PREFERENCES.map(
         (preference) => html`
@@ -72,7 +76,11 @@ export class HaAnalytics extends LitElement {
               .checked=${!!this.analytics?.preferences[preference]}
               .preference=${preference}
               name=${preference}
-            ></ha-switch>
+            >
+              ${this.localize(
+                `ui.panel.${this.translationKeyPanel}.analytics.preferences.${preference}.title`
+              )}
+            </ha-switch>
             ${
               baseEnabled
                 ? nothing
@@ -106,7 +114,11 @@ export class HaAnalytics extends LitElement {
           .preference=${"diagnostics"}
           .disabled=${loading}
           name="diagnostics"
-        ></ha-switch>
+        >
+          ${this.localize(
+            `ui.panel.${this.translationKeyPanel}.analytics.preferences.diagnostics.title`
+          )}
+        </ha-switch>
       </ha-row-item>
     `;
   }
@@ -141,6 +153,19 @@ export class HaAnalytics extends LitElement {
       css`
         .error {
           color: var(--error-color);
+        }
+
+        /* The visible headline already names the row. Keep the switch's
+           slotted label available to assistive technology without repeating it. */
+        ha-switch::part(label) {
+          position: absolute;
+          overflow: hidden;
+          clip: rect(0 0 0 0);
+          height: 1px;
+          width: 1px;
+          margin: -1px;
+          padding: 0;
+          border: 0;
         }
 
         ha-row-item {

--- a/test/e2e/onboarding.spec.ts
+++ b/test/e2e/onboarding.spec.ts
@@ -61,3 +61,59 @@ test("completes onboarding and opens the default dashboard", async ({
   expect(calls.tokenRequests[1]).toContain("dashboard-auth-code");
   expectNoPageErrors(errors);
 });
+
+test("chooses analytics consent using named switches", async ({
+  page,
+  baseURL,
+}) => {
+  const errors = trackPageErrors(page);
+  const calls = await setupOnboardingMocks(page);
+
+  await openOnboarding(page, baseURL!);
+  await createOwner(page);
+  await completeCoreConfig(page);
+
+  const analytics = page.locator("onboarding-analytics");
+  const basic = analytics.getByRole("switch", {
+    name: "Basic analytics",
+    exact: true,
+  });
+  const usage = analytics.getByRole("switch", { name: "Usage", exact: true });
+  const statistics = analytics.getByRole("switch", {
+    name: "Statistical data",
+    exact: true,
+  });
+  const diagnostics = analytics.getByRole("switch", {
+    name: "Diagnostics",
+    exact: true,
+  });
+
+  await expect(basic).toBeVisible();
+  await basic.press("Space");
+  await usage.press("Space");
+  await statistics.press("Space");
+  await diagnostics.press("Space");
+  await expect(usage).toBeChecked();
+  await expect(statistics).toBeChecked();
+  await expect(diagnostics).toBeChecked();
+
+  // Withdrawing basic consent also withdraws its dependent categories,
+  // while independently selected crash reporting stays enabled.
+  await basic.press("Space");
+  await expect(usage).not.toBeChecked();
+  await expect(statistics).not.toBeChecked();
+  await expect(diagnostics).toBeChecked();
+  await completeAnalytics(page);
+  await expect.poll(() => calls.analyticsCompleted).toBe(true);
+
+  expect(calls.analyticsPreferences).toMatchObject({
+    type: "analytics/preferences",
+    preferences: {
+      base: false,
+      usage: false,
+      statistics: false,
+      diagnostics: true,
+    },
+  });
+  expectNoPageErrors(errors);
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Give the four analytics consent switches localized accessible names through their label slots. The visible row headings remain in place; the duplicate slotted labels are visually hidden. This covers both onboarding and the shared settings component without changing consent behavior.

The regression test selects the switches by accessible name, operates them with the keyboard, and verifies the submitted preferences after withdrawing basic consent.

Local validation: onboarding flows pass on Chromium desktop and mobile emulation; focused keyboard consent tests pass on both. ESLint, Prettier, and the project typecheck pass. Focused Lit analysis has no errors and three warnings on existing `.preference` bindings. Full `yarn lint` exits successfully; Lit reports 1,230 warnings across 543 files (zero errors). Safari with VoiceOver has not been tested.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Screenshots

Before/after screenshots are prepared locally for the contributor to review and attach. No visible label duplication is intended.

<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53910
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
