### PR TITLE
Move history timeline names under the bars

### DIFF
--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -23,6 +23,8 @@ import { measureTextWidth } from "../../util/text";
 import { fireEvent, type HASSDomEvent } from "../../common/dom/fire_event";
 
 const ROW_HEIGHT = 30;
+// Taller rows when the name is drawn under the bar instead of in a column.
+const ROW_HEIGHT_INSIDE_LABELS = 64;
 const GRID_BOTTOM = 30;
 
 @customElement("state-history-chart-timeline")
@@ -40,6 +42,11 @@ export class StateHistoryChartTimeline extends LitElement {
   @property() public identifier?: string;
 
   @property({ attribute: "show-names", type: Boolean }) public showNames = true;
+
+  // Render each row's name inside the plot (under its bar) instead of in a
+  // left-hand category-label column. Opt-in; used by the history panel.
+  @property({ attribute: "inside-labels", type: Boolean })
+  public insideLabels = false;
 
   @property({ attribute: "click-for-more-info", type: Boolean })
   public clickForMoreInfo = true;
@@ -70,7 +77,11 @@ export class StateHistoryChartTimeline extends LitElement {
       <ha-chart-base
         .hass=${this.hass}
         .options=${this._chartOptions}
-        .height=${`${this.data.length * ROW_HEIGHT + GRID_BOTTOM}px`}
+        .height=${`${
+          this.data.length *
+            (this.insideLabels ? ROW_HEIGHT_INSIDE_LABELS : ROW_HEIGHT) +
+          GRID_BOTTOM
+        }px`}
         .data=${this._chartData as HaECSeries}
         small-controls
         @chart-click=${this._handleChartClick}
@@ -185,6 +196,7 @@ export class StateHistoryChartTimeline extends LitElement {
       changedProps.has("startTime") ||
       changedProps.has("endTime") ||
       changedProps.has("showNames") ||
+      changedProps.has("insideLabels") ||
       changedProps.has("paddingYAxis") ||
       changedProps.has("_yWidth")
     ) {
@@ -196,9 +208,11 @@ export class StateHistoryChartTimeline extends LitElement {
     const narrow = this.narrow;
     const showNames = this.chunked || this.showNames;
     const maxInternalLabelWidth = narrow ? 105 : 185;
-    const labelWidth = showNames
-      ? Math.max(this.paddingYAxis, this._yWidth)
-      : 0;
+    const insideLabels = this.insideLabels;
+    const labelWidth =
+      showNames && !insideLabels
+        ? Math.max(this.paddingYAxis, this._yWidth)
+        : 0;
     const labelMargin = 5;
     const rtl = computeRTL(
       this.hass.language,
@@ -227,31 +241,47 @@ export class StateHistoryChartTimeline extends LitElement {
         axisLine: {
           show: false,
         },
-        axisLabel: {
-          show: showNames,
-          width: labelWidth,
-          overflow: "truncate",
-          margin: labelMargin,
-          formatter: (id: string) => {
-            const label = this._chartData.find((d) => d.id === id)
-              ?.name as string;
-            const width = label
-              ? Math.min(
-                  measureTextWidth(label, 12) + labelMargin,
-                  maxInternalLabelWidth
-                )
-              : 0;
-            if (width > this._yWidth) {
-              this._yWidth = width;
-              fireEvent(this, "y-width-changed", {
-                value: this._yWidth,
-                chartIndex: this.chartIndex,
-              });
+        axisLabel: insideLabels
+          ? {
+              // Draw the name inside the plot, under each row's bar, matching
+              // the line charts whose legend sits under the plot. The taller
+              // rows keep a name clear of the next row's bar.
+              show: showNames,
+              inside: true,
+              margin: 0,
+              padding: [18, 0, 0, rtl ? 0 : 2],
+              align: rtl ? "right" : "left",
+              verticalAlign: "top",
+              formatter: (id: string) =>
+                (this._chartData.find((d) => d.id === id)?.name as string) ??
+                "",
+              hideOverlap: true,
             }
-            return label;
-          },
-          hideOverlap: true,
-        },
+          : {
+              show: showNames,
+              width: labelWidth,
+              overflow: "truncate",
+              margin: labelMargin,
+              formatter: (id: string) => {
+                const label = this._chartData.find((d) => d.id === id)
+                  ?.name as string;
+                const width = label
+                  ? Math.min(
+                      measureTextWidth(label, 12) + labelMargin,
+                      maxInternalLabelWidth
+                    )
+                  : 0;
+                if (width > this._yWidth) {
+                  this._yWidth = width;
+                  fireEvent(this, "y-width-changed", {
+                    value: this._yWidth,
+                    chartIndex: this.chartIndex,
+                  });
+                }
+                return label;
+              },
+              hideOverlap: true,
+            },
       },
       grid: {
         top: 10,

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -79,6 +79,11 @@ export class StateHistoryCharts extends LitElement {
 
   @property({ attribute: "show-names", type: Boolean }) public showNames = true;
 
+  // Render timeline row names inside the plot (under each bar) instead of in a
+  // left-hand column. Opt-in; used by the history panel.
+  @property({ attribute: "inside-labels", type: Boolean })
+  public insideLabels = false;
+
   @property({ attribute: "click-for-more-info", type: Boolean })
   public clickForMoreInfo = true;
 
@@ -227,6 +232,7 @@ export class StateHistoryCharts extends LitElement {
         .startTime=${this._computedStartTime}
         .endTime=${this._computedEndTime}
         .showNames=${this.showNames}
+        .insideLabels=${this.insideLabels}
         .names=${this.names}
         .narrow=${this.narrow}
         .chunked=${this.virtualize}
@@ -442,6 +448,10 @@ export class StateHistoryCharts extends LitElement {
     .entry-container:not(:first-child) {
       border-top: 2px solid var(--divider-color);
       margin-top: 16px;
+    }
+
+    .entry-container.timeline:not(:first-child) {
+      margin-top: var(--ha-space-8);
     }
 
     .container,

--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -5,7 +5,7 @@ import type {
   MessageBase,
 } from "home-assistant-js-websocket";
 import { computeDomain } from "../common/entity/compute_domain";
-import { computeEntityNameList } from "../common/entity/compute_entity_name_display";
+import { DEFAULT_ENTITY_NAME } from "../common/entity/compute_entity_name_display";
 import { computeStateDisplayFromEntityAttributes } from "../common/entity/compute_state_display";
 import { computeStateNameFromEntityAttributes } from "../common/entity/compute_state_name";
 import type { LocalizeFunc } from "../common/translations/localize";
@@ -333,32 +333,6 @@ const equalState = (obj1: LineChartState, obj2: LineChartState) =>
       (attr) => obj1.attributes![attr] === obj2.attributes![attr]
     ));
 
-// Label history rows like the activity list: "Device ▸ Entity" when the entity
-// has its own name, otherwise just the device or entity name.
-const computeHistoryName = (
-  hass: HomeAssistant,
-  stateObj: HassEntity
-): string => {
-  const [entityName, deviceName] = computeEntityNameList(
-    stateObj,
-    [{ type: "entity" }, { type: "device" }],
-    hass.entities,
-    hass.devices,
-    hass.areas,
-    hass.floors
-  );
-  if (entityName && deviceName) {
-    const separator = computeRTL(
-      hass.language,
-      hass.translationMetadata.translations
-    )
-      ? " ◂ "
-      : " ▸ ";
-    return `${deviceName}${separator}${entityName}`;
-  }
-  return entityName || deviceName || stateObj.entity_id;
-};
-
 const processTimelineEntity = (
   localize: LocalizeFunc,
   locale: FrontendLocaleData,
@@ -402,7 +376,14 @@ const processTimelineEntity = (
 
   return {
     name: current_state
-      ? computeHistoryName(hass, current_state)
+      ? hass.formatEntityName(current_state, DEFAULT_ENTITY_NAME, {
+          separator: computeRTL(
+            hass.language,
+            hass.translationMetadata.translations
+          )
+            ? " ◂ "
+            : " ▸ ",
+        }) || current_state.entity_id
       : computeStateNameFromEntityAttributes(entityId, first.a),
     entity_id: entityId,
     data,
@@ -416,6 +397,12 @@ const processLineChartEntities = (
   hass: HomeAssistant
 ): LineChartUnit => {
   const data: LineChartEntity[] = [];
+  const nameSeparator = computeRTL(
+    hass.language,
+    hass.translationMetadata.translations
+  )
+    ? " ◂ "
+    : " ▸ ";
 
   const entityIds = Object.keys(entities);
   entityIds.forEach((entityId) => {
@@ -464,7 +451,9 @@ const processLineChartEntities = (
 
     const name =
       entityId in hass.states
-        ? computeHistoryName(hass, hass.states[entityId])
+        ? hass.formatEntityName(hass.states[entityId], DEFAULT_ENTITY_NAME, {
+            separator: nameSeparator,
+          }) || entityId
         : computeStateNameFromEntityAttributes(
             entityId,
             "friendly_name" in first.a ? first.a : {}

--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -1,14 +1,15 @@
 import type {
   HassConfig,
-  HassEntities,
   HassEntity,
   HassEntityAttributeBase,
   MessageBase,
 } from "home-assistant-js-websocket";
 import { computeDomain } from "../common/entity/compute_domain";
+import { computeEntityNameList } from "../common/entity/compute_entity_name_display";
 import { computeStateDisplayFromEntityAttributes } from "../common/entity/compute_state_display";
 import { computeStateNameFromEntityAttributes } from "../common/entity/compute_state_name";
 import type { LocalizeFunc } from "../common/translations/localize";
+import { computeRTL } from "../common/util/compute_rtl";
 import type { HomeAssistant } from "../types";
 import { isNumericSensorDeviceClass } from "./sensor";
 import type { FrontendLocaleData } from "./translation";
@@ -332,11 +333,37 @@ const equalState = (obj1: LineChartState, obj2: LineChartState) =>
       (attr) => obj1.attributes![attr] === obj2.attributes![attr]
     ));
 
+// Label history rows like the activity list: "Device ▸ Entity" when the entity
+// has its own name, otherwise just the device or entity name.
+const computeHistoryName = (
+  hass: HomeAssistant,
+  stateObj: HassEntity
+): string => {
+  const [entityName, deviceName] = computeEntityNameList(
+    stateObj,
+    [{ type: "entity" }, { type: "device" }],
+    hass.entities,
+    hass.devices,
+    hass.areas,
+    hass.floors
+  );
+  if (entityName && deviceName) {
+    const separator = computeRTL(
+      hass.language,
+      hass.translationMetadata.translations
+    )
+      ? " ◂ "
+      : " ▸ ";
+    return `${deviceName}${separator}${entityName}`;
+  }
+  return entityName || deviceName || stateObj.entity_id;
+};
+
 const processTimelineEntity = (
   localize: LocalizeFunc,
   locale: FrontendLocaleData,
   config: HassConfig,
-  entities: HomeAssistant["entities"],
+  hass: HomeAssistant,
   entityId: string,
   states: EntityHistoryState[],
   current_state: HassEntity | undefined
@@ -358,7 +385,7 @@ const processTimelineEntity = (
         localize,
         locale,
         config,
-        entities[entityId],
+        hass.entities[entityId],
         entityId,
         {
           ...(state.a || first.a),
@@ -374,10 +401,9 @@ const processTimelineEntity = (
   }
 
   return {
-    name: computeStateNameFromEntityAttributes(
-      entityId,
-      current_state?.attributes || first.a
-    ),
+    name: current_state
+      ? computeHistoryName(hass, current_state)
+      : computeStateNameFromEntityAttributes(entityId, first.a),
     entity_id: entityId,
     data,
   };
@@ -387,7 +413,7 @@ const processLineChartEntities = (
   unit: string,
   device_class: string | undefined,
   entities: HistoryStates,
-  hassEntities: HassEntities
+  hass: HomeAssistant
 ): LineChartUnit => {
   const data: LineChartEntity[] = [];
 
@@ -436,16 +462,17 @@ const processLineChartEntities = (
       processedStates.push(processedState);
     }
 
-    const attributes =
-      entityId in hassEntities
-        ? hassEntities[entityId].attributes
-        : "friendly_name" in first.a
-          ? first.a
-          : undefined;
+    const name =
+      entityId in hass.states
+        ? computeHistoryName(hass, hass.states[entityId])
+        : computeStateNameFromEntityAttributes(
+            entityId,
+            "friendly_name" in first.a ? first.a : {}
+          );
 
     data.push({
       domain,
-      name: computeStateNameFromEntityAttributes(entityId, attributes || {}),
+      name,
       entity_id: entityId,
       states: processedStates,
     });
@@ -610,7 +637,7 @@ export const computeHistory = (
           localize,
           hass.locale,
           hass.config,
-          hass.entities,
+          hass,
           entityId,
           stateInfo,
           currentState
@@ -638,7 +665,7 @@ export const computeHistory = (
       unit,
       deviceClass,
       lineChartDevices[key],
-      hass.states
+      hass
     );
   });
 

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -270,6 +270,7 @@ class HaPanelHistory extends LitElement {
                             .endTime=${this._endDate}
                             .narrow=${this.narrow}
                             sync-charts
+                            inside-labels
                           >
                           </state-history-charts>
                         `
@@ -812,7 +813,13 @@ class HaPanelHistory extends LitElement {
           flex: 1;
           min-width: 0;
           overflow: hidden auto;
-          padding: 16px;
+          padding: var(--ha-space-4);
+        }
+
+        /* Narrow screens: keep the vertical rhythm but give the charts the
+           horizontal space back. */
+        :host([narrow]) .results {
+          padding-inline: var(--ha-space-2);
         }
 
         .progress-wrapper {

--- a/test/data/history.test.ts
+++ b/test/data/history.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, assert, expect, vi } from "vitest";
 import { HistoryStream, computeHistory } from "../../src/data/history";
 import type { HomeAssistant } from "../../src/types";
-import {
-  mockDevice,
-  mockEntity,
-} from "../common/entity/context/context-mock";
+import { mockDevice, mockEntity } from "../common/entity/context/context-mock";
 import {
   createMockEntityState,
   createMockHass,

--- a/test/data/history.test.ts
+++ b/test/data/history.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, assert, vi } from "vitest";
-import { HistoryStream } from "../../src/data/history";
+import { describe, it, assert, expect, vi } from "vitest";
+import { HistoryStream, computeHistory } from "../../src/data/history";
 import type { HomeAssistant } from "../../src/types";
+import {
+  mockDevice,
+  mockEntity,
+} from "../common/entity/context/context-mock";
+import {
+  createMockEntityState,
+  createMockHass,
+  mockLocalize,
+} from "../fixtures/hass";
 
 const mockHass = {} as HomeAssistant;
 
@@ -106,5 +115,149 @@ describe("HistoryStream.processMessage", () => {
     const firstState = result["sensor.power"][0];
     assert.equal(firstState.lc, purgeBeforePythonTime + 50);
     assert.equal(firstState.lu, purgeBeforePythonTime + 100);
+  });
+});
+
+const namedHistoryHass = (options: {
+  entityId: string;
+  entityName?: string;
+  deviceName: string;
+  attributes?: Record<string, unknown>;
+  rtl?: boolean;
+}): HomeAssistant => {
+  const hass = createMockHass(
+    {
+      [options.entityId]: createMockEntityState(
+        options.entityId,
+        "on",
+        options.attributes ?? { friendly_name: "Caméra Allée Battery state" }
+      ),
+    },
+    {
+      entities: {
+        [options.entityId]: mockEntity({
+          entity_id: options.entityId,
+          name: options.entityName,
+          device_id: "device_1",
+        }),
+      },
+      devices: {
+        device_1: mockDevice({
+          id: "device_1",
+          name: options.deviceName,
+        }),
+      },
+    }
+  );
+  if (options.rtl) {
+    hass.language = "he";
+    hass.translationMetadata = {
+      fragments: [],
+      translations: {
+        he: { nativeName: "Hebrew", isRTL: true, hash: "" },
+      },
+    };
+  }
+  return hass;
+};
+
+const binaryHistory = (entityId: string, friendlyName?: string) => ({
+  [entityId]: [
+    {
+      s: "on",
+      a: friendlyName ? { friendly_name: friendlyName } : {},
+      lu: 1_700_000_000,
+    },
+  ],
+});
+
+const numericHistory = (entityId: string, friendlyName?: string) => ({
+  [entityId]: [
+    {
+      s: "12",
+      a: {
+        unit_of_measurement: "W",
+        ...(friendlyName ? { friendly_name: friendlyName } : {}),
+      },
+      lu: 1_700_000_000,
+    },
+  ],
+});
+
+describe("computeHistory entity names", () => {
+  it("labels a timeline entity as Device ▸ Entity when the entity has its own name", () => {
+    const entityId = "binary_sensor.allee_battery";
+    const result = computeHistory(
+      namedHistoryHass({
+        entityId,
+        entityName: "Battery state",
+        deviceName: "Caméra Allée",
+      }),
+      binaryHistory(entityId),
+      [],
+      mockLocalize
+    );
+    expect(result.timeline[0]?.name).toBe("Caméra Allée ▸ Battery state");
+  });
+
+  it("labels a line entity as Device ▸ Entity when the entity has its own name", () => {
+    const entityId = "sensor.allee_power";
+    const result = computeHistory(
+      namedHistoryHass({
+        entityId,
+        entityName: "Power",
+        deviceName: "Caméra Allée",
+        attributes: {
+          unit_of_measurement: "W",
+          friendly_name: "Caméra Allée Power",
+        },
+      }),
+      numericHistory(entityId),
+      [],
+      mockLocalize
+    );
+    expect(result.line[0]?.data[0]?.name).toBe("Caméra Allée ▸ Power");
+  });
+
+  it("uses just the device name when the entity has no name of its own", () => {
+    const entityId = "binary_sensor.desk";
+    const result = computeHistory(
+      namedHistoryHass({
+        entityId,
+        deviceName: "Desk",
+        attributes: { friendly_name: "Desk" },
+      }),
+      binaryHistory(entityId),
+      [],
+      mockLocalize
+    );
+    expect(result.timeline[0]?.name).toBe("Desk");
+  });
+
+  it("falls back to friendly_name when the entity has no current state", () => {
+    const entityId = "binary_sensor.removed";
+    const result = computeHistory(
+      createMockHass(),
+      binaryHistory(entityId, "Gone sensor"),
+      [],
+      mockLocalize
+    );
+    expect(result.timeline[0]?.name).toBe("Gone sensor");
+  });
+
+  it("uses the RTL separator when the language is RTL", () => {
+    const entityId = "binary_sensor.allee_battery";
+    const result = computeHistory(
+      namedHistoryHass({
+        entityId,
+        entityName: "Battery state",
+        deviceName: "Caméra Allée",
+        rtl: true,
+      }),
+      binaryHistory(entityId),
+      [],
+      mockLocalize
+    );
+    expect(result.timeline[0]?.name).toBe("Caméra Allée ◂ Battery state");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

History timeline rows currently put the entity name in a left-hand column next to the bar. On a phone that column can take up a third of the width, names get truncated, and timeline labels sit in a different place than line-chart legends.

This change:

- Moves History panel timeline names **under each bar** so the bar spans the full width and every entity reads "plot, then label" like the line charts.
- Uses taller timeline rows and extra space between timeline blocks so each entity is a clear block.
- Trims side padding on narrow screens so the charts get the width back.
- Labels entities the way the activity list does: **Device ▸ Entity** when the entity has its own name, otherwise just the device name.

`inside-labels` is opt-in and enabled only on the History panel. Lovelace history-graph cards and more-info keep the existing left-column layout.

Based on the prototype in #54034.

Please add your own screenshots or a short video on a real instance if you want additional review evidence. A walkthrough of the demo History panel is attached.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Desktop History panel — names under timeline bars, full-width plots:

![History panel desktop with timeline names under bars](https://cursor.com/artifacts/c/art-e0f528e6-7fbe-4aab-92f1-6cf1c881bb0c)

Narrow History panel:

![History panel on a phone-width viewport](https://cursor.com/artifacts/c/art-1801a722-993d-4034-85f1-7dfba670c6f0)

Clicking a timeline name still opens more-info:

![More-info dialog opened from a timeline name](https://cursor.com/artifacts/c/art-2e97bf69-b3ff-4895-8e3f-01a3df223e37)

<a href="https://cursor.com/agents/bc-dc2a8557-e8a3-4351-bed2-d5dad337f5e2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_panel_timeline_labels_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-4498db81-3375-4217-82c9-dda5e1c8beb8" alt="history_panel_timeline_labels_walkthrough.mp4" /></a>

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54034
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc2a8557-e8a3-4351-bed2-d5dad337f5e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc2a8557-e8a3-4351-bed2-d5dad337f5e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

