### PR TITLE
An empty placeholder for entity-filter-badge in edit mode

### DIFF
--- a/src/panels/lovelace/badges/hui-badge.ts
+++ b/src/panels/lovelace/badges/hui-badge.ts
@@ -67,6 +67,7 @@ export class HuiBadge extends ConditionalListenerMixin<LovelaceBadgeConfig>(
     if (this.hass) {
       this._element.hass = this.hass;
     }
+    this._element.preview = this.preview;
     // Update element when the visibility of the badge changes, e.g. custom badge
     this._element.addEventListener("badge-visibility-changed", (ev: Event) => {
       ev.stopPropagation();
@@ -128,11 +129,12 @@ export class HuiBadge extends ConditionalListenerMixin<LovelaceBadgeConfig>(
           }
         }
       }
-      if (changedProps.has("hass")) {
+      if (changedProps.has("hass") || changedProps.has("preview")) {
         try {
           if (this.hass) {
             this._element.hass = this.hass;
           }
+          this._element.preview = this.preview;
         } catch (e: any) {
           this._loadElement(createErrorBadgeConfig(e.message, null));
         }

--- a/src/panels/lovelace/badges/hui-entity-filter-badge.ts
+++ b/src/panels/lovelace/badges/hui-entity-filter-badge.ts
@@ -28,6 +28,8 @@ export class HuiEntityFilterBadge
 
   private _elements?: HuiBadge[];
 
+  private _placeholderBadge?: HTMLElement;
+
   private _configEntities?: EntityFilterEntityConfig[];
 
   private _oldEntities?: EntityFilterEntityConfig[];
@@ -56,6 +58,7 @@ export class HuiEntityFilterBadge
       this.removeChild(this.lastChild);
     }
     this._elements = undefined;
+    this._placeholderBadge = undefined;
 
     this._configEntities = processConfigEntities(config.entities);
     this._oldEntities = undefined;
@@ -69,6 +72,7 @@ export class HuiEntityFilterBadge
   protected shouldUpdate(changedProperties: PropertyValues): boolean {
     if (
       changedProperties.has("_config") ||
+      changedProperties.has("preview") ||
       (changedProperties.has("hass") &&
         this._haveEntitiesChanged(
           changedProperties.get("hass") as HomeAssistant | undefined
@@ -112,33 +116,42 @@ export class HuiEntityFilterBadge
     });
 
     if (entitiesList.length === 0) {
-      this.style.display = "none";
       this._oldEntities = entitiesList;
-      return;
-    }
 
-    const isSame =
-      this._oldEntities &&
-      entitiesList.length === this._oldEntities.length &&
-      entitiesList.every((entity, idx) => entity === this._oldEntities![idx]);
-
-    if (!isSame) {
-      this._elements = [];
-      for (const badgeConfig of entitiesList) {
-        const element = document.createElement("hui-badge");
-        element.hass = this.hass;
-        element.preview = this.preview;
-        element.config = {
-          type: "entity",
-          ...badgeConfig,
-        };
-        element.load();
-        this._elements.push(element);
+      if (!this.preview) {
+        this._placeholderBadge = undefined;
+        this.style.display = "none";
+        return;
       }
-      this._oldEntities = entitiesList;
+
+      this._placeholderBadge ??= document.createElement("ha-badge");
+    } else {
+      this._placeholderBadge = undefined;
+
+      const isSame =
+        !changedProperties.has("preview") &&
+        this._oldEntities &&
+        entitiesList.length === this._oldEntities.length &&
+        entitiesList.every((entity, idx) => entity === this._oldEntities![idx]);
+
+      if (!isSame) {
+        this._elements = [];
+        for (const badgeConfig of entitiesList) {
+          const element = document.createElement("hui-badge");
+          element.hass = this.hass;
+          element.preview = this.preview;
+          element.config = {
+            type: "entity",
+            ...badgeConfig,
+          };
+          element.load();
+          this._elements.push(element);
+        }
+        this._oldEntities = entitiesList;
+      }
     }
 
-    if (!this._elements) {
+    if (!this._elements && !this._placeholderBadge) {
       return;
     }
 
@@ -146,8 +159,12 @@ export class HuiEntityFilterBadge
       this.removeChild(this.lastChild);
     }
 
-    for (const element of this._elements) {
-      this.appendChild(element);
+    if (this._placeholderBadge) {
+      this.appendChild(this._placeholderBadge);
+    } else {
+      for (const element of this._elements!) {
+        this.appendChild(element);
+      }
     }
 
     this.style.display = "flex";

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -43,6 +43,7 @@ export interface Lovelace {
 
 export interface LovelaceBadge extends HTMLElement {
   hass?: HomeAssistant;
+  preview?: boolean;
   connectedWhileHidden?: boolean;
   setConfig(config: LovelaceBadgeConfig): void;
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
If entity-filter badge filters all entities, the badge becomes lost. Even in edit mode, it renders nothing, so there's no handle to edit it or even see that it still exists, it's just a 0-pixel empty space. You would have to dive into raw yaml config to find and edit it.

This PR will render it as an empty badge placeholder, so that it has something to click on to edit and host the overflow menu, only when the filtered entities list is empty, and only in edit mode. Otherwise it renders as it normally does today.

This is the same approach taken with entity-filter card, which renders a small empty rectangle in edit mode to host the editing options. 

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="404" height="102" alt="image" src="https://github.com/user-attachments/assets/390c24a6-96ab-44ca-aee0-140ce12a11e5" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
