### PR TITLE
Show Energy Now view for water and gas flow without power sensors

### DIFF
--- a/src/panels/energy/strategies/energy-cards.ts
+++ b/src/panels/energy/strategies/energy-cards.ts
@@ -85,6 +85,14 @@ export const hasGasRateSource = (prefs: EnergyPreferences): boolean =>
     (source) => source.type === "gas" && !!source.stat_rate
   );
 
+/** Whether the Now view has any live power or flow-rate content to show. */
+export const hasNowViewContent = (prefs: EnergyPreferences): boolean =>
+  hasPowerSources(prefs) ||
+  hasPowerDevices(prefs) ||
+  hasWaterRateSource(prefs) ||
+  hasWaterRateDevices(prefs) ||
+  hasGasRateSource(prefs);
+
 // --- Card catalog ----------------------------------------------------------
 
 export interface EnergyCardCatalogEntry {

--- a/src/panels/energy/strategies/energy-dashboard-strategy.ts
+++ b/src/panels/energy/strategies/energy-dashboard-strategy.ts
@@ -18,7 +18,7 @@ import {
   hasDeviceConsumption,
   hasEnergySource,
   hasGasSource,
-  hasPowerDevices,
+  hasNowViewContent,
   hasPowerSources,
   hasWaterDevices,
   hasWaterSource,
@@ -100,8 +100,6 @@ export class EnergyDashboardStrategy extends ReactiveElement {
 
     const hasEnergy = hasEnergySource(prefs);
     const hasPowerSource = hasPowerSources(prefs);
-    const hasDevicePower = hasPowerDevices(prefs);
-    const hasPower = hasPowerSource || hasDevicePower;
     const hasWater = hasWaterSource(prefs) || hasWaterDevices(prefs);
     const hasGas = hasGasSource(prefs);
     const hasDevices = hasDeviceConsumption(prefs);
@@ -118,7 +116,7 @@ export class EnergyDashboardStrategy extends ReactiveElement {
     if (hasWater) {
       candidateViews.push(WATER_VIEW);
     }
-    if (hasPower) {
+    if (hasNowViewContent(prefs)) {
       candidateViews.push(POWER_VIEW);
     }
     if (

--- a/src/panels/energy/strategies/energy-dashboard-strategy.ts
+++ b/src/panels/energy/strategies/energy-dashboard-strategy.ts
@@ -90,7 +90,8 @@ export class EnergyDashboardStrategy extends ReactiveElement {
     if (
       !prefs ||
       (prefs.device_consumption.length === 0 &&
-        prefs.energy_sources.length === 0)
+        prefs.energy_sources.length === 0 &&
+        !hasWaterDevices(prefs))
     ) {
       await import("../cards/energy-setup-wizard-card");
       return {

--- a/src/panels/energy/strategies/power-view-strategy.ts
+++ b/src/panels/energy/strategies/power-view-strategy.ts
@@ -9,9 +9,8 @@ import type { HomeAssistant } from "../../../types";
 import type { EnergyViewStrategyConfig } from "./energy-cards";
 import {
   hasGasRateSource,
-  hasPowerDevices,
+  hasNowViewContent,
   hasPowerSources,
-  hasWaterRateDevices,
   hasWaterRateSource,
   isEnergyCardVisible,
 } from "./energy-cards";
@@ -54,20 +53,11 @@ export class PowerViewStrategy extends ReactiveElement {
     };
 
     const hasPowerSrc = !!prefs && hasPowerSources(prefs);
-    const hasPowerDev = !!prefs && hasPowerDevices(prefs);
-    const hasWaterDev = !!prefs && hasWaterRateDevices(prefs);
     const hasWaterSrc = !!prefs && hasWaterRateSource(prefs);
     const hasGasSrc = !!prefs && hasGasRateSource(prefs);
 
-    // No sources configured
-    if (
-      !prefs ||
-      (!hasPowerSrc &&
-        !hasPowerDev &&
-        !hasWaterDev &&
-        !hasWaterSrc &&
-        !hasGasSrc)
-    ) {
+    // No live power or flow-rate sources configured
+    if (!prefs || !hasNowViewContent(prefs)) {
       return view;
     }
 

--- a/test/panels/energy/strategies/energy-cards.test.ts
+++ b/test/panels/energy/strategies/energy-cards.test.ts
@@ -193,6 +193,18 @@ describe("source predicates", () => {
     expect(
       hasNowViewContent(
         makePrefs({
+          device_consumption: [
+            {
+              stat_consumption: "sensor.device",
+              stat_rate: "sensor.device_rate",
+            },
+          ],
+        })
+      )
+    ).toBe(true);
+    expect(
+      hasNowViewContent(
+        makePrefs({
           energy_sources: [
             source({
               type: "solar",

--- a/test/panels/energy/strategies/energy-cards.test.ts
+++ b/test/panels/energy/strategies/energy-cards.test.ts
@@ -9,6 +9,7 @@ import {
   energyCardKey,
   hasEnergySource,
   hasGasRateSource,
+  hasNowViewContent,
   hasWaterRateSource,
   isEnergyCardHidden,
   isEnergyCardVisible,
@@ -165,6 +166,43 @@ describe("source predicates", () => {
     expect(hasGasRateSource(makePrefs({ energy_sources: [GAS_RATE] }))).toBe(
       true
     );
+  });
+
+  it("hasNowViewContent is true for any live power or flow-rate content", () => {
+    expect(hasNowViewContent(makePrefs({ energy_sources: [WATER] }))).toBe(
+      false
+    );
+    expect(hasNowViewContent(makePrefs({ energy_sources: [WATER_RATE] }))).toBe(
+      true
+    );
+    expect(hasNowViewContent(makePrefs({ energy_sources: [GAS_RATE] }))).toBe(
+      true
+    );
+    expect(
+      hasNowViewContent(
+        makePrefs({
+          device_consumption_water: [
+            {
+              stat_consumption: "sensor.water_device",
+              stat_rate: "sensor.water_device_rate",
+            },
+          ],
+        })
+      )
+    ).toBe(true);
+    expect(
+      hasNowViewContent(
+        makePrefs({
+          energy_sources: [
+            source({
+              type: "solar",
+              stat_energy_from: "sensor.solar",
+              stat_rate: "sensor.solar_power",
+            }),
+          ],
+        })
+      )
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The Energy dashboard Now tab was only added when a power sensor existed, so water-only or gas-only live-rate setups never showed the flow chip or Now view. Tab visibility now uses the same live-rate checks the Now view already uses (`hasNowViewContent`), covering power sources/devices, water flow rates, and gas flow rates.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
Water-only Energy preferences (water consumption + flow rate sensors, no power):

| Before | After |
| --- | --- |
| Water tab only; no Now tab | Water + Now tabs |
| ![Before](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/energy-before-water-fb924069.png) | ![After water](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/energy-after-water-43df4158.png) |

Now tab with live water flow badge and current water flow sankey:

![After Now](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/energy-after-now-42a79a6e.png)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54089
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
