### PR TITLE
Await Lovelace resources before loading dashboard

### DIFF
--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -32,7 +32,7 @@ import type { ShowToastParams } from "../../managers/notification-manager";
 import type { HomeAssistant, PanelInfo, Route } from "../../types";
 import { showToast } from "../../util/toast";
 import { checkLovelaceConfig } from "./common/check-lovelace-config";
-import { loadLovelaceResources } from "./common/load-resources";
+import { loadLovelaceResourcesAndWait } from "./common/load-resources";
 import { showSaveDialog } from "./editor/show-save-config-dialog";
 import "./hui-root";
 import {
@@ -52,7 +52,7 @@ interface LovelacePanelConfig {
 const EXTERNALLY_UPDATED_TOAST_ID = "lovelace-externally-updated";
 
 let editorLoaded = false;
-let resourcesLoaded = false;
+let resourcesLoadPromise: Promise<void> | undefined;
 
 @customElement("ha-panel-lovelace")
 export class LovelacePanel extends LitElement {
@@ -309,12 +309,9 @@ export class LovelacePanel extends LitElement {
       confProm = preloadWindow.llConfProm;
       preloadWindow.llConfProm = undefined;
     }
-    if (!resourcesLoaded) {
-      resourcesLoaded = true;
-      (preloadWindow.llResProm || fetchResources(this.hass!.connection)).then(
-        (resources) => loadLovelaceResources(resources, this.hass!)
-      );
-    }
+    resourcesLoadPromise ??= (
+      preloadWindow.llResProm || fetchResources(this.hass!.connection)
+    ).then((resources) => loadLovelaceResourcesAndWait(resources, this.hass!));
     if (this.urlPath !== null || !confProm) {
       // Refreshing a YAML config can trigger an update event. We will ignore
       // all update events while fetching the config and for 2 seconds after the config is back.
@@ -331,7 +328,7 @@ export class LovelacePanel extends LitElement {
     }
 
     try {
-      rawConf = await confProm;
+      [rawConf] = await Promise.all([confProm, resourcesLoadPromise]);
 
       // If strategy defined, apply it here.
       if (isStrategyDashboard(rawConf)) {

--- a/test/panels/lovelace/ha-panel-lovelace.test.ts
+++ b/test/panels/lovelace/ha-panel-lovelace.test.ts
@@ -1,0 +1,78 @@
+import { expect, it, vi } from "vitest";
+
+import type { LovelaceConfig } from "../../../src/data/lovelace/config/types";
+import type { WindowWithPreloads } from "../../../src/data/preloads";
+import type { LovelacePanel } from "../../../src/panels/lovelace/ha-panel-lovelace";
+import type { Lovelace } from "../../../src/panels/lovelace/types";
+import type { HomeAssistant, PanelInfo } from "../../../src/types";
+
+const mocks = vi.hoisted(() => ({ loadModule: vi.fn() }));
+
+vi.hoisted(() => {
+  Object.assign(globalThis, {
+    __STATIC_PATH__: "/",
+    __HASS_URL__: "",
+    __BUILD__: "modern",
+    __VERSION__: "test",
+    __BACKWARDS_COMPAT__: false,
+    __SUPERVISOR__: false,
+    __NAMESPACE__: "frontend",
+  });
+});
+
+vi.mock("../../../src/common/dom/load_resource", () => ({
+  loadCSS: vi.fn(),
+  loadJS: vi.fn(),
+  loadModule: mocks.loadModule,
+}));
+
+await import("../../../src/panels/lovelace/ha-panel-lovelace");
+
+interface LovelacePanelInternals {
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- private panel lifecycle
+  _fetchConfig(forceDiskRefresh: boolean): Promise<void>;
+  lovelace?: Lovelace;
+}
+
+it("waits for Lovelace resources before setting the dashboard config", async () => {
+  let resolveResourceLoad: (() => void) | undefined;
+  const resourceLoad = new Promise<void>((resolve) => {
+    resolveResourceLoad = resolve;
+  });
+  mocks.loadModule.mockReturnValue(resourceLoad);
+
+  const config: LovelaceConfig = { views: [] };
+  const preloadWindow = window as WindowWithPreloads;
+  preloadWindow.llConfProm = Promise.resolve(config);
+  preloadWindow.llResProm = Promise.resolve([
+    { id: "test", type: "module", url: "/local/test-card.js" },
+  ]);
+
+  const panel = document.createElement("ha-panel-lovelace") as LovelacePanel;
+  panel.panel = {
+    config: { mode: "storage" },
+    url_path: null,
+  } as unknown as PanelInfo<{ mode: "storage" }>;
+  panel.hass = {
+    areas: {},
+    auth: { data: { hassUrl: "http://localhost:8123" } },
+    connection: {},
+    devices: {},
+    entities: {},
+    locale: {},
+    localize: (key: string) => key,
+  } as unknown as HomeAssistant;
+  const internals = panel as unknown as LovelacePanelInternals;
+
+  const configLoad = internals._fetchConfig(false);
+
+  await vi.waitFor(() => {
+    expect(mocks.loadModule).toHaveBeenCalledOnce();
+  });
+  expect(internals.lovelace).toBeUndefined();
+
+  resolveResourceLoad!();
+  await configLoad;
+
+  expect(internals.lovelace?.rawConfig).toBe(config);
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not applicable.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Wait for Lovelace resources to finish loading before applying the dashboard configuration. The resource and configuration requests still start in parallel, but the dashboard is no longer constructed until registered custom cards, views, and strategies are available.

This prevents a cold-load race that can leave a custom card showing a permanent “Configuration error” even though its module finishes loading shortly afterward. A regression test holds a custom module load open and verifies that Lovelace configuration is not applied until the module completes.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Not applicable; this changes load ordering and has no intentional visual change.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #52570
- External issue: https://github.com/distante/ha-xplora-watch/issues/5
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
