### PR TITLE
Roll energy collections over at midnight

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -802,14 +802,21 @@ const scheduleHourlyRefresh = (collection: EnergyCollection) => {
   }
 
   if (collection._active && (!collection.end || collection.end > new Date())) {
-    // The stats are created every hour
-    // Schedule a refresh for 20 minutes past the hour
-    // If the end is larger than the current time.
+    // Long-term hourly stats land around :20. Before that, Core can already
+    // stitch the open hour from short-term rows once the first 5-minute
+    // bucket exists (recorder compiles at :05:10), so prefer an early
+    // refresh after midnight / early-hour fetches, then resume :20.
     const nextFetch = new Date();
-    if (nextFetch.getMinutes() >= 20) {
-      nextFetch.setHours(nextFetch.getHours() + 1);
+    const firstShortTermRefresh = new Date(nextFetch);
+    firstShortTermRefresh.setMinutes(5, 15, 0);
+    if (nextFetch < firstShortTermRefresh) {
+      nextFetch.setTime(firstShortTermRefresh.getTime());
+    } else {
+      if (nextFetch.getMinutes() >= 20) {
+        nextFetch.setHours(nextFetch.getHours() + 1);
+      }
+      nextFetch.setMinutes(20, 0, 0);
     }
-    nextFetch.setMinutes(20, 0, 0);
 
     collection._refreshTimeout = window.setTimeout(
       () => collection.refresh(),

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -9,6 +9,7 @@ import {
   isFirstDayOfMonth,
   isLastDayOfMonth,
   startOfDay,
+  startOfHour,
 } from "date-fns";
 import type { Collection, HassEntity } from "home-assistant-js-websocket";
 import { getCollection } from "home-assistant-js-websocket";
@@ -600,6 +601,9 @@ const getEnergyData = async (
   let statsCompare;
   let startCompare;
   let endCompare;
+  // Compare ranges are completed/historical; pick their period independently so
+  // hour-0's live "5minute" choice is not reused for YoY/previous compare.
+  let periodCompare = period;
   let _energyStatsCompare: Statistics | Promise<Statistics> = {};
   let _waterStatsCompare: Statistics | Promise<Statistics> = {};
   if (compare) {
@@ -646,13 +650,14 @@ const getEnergyData = async (
       startCompare = calcDate(start, addYears, hass.locale, hass.config, -1);
       endCompare = calcDate(end!, addYears, hass.locale, hass.config, -1);
     }
+    periodCompare = getSuggestedPeriod(startCompare!, endCompare);
     if (energyStatIds.length) {
       _energyStatsCompare = fetchStatistics(
         hass!,
         startCompare,
         endCompare,
         energyStatIds,
-        period,
+        periodCompare,
         energyUnits,
         ["change"]
       );
@@ -663,7 +668,7 @@ const getEnergyData = async (
         startCompare,
         endCompare,
         waterStatIds,
-        period,
+        periodCompare,
         waterUnits,
         ["change"]
       );
@@ -686,13 +691,15 @@ const getEnergyData = async (
       fossilPeriod
     );
     if (compare) {
+      const fossilPeriodCompare =
+        periodCompare === "5minute" ? "hour" : periodCompare;
       _fossilEnergyConsumptionCompare = getFossilEnergyConsumption(
         hass!,
         startCompare,
         consumptionStatIDs,
         co2SignalEntity,
         endCompare,
-        fossilPeriod
+        fossilPeriodCompare
       );
     }
   }
@@ -1804,10 +1811,14 @@ export function getSuggestedPeriod(
         : "hour";
 
   // Hourly long-term stats for the current hour do not exist until it ends.
-  // Use 5-minute short-term stats while the visible range is still < 1 hour.
+  // Use 5-minute short-term stats only for the live incomplete hour — not for
+  // historical short ranges (e.g. year-over-year compare during hour 0).
   if (coarse === "hour") {
     const rangeEnd = Math.min((end ?? now).getTime(), now.getTime());
-    if (rangeEnd - start.getTime() < 60 * 60 * 1000) {
+    if (
+      start.getTime() >= startOfHour(now).getTime() &&
+      rangeEnd - start.getTime() < 60 * 60 * 1000
+    ) {
       return "5minute";
     }
   }

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -9,7 +9,6 @@ import {
   isFirstDayOfMonth,
   isLastDayOfMonth,
   startOfDay,
-  startOfHour,
 } from "date-fns";
 import type { Collection, HassEntity } from "home-assistant-js-websocket";
 import { getCollection } from "home-assistant-js-websocket";
@@ -601,9 +600,6 @@ const getEnergyData = async (
   let statsCompare;
   let startCompare;
   let endCompare;
-  // Compare ranges are completed/historical; pick their period independently so
-  // hour-0's live "5minute" choice is not reused for YoY/previous compare.
-  let periodCompare = period;
   let _energyStatsCompare: Statistics | Promise<Statistics> = {};
   let _waterStatsCompare: Statistics | Promise<Statistics> = {};
   if (compare) {
@@ -650,14 +646,13 @@ const getEnergyData = async (
       startCompare = calcDate(start, addYears, hass.locale, hass.config, -1);
       endCompare = calcDate(end!, addYears, hass.locale, hass.config, -1);
     }
-    periodCompare = getSuggestedPeriod(startCompare!, endCompare);
     if (energyStatIds.length) {
       _energyStatsCompare = fetchStatistics(
         hass!,
         startCompare,
         endCompare,
         energyStatIds,
-        periodCompare,
+        period,
         energyUnits,
         ["change"]
       );
@@ -668,7 +663,7 @@ const getEnergyData = async (
         startCompare,
         endCompare,
         waterStatIds,
-        periodCompare,
+        period,
         waterUnits,
         ["change"]
       );
@@ -679,27 +674,22 @@ const getEnergyData = async (
   let _fossilEnergyConsumptionCompare:
     undefined | Promise<FossilEnergyConsumption>;
   if (co2SignalEntity !== undefined) {
-    // Fossil consumption always queries hourly recorder data; "5minute" is
-    // accepted by the schema but does not produce usable results.
-    const fossilPeriod = period === "5minute" ? "hour" : period;
     _fossilEnergyConsumption = getFossilEnergyConsumption(
       hass!,
       start,
       consumptionStatIDs,
       co2SignalEntity,
       end,
-      fossilPeriod
+      period
     );
     if (compare) {
-      const fossilPeriodCompare =
-        periodCompare === "5minute" ? "hour" : periodCompare;
       _fossilEnergyConsumptionCompare = getFossilEnergyConsumption(
         hass!,
         startCompare,
         consumptionStatIDs,
         co2SignalEntity,
         endCompare,
-        fossilPeriodCompare
+        period
       );
     }
   }
@@ -868,8 +858,9 @@ export const getEnergyDefaultPeriodStorageKey = (
 };
 
 // Live day used while a rollover timer is scheduled. Custom dates do not use
-// this. Always today — kWh fetches use 5-minute stats in hour 0 via
-// getSuggestedPeriod, so the graph is not empty after the first bucket.
+// this. Always today — Core fills the unfinished current hour from short-term
+// stats in statistics_during_period, so hour/day charts are not empty after
+// the first short-term bucket.
 export const getEnergyLiveDayPeriod = (
   now: Date,
   locale: HomeAssistant["locale"],
@@ -1793,36 +1784,20 @@ export const formatPowerShort = (
 export function getSuggestedPeriod(
   start: Date,
   end?: Date,
-  fine = false,
-  now = new Date()
+  fine = false
 ): "5minute" | "hour" | "day" | "month" {
-  const dayDifference = differenceInDays(end || now, start);
+  const dayDifference = differenceInDays(end || new Date(), start);
 
   if (fine) {
     return dayDifference > 64 ? "day" : dayDifference > 8 ? "hour" : "5minute";
   }
-  const coarse =
-    isFirstDayOfMonth(start) &&
+  return isFirstDayOfMonth(start) &&
     (!end || isLastDayOfMonth(end)) &&
     dayDifference > 35
-      ? "month"
-      : dayDifference > 2
-        ? "day"
-        : "hour";
-
-  // Hourly long-term stats for the current hour do not exist until it ends.
-  // Use 5-minute short-term stats only for the live incomplete hour — not for
-  // historical short ranges (e.g. year-over-year compare during hour 0).
-  if (coarse === "hour") {
-    const rangeEnd = Math.min((end ?? now).getTime(), now.getTime());
-    if (
-      start.getTime() >= startOfHour(now).getTime() &&
-      rangeEnd - start.getTime() < 60 * 60 * 1000
-    ) {
-      return "5minute";
-    }
-  }
-  return coarse;
+    ? "month"
+    : dayDifference > 2
+      ? "day"
+      : "hour";
 }
 
 export const downloadEnergyData = (

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -1,6 +1,5 @@
 import {
   addDays,
-  addHours,
   addMilliseconds,
   addMonths,
   addYears,
@@ -675,13 +674,16 @@ const getEnergyData = async (
   let _fossilEnergyConsumptionCompare:
     undefined | Promise<FossilEnergyConsumption>;
   if (co2SignalEntity !== undefined) {
+    // Fossil consumption always queries hourly recorder data; "5minute" is
+    // accepted by the schema but does not produce usable results.
+    const fossilPeriod = period === "5minute" ? "hour" : period;
     _fossilEnergyConsumption = getFossilEnergyConsumption(
       hass!,
       start,
       consumptionStatIDs,
       co2SignalEntity,
       end,
-      period
+      fossilPeriod
     );
     if (compare) {
       _fossilEnergyConsumptionCompare = getFossilEnergyConsumption(
@@ -690,7 +692,7 @@ const getEnergyData = async (
         consumptionStatIDs,
         co2SignalEntity,
         endCompare,
-        period
+        fossilPeriod
       );
     }
   }
@@ -858,104 +860,29 @@ export const getEnergyDefaultPeriodStorageKey = (
   return `energy-default-period-${key}`;
 };
 
-// When today's first hourly statistic becomes available (01:00 in the
-// configured timezone). Rolling the statistics view over at midnight would
-// show an empty graph.
-export const getEnergyFirstStatisticAt = (
-  now: Date,
-  locale: HomeAssistant["locale"],
-  config: HomeAssistant["config"]
-): Date => addHours(calcDate(now, startOfDay, locale, config), 1);
-
-// The statistics Energy view shows yesterday until 01:00 so the graph is not
-// empty. The real-time "Now" view never does this — it has live data.
-export const shouldFallbackEnergyPeriodToYesterday = (
-  midnightRollover: boolean,
-  now: Date,
-  locale: HomeAssistant["locale"],
-  config: HomeAssistant["config"]
-): boolean =>
-  !midnightRollover &&
-  now.getTime() < getEnergyFirstStatisticAt(now, locale, config).getTime();
-
-// Live day used while a rollover timer is scheduled (today, or the hour-0
-// yesterday fallback). Custom dates do not use this. If the user already
-// picked today during hour 0, keep today rather than snapping back.
+// Live day used while a rollover timer is scheduled. Custom dates do not use
+// this. Always today — kWh fetches use 5-minute stats in hour 0 via
+// getSuggestedPeriod, so the graph is not empty after the first bucket.
 export const getEnergyLiveDayPeriod = (
-  midnightRollover: boolean,
   now: Date,
   locale: HomeAssistant["locale"],
-  config: HomeAssistant["config"],
-  currentStart: Date
-): { start: Date; end: Date } => {
-  const todayStart = calcDate(now, startOfDay, locale, config);
-  if (
-    shouldFallbackEnergyPeriodToYesterday(
-      midnightRollover,
-      now,
-      locale,
-      config
-    ) &&
-    currentStart.getTime() !== todayStart.getTime()
-  ) {
-    const yesterday = calcDate(now, addDays, locale, config, -1);
-    return {
-      start: calcDate(yesterday, startOfDay, locale, config),
-      end: calcDate(yesterday, endOfDay, locale, config),
-    };
-  }
-  return {
-    start: todayStart,
-    end: calcDate(now, endOfDay, locale, config),
-  };
-};
+  config: HomeAssistant["config"]
+): { start: Date; end: Date } => ({
+  start: calcDate(now, startOfDay, locale, config),
+  end: calcDate(now, endOfDay, locale, config),
+});
 
-// When does the collection's day period need to roll over to the next day?
-// With `midnightRollover` (the real-time "Now" view) it rolls over right at
-// midnight. Otherwise it waits an hour, until the new day's first hourly
-// statistic exists — rolling over at midnight would show an empty graph.
-// Pass `periodStart` when the collection is on a specific day: hour-0
-// yesterday (and any older stale live day) must wake at today 01:00, not
-// tomorrow 01:00. Keep tomorrow 01:00 only when the user already picked today.
+// Next midnight in the configured zone, not browser-local addDays, so a DST
+// transition cannot skip a server-tz day.
 export const getNextEnergyPeriodStart = (
-  midnightRollover: boolean,
   now: Date,
   locale: HomeAssistant["locale"],
-  config: HomeAssistant["config"],
-  periodStart?: Date
-): Date => {
-  const todayStart = calcDate(now, startOfDay, locale, config);
-  if (
-    periodStart &&
-    shouldFallbackEnergyPeriodToYesterday(
-      midnightRollover,
-      now,
-      locale,
-      config
-    ) &&
-    periodStart.getTime() !== todayStart.getTime()
-  ) {
-    return getEnergyFirstStatisticAt(now, locale, config);
-  }
-  // Next midnight in the configured zone, not browser-local addDays, so a
-  // DST transition cannot skip a server-tz day.
-  const nextMidnight = addMilliseconds(
-    calcDate(now, endOfDay, locale, config),
-    1
-  );
-  return midnightRollover ? nextMidnight : addHours(nextMidnight, 1);
-};
+  config: HomeAssistant["config"]
+): Date => addMilliseconds(calcDate(now, endOfDay, locale, config), 1);
 
 export const getEnergyDataCollection = (
   hass: HomeAssistant,
-  options: {
-    prefs?: EnergyPreferences;
-    key?: string;
-    // The real-time "Now" view opts in to rolling its day period over at
-    // midnight rather than an hour later (it shows live data, so it always
-    // tracks today and never falls back to yesterday in the first hour).
-    midnightRollover?: boolean;
-  } = {}
+  options: { prefs?: EnergyPreferences; key?: string } = {}
 ): EnergyCollection => {
   const [key, collectionKey] = convertCollectionKeyToConnection(
     hass,
@@ -964,8 +891,6 @@ export const getEnergyDataCollection = (
   if ((hass.connection as any)[key]) {
     return (hass.connection as any)[key];
   }
-
-  const midnightRollover = options.midnightRollover ?? false;
 
   energyCollectionKeys.add(collectionKey);
 
@@ -1005,18 +930,12 @@ export const getEnergyDataCollection = (
   collection._active = 0;
   collection.prefs = options.prefs;
 
-  // True while the collection is tracking the rolling "today" (or hour-0
-  // yesterday) day. Cleared when the user picks a custom range.
+  // True while the collection is tracking the rolling "today" day. Cleared
+  // when the user picks a custom range.
   let followLiveDay = false;
 
   const applyLiveDayPeriod = (now: Date): boolean => {
-    const live = getEnergyLiveDayPeriod(
-      midnightRollover,
-      now,
-      hass.locale,
-      hass.config,
-      collection.start
-    );
+    const live = getEnergyLiveDayPeriod(now, hass.locale, hass.config);
     const changed =
       collection.start.getTime() !== live.start.getTime() ||
       collection.end?.getTime() !== live.end.getTime();
@@ -1045,11 +964,9 @@ export const getEnergyDataCollection = (
       Math.max(
         0,
         getNextEnergyPeriodStart(
-          midnightRollover,
           scheduledAt,
           hass.locale,
-          hass.config,
-          collection.start
+          hass.config
         ).getTime() - scheduledAt.getTime()
       )
     );
@@ -1093,26 +1010,12 @@ export const getEnergyDataCollection = (
     };
   };
 
-  // Set start to start of today if we have data for today, otherwise yesterday.
-  // The real-time "Now" view always tracks today; it shows live data even
-  // before today's first statistic exists, so it never falls back to yesterday.
-  const now = new Date();
   const preferredPeriod =
     (localStorage.getItem(
       getEnergyDefaultPeriodStorageKey(hass, options.key)
     ) as DateRange) || "today";
-  const period =
-    preferredPeriod === "today" &&
-    shouldFallbackEnergyPeriodToYesterday(
-      midnightRollover,
-      now,
-      hass.locale,
-      hass.config
-    )
-      ? "yesterday"
-      : preferredPeriod;
 
-  const [start, end] = calcDateRange(hass.locale, hass.config, period);
+  const [start, end] = calcDateRange(hass.locale, hass.config, preferredPeriod);
   collection.start = calcDate(start, startOfDay, hass.locale, hass.config);
   collection.end = calcDate(end, endOfDay, hass.locale, hass.config);
   followLiveDay = preferredPeriod === "today";
@@ -1883,20 +1786,32 @@ export const formatPowerShort = (
 export function getSuggestedPeriod(
   start: Date,
   end?: Date,
-  fine = false
+  fine = false,
+  now = new Date()
 ): "5minute" | "hour" | "day" | "month" {
-  const dayDifference = differenceInDays(end || new Date(), start);
+  const dayDifference = differenceInDays(end || now, start);
 
   if (fine) {
     return dayDifference > 64 ? "day" : dayDifference > 8 ? "hour" : "5minute";
   }
-  return isFirstDayOfMonth(start) &&
+  const coarse =
+    isFirstDayOfMonth(start) &&
     (!end || isLastDayOfMonth(end)) &&
     dayDifference > 35
-    ? "month"
-    : dayDifference > 2
-      ? "day"
-      : "hour";
+      ? "month"
+      : dayDifference > 2
+        ? "day"
+        : "hour";
+
+  // Hourly long-term stats for the current hour do not exist until it ends.
+  // Use 5-minute short-term stats while the visible range is still < 1 hour.
+  if (coarse === "hour") {
+    const rangeEnd = Math.min((end ?? now).getTime(), now.getTime());
+    if (rangeEnd - start.getTime() < 60 * 60 * 1000) {
+      return "5minute";
+    }
+  }
+  return coarse;
 }
 
 export const downloadEnergyData = (

--- a/src/panels/energy/strategies/energy-dashboard-strategy.ts
+++ b/src/panels/energy/strategies/energy-dashboard-strategy.ts
@@ -158,9 +158,6 @@ async function fetchEnergyPrefs(
 ): Promise<EnergyPreferences> {
   const collection = getEnergyDataCollection(hass, {
     key: defaultCollection || DEFAULT_ENERGY_COLLECTION_KEY,
-    // When landing directly on the "Now" view this warms its real-time
-    // collection, so it must be created with midnight rollover too.
-    midnightRollover: defaultCollection === DEFAULT_POWER_COLLECTION_KEY,
   });
 
   return await new Promise<EnergyPreferences>((resolve) => {

--- a/src/panels/energy/strategies/power-view-strategy.ts
+++ b/src/panels/energy/strategies/power-view-strategy.ts
@@ -34,8 +34,6 @@ export class PowerViewStrategy extends ReactiveElement {
 
     const energyCollection = getEnergyDataCollection(hass, {
       key: collectionKey,
-      // The "Now" view is real-time; roll its day period over at midnight.
-      midnightRollover: true,
     });
     if (!energyCollection.prefs) {
       await energyCollection.refresh();

--- a/test/data/energy-dst.test.ts
+++ b/test/data/energy-dst.test.ts
@@ -1,10 +1,4 @@
-import {
-  addDays,
-  addHours,
-  addMilliseconds,
-  endOfDay,
-  startOfDay,
-} from "date-fns";
+import { addDays, addMilliseconds, endOfDay, startOfDay } from "date-fns";
 import type { HassConfig } from "home-assistant-js-websocket";
 import { afterAll, assert, beforeAll, describe, it } from "vitest";
 
@@ -18,7 +12,6 @@ import {
   TimeZone,
 } from "../../src/data/translation";
 import {
-  getEnergyFirstStatisticAt,
   getEnergyLiveDayPeriod,
   getNextEnergyPeriodStart,
 } from "../../src/data/energy";
@@ -55,62 +48,52 @@ describe("energy period DST (Europe/Berlin local TZ)", () => {
     );
   });
 
-  it("schedules tomorrow 01:00 in the server zone, not via browser-local addDays", () => {
+  it("schedules tomorrow midnight in the server zone, not via browser-local addDays", () => {
     // 23:30 JST on 24 Oct 2026. Europe/Berlin falls back on 25 Oct; local
-    // addDays(now, 1) then startOfDay in Tokyo skips to 26 Oct 01:00 JST.
+    // addDays(now, 1) then startOfDay in Tokyo skips to 26 Oct midnight JST.
     const now = new Date("2026-10-24T14:30:00.000Z");
 
     // Compare to the tz-internal formula rather than a hardcoded instant:
     // the formula is the production invariant, and a pinned ISO string would
     // not explain why UTC CI cannot catch a raw addDays(now, 1) regression.
-    const tzInternal = addHours(
-      addMilliseconds(calcDate(now, endOfDay, locale, tokyoConfig), 1),
+    const tzInternal = addMilliseconds(
+      calcDate(now, endOfDay, locale, tokyoConfig),
       1
     );
-    const browserLocalAddDays = getEnergyFirstStatisticAt(
+    const browserLocalAddDays = calcDate(
       addDays(now, 1),
+      startOfDay,
       locale,
       tokyoConfig
     );
-    const actual = getNextEnergyPeriodStart(false, now, locale, tokyoConfig);
+    const actual = getNextEnergyPeriodStart(now, locale, tokyoConfig);
 
     assert.equal(actual.getTime(), tzInternal.getTime());
     assert.notEqual(actual.getTime(), browserLocalAddDays.getTime());
     assert.equal(
       actual.getTime(),
-      new Date("2026-10-24T16:00:00.000Z").getTime()
+      new Date("2026-10-24T15:00:00.000Z").getTime()
     );
     assert.equal(
       browserLocalAddDays.getTime(),
-      new Date("2026-10-25T16:00:00.000Z").getTime()
+      new Date("2026-10-25T15:00:00.000Z").getTime()
     );
   });
 
-  it("resolves yesterday in the server zone, not via browser-local addDays", () => {
-    // 00:30 JST on 26 Oct 2026. Browser-local addDays can land two days back.
+  it("resolves today in the server zone, not via browser-local addDays", () => {
+    // 00:30 JST on 26 Oct 2026. Browser-local yesterday can land two days back.
     const now = new Date("2026-10-25T15:30:00.000Z");
 
-    const tzInternal = calcDate(
-      calcDate(now, addDays, locale, tokyoConfig, -1),
-      startOfDay,
-      locale,
-      tokyoConfig
-    );
-    const browserLocalAddDays = calcDate(
+    const tzInternal = calcDate(now, startOfDay, locale, tokyoConfig);
+    const browserLocalYesterday = calcDate(
       addDays(now, -1),
       startOfDay,
       locale,
       tokyoConfig
     );
-    const live = getEnergyLiveDayPeriod(
-      false,
-      now,
-      locale,
-      tokyoConfig,
-      new Date(0)
-    );
+    const live = getEnergyLiveDayPeriod(now, locale, tokyoConfig);
 
     assert.equal(live.start.getTime(), tzInternal.getTime());
-    assert.notEqual(live.start.getTime(), browserLocalAddDays.getTime());
+    assert.notEqual(live.start.getTime(), browserLocalYesterday.getTime());
   });
 });

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -1037,6 +1037,20 @@ describe("getEnergyDataCollection live day", () => {
     assert.equal(refresh.mock.calls.length, 1);
     assert.equal(energyInfoFetches(callWS).length, 1);
 
+    // Midnight refresh is before the first short-term bucket. Schedule a
+    // follow-up after recorder's :05:10 compile, then resume :20 cadence.
+    refresh.mockClear();
+    callWS.mockClear();
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 15 * 1000);
+    assert.equal(refresh.mock.calls.length, 1);
+    assert.equal(energyInfoFetches(callWS).length, 1);
+
+    refresh.mockClear();
+    callWS.mockClear();
+    await vi.advanceTimersByTimeAsync(14 * 60 * 1000 + 45 * 1000);
+    assert.equal(refresh.mock.calls.length, 1);
+    assert.equal(energyInfoFetches(callWS).length, 1);
+
     unsub();
   });
 

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -957,6 +957,15 @@ describe("getSuggestedPeriod", () => {
     assert.equal(getSuggestedPeriod(start, end, false, now), "hour");
   });
 
+  it("uses hour for a year-ago short range during hour 0", () => {
+    // YoY compare of "today" during hour 0 is also < 1 hour long, but those
+    // hours completed a year ago so hourly long-term stats already exist.
+    const now = new Date("2026-06-20T00:30:00-04:00");
+    const start = new Date("2025-06-20T00:00:00-04:00");
+    const end = new Date("2025-06-20T00:30:00-04:00");
+    assert.equal(getSuggestedPeriod(start, end, false, now), "hour");
+  });
+
   it("keeps day and month for longer ranges during hour 0", () => {
     const now = new Date("2026-06-20T00:30:00-04:00");
     const weekStart = calcDate(

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -22,7 +22,6 @@ import {
   getEnergyDefaultPeriodStorageKey,
   getEnergyLiveDayPeriod,
   getEnergyDataCollection,
-  getSuggestedPeriod,
   EMPTY_PREFERENCES,
 } from "../../src/data/energy";
 import type { DeviceRegistryEntry } from "../../src/data/device/device_registry";
@@ -935,60 +934,6 @@ describe("getNextEnergyPeriodStart", () => {
       next.getTime(),
       new Date("2026-06-21T00:00:00-04:00").getTime()
     );
-  });
-});
-
-describe("getSuggestedPeriod", () => {
-  it("uses 5minute for today during hour 0", () => {
-    const now = new Date("2026-06-20T00:30:00-04:00");
-    const { start, end } = energyPeriodDay(now);
-    assert.equal(getSuggestedPeriod(start, end, false, now), "5minute");
-  });
-
-  it("uses hour for today after 01:00", () => {
-    const now = new Date("2026-06-20T01:30:00-04:00");
-    const { start, end } = energyPeriodDay(now);
-    assert.equal(getSuggestedPeriod(start, end, false, now), "hour");
-  });
-
-  it("uses hour for a completed yesterday day viewed during hour 0", () => {
-    const now = new Date("2026-06-20T00:30:00-04:00");
-    const { start, end } = energyPeriodDay(now, -1);
-    assert.equal(getSuggestedPeriod(start, end, false, now), "hour");
-  });
-
-  it("uses hour for a year-ago short range during hour 0", () => {
-    // YoY compare of "today" during hour 0 is also < 1 hour long, but those
-    // hours completed a year ago so hourly long-term stats already exist.
-    const now = new Date("2026-06-20T00:30:00-04:00");
-    const start = new Date("2025-06-20T00:00:00-04:00");
-    const end = new Date("2025-06-20T00:30:00-04:00");
-    assert.equal(getSuggestedPeriod(start, end, false, now), "hour");
-  });
-
-  it("keeps day and month for longer ranges during hour 0", () => {
-    const now = new Date("2026-06-20T00:30:00-04:00");
-    const weekStart = calcDate(
-      now,
-      addDays,
-      energyPeriodLocale,
-      energyPeriodConfig,
-      -6
-    );
-    assert.equal(
-      getSuggestedPeriod(
-        calcDate(weekStart, startOfDay, energyPeriodLocale, energyPeriodConfig),
-        energyPeriodDay(now).end,
-        false,
-        now
-      ),
-      "day"
-    );
-
-    // Noon offsets so first/last-of-month checks are stable across UTC CI.
-    const monthStart = new Date("2026-04-01T12:00:00-04:00");
-    const monthEnd = new Date("2026-05-31T12:00:00-04:00");
-    assert.equal(getSuggestedPeriod(monthStart, monthEnd, false, now), "month");
   });
 });
 

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -20,10 +20,9 @@ import {
   formatPowerShort,
   getNextEnergyPeriodStart,
   getEnergyDefaultPeriodStorageKey,
-  getEnergyFirstStatisticAt,
   getEnergyLiveDayPeriod,
-  shouldFallbackEnergyPeriodToYesterday,
   getEnergyDataCollection,
+  getSuggestedPeriod,
   EMPTY_PREFERENCES,
 } from "../../src/data/energy";
 import type { DeviceRegistryEntry } from "../../src/data/device/device_registry";
@@ -905,204 +904,106 @@ describe("getNextEnergyPeriodStart", () => {
       energyPeriodConfig
     ).getTime() === date.getTime();
 
-  it("rolls the real-time view over at midnight, statistics an hour later", () => {
+  it("schedules the next midnight in the configured zone", () => {
     const now = new Date("2026-06-19T15:30:00-04:00");
 
-    const realTime = getNextEnergyPeriodStart(
-      true,
-      now,
-      energyPeriodLocale,
-      energyPeriodConfig
-    );
-    const statistics = getNextEnergyPeriodStart(
-      false,
+    const next = getNextEnergyPeriodStart(
       now,
       energyPeriodLocale,
       energyPeriodConfig
     );
 
-    // Real-time rolls over exactly at the next midnight.
-    assert.isTrue(isMidnight(realTime));
+    assert.isTrue(isMidnight(next));
     assert.equal(
-      realTime.getTime(),
+      next.getTime(),
       new Date("2026-06-20T00:00:00-04:00").getTime()
     );
-
-    // Statistics roll over an hour after midnight, on the same day boundary.
-    assert.equal(statistics.getTime() - realTime.getTime(), 60 * 60 * 1000);
-    assert.equal(
-      calcDate(
-        statistics,
-        startOfDay,
-        energyPeriodLocale,
-        energyPeriodConfig
-      ).getTime(),
-      realTime.getTime()
-    );
   });
 
-  it("advances the real-time view to the next midnight when called after midnight", () => {
+  it("advances to the following midnight when called after midnight", () => {
     const now = new Date("2026-06-20T00:30:00-04:00");
 
-    const realTime = getNextEnergyPeriodStart(
-      true,
+    const next = getNextEnergyPeriodStart(
       now,
       energyPeriodLocale,
       energyPeriodConfig
     );
 
-    assert.isTrue(isMidnight(realTime));
+    assert.isTrue(isMidnight(next));
     // Next midnight is June 21, not the already-passed June 20 midnight.
     assert.equal(
-      realTime.getTime(),
+      next.getTime(),
       new Date("2026-06-21T00:00:00-04:00").getTime()
-    );
-  });
-
-  it("wakes a non-today live day at today 01:00 during hour 0", () => {
-    const now = new Date("2026-06-20T00:30:00-04:00");
-    const todayOne = new Date("2026-06-20T01:00:00-04:00").getTime();
-
-    for (const offset of [-1, -2]) {
-      assert.equal(
-        getNextEnergyPeriodStart(
-          false,
-          now,
-          energyPeriodLocale,
-          energyPeriodConfig,
-          energyPeriodDay(now, offset).start
-        ).getTime(),
-        todayOne
-      );
-    }
-  });
-
-  it("keeps tomorrow 01:00 when statistics is already on today during hour 0", () => {
-    const now = new Date("2026-06-20T00:30:00-04:00");
-
-    assert.equal(
-      getNextEnergyPeriodStart(
-        false,
-        now,
-        energyPeriodLocale,
-        energyPeriodConfig,
-        energyPeriodDay(now).start
-      ).getTime(),
-      new Date("2026-06-21T01:00:00-04:00").getTime()
     );
   });
 });
 
-describe("shouldFallbackEnergyPeriodToYesterday", () => {
-  it("is true for the statistics view before 01:00", () => {
+describe("getSuggestedPeriod", () => {
+  it("uses 5minute for today during hour 0", () => {
     const now = new Date("2026-06-20T00:30:00-04:00");
-    assert.isTrue(
-      shouldFallbackEnergyPeriodToYesterday(
-        false,
-        now,
-        energyPeriodLocale,
-        energyPeriodConfig
-      )
-    );
-    assert.equal(
-      getEnergyFirstStatisticAt(
-        now,
-        energyPeriodLocale,
-        energyPeriodConfig
-      ).getTime(),
-      new Date("2026-06-20T01:00:00-04:00").getTime()
-    );
+    const { start, end } = energyPeriodDay(now);
+    assert.equal(getSuggestedPeriod(start, end, false, now), "5minute");
   });
 
-  it("is false at 01:00 and for the real-time view", () => {
-    const atOne = new Date("2026-06-20T01:00:00-04:00");
-    const beforeOne = new Date("2026-06-20T00:30:00-04:00");
-    assert.isFalse(
-      shouldFallbackEnergyPeriodToYesterday(
+  it("uses hour for today after 01:00", () => {
+    const now = new Date("2026-06-20T01:30:00-04:00");
+    const { start, end } = energyPeriodDay(now);
+    assert.equal(getSuggestedPeriod(start, end, false, now), "hour");
+  });
+
+  it("uses hour for a completed yesterday day viewed during hour 0", () => {
+    const now = new Date("2026-06-20T00:30:00-04:00");
+    const { start, end } = energyPeriodDay(now, -1);
+    assert.equal(getSuggestedPeriod(start, end, false, now), "hour");
+  });
+
+  it("keeps day and month for longer ranges during hour 0", () => {
+    const now = new Date("2026-06-20T00:30:00-04:00");
+    const weekStart = calcDate(
+      now,
+      addDays,
+      energyPeriodLocale,
+      energyPeriodConfig,
+      -6
+    );
+    assert.equal(
+      getSuggestedPeriod(
+        calcDate(weekStart, startOfDay, energyPeriodLocale, energyPeriodConfig),
+        energyPeriodDay(now).end,
         false,
-        atOne,
-        energyPeriodLocale,
-        energyPeriodConfig
-      )
+        now
+      ),
+      "day"
     );
-    assert.isFalse(
-      shouldFallbackEnergyPeriodToYesterday(
-        true,
-        beforeOne,
-        energyPeriodLocale,
-        energyPeriodConfig
-      )
-    );
+
+    // Noon offsets so first/last-of-month checks are stable across UTC CI.
+    const monthStart = new Date("2026-04-01T12:00:00-04:00");
+    const monthEnd = new Date("2026-05-31T12:00:00-04:00");
+    assert.equal(getSuggestedPeriod(monthStart, monthEnd, false, now), "month");
   });
 });
 
 describe("getEnergyLiveDayPeriod", () => {
-  it("keeps yesterday during hour 0 when that is the current period", () => {
+  it("returns today during hour 0", () => {
     const now = new Date("2026-06-20T00:30:00-04:00");
-    const { start, end } = energyPeriodDay(now, -1);
     const live = getEnergyLiveDayPeriod(
-      false,
       now,
       energyPeriodLocale,
-      energyPeriodConfig,
-      start
-    );
-    assert.equal(live.start.getTime(), start.getTime());
-    assert.equal(live.end.getTime(), end.getTime());
-  });
-
-  it("keeps today during hour 0 when the user already picked today", () => {
-    const now = new Date("2026-06-20T00:30:00-04:00");
-    const { start, end } = energyPeriodDay(now);
-    const live = getEnergyLiveDayPeriod(
-      false,
-      now,
-      energyPeriodLocale,
-      energyPeriodConfig,
-      start
-    );
-    assert.equal(live.start.getTime(), start.getTime());
-    assert.equal(live.end.getTime(), end.getTime());
-  });
-
-  it("advances a stale yesterday to today after 01:00", () => {
-    const now = new Date("2026-06-20T10:00:00-04:00");
-    const live = getEnergyLiveDayPeriod(
-      false,
-      now,
-      energyPeriodLocale,
-      energyPeriodConfig,
-      energyPeriodDay(now, -1).start
+      energyPeriodConfig
     );
     const expected = energyPeriodDay(now);
     assert.equal(live.start.getTime(), expected.start.getTime());
     assert.equal(live.end.getTime(), expected.end.getTime());
   });
 
-  it("advances a two-day-old live day to today", () => {
+  it("returns today after 01:00", () => {
     const now = new Date("2026-06-20T10:00:00-04:00");
     const live = getEnergyLiveDayPeriod(
-      false,
       now,
       energyPeriodLocale,
-      energyPeriodConfig,
-      energyPeriodDay(now, -2).start
+      energyPeriodConfig
     );
     const expected = energyPeriodDay(now);
-    assert.equal(live.start.getTime(), expected.start.getTime());
-    assert.equal(live.end.getTime(), expected.end.getTime());
-  });
-
-  it("falls back to yesterday for a stale live day during hour 0", () => {
-    const now = new Date("2026-06-20T00:30:00-04:00");
-    const live = getEnergyLiveDayPeriod(
-      false,
-      now,
-      energyPeriodLocale,
-      energyPeriodConfig,
-      energyPeriodDay(now, -2).start
-    );
-    const expected = energyPeriodDay(now, -1);
     assert.equal(live.start.getTime(), expected.start.getTime());
     assert.equal(live.end.getTime(), expected.end.getTime());
   });
@@ -1114,11 +1015,7 @@ describe("getEnergyDataCollection live day", () => {
     vi.useRealTimers();
   });
 
-  const createCollection = (
-    key: string,
-    preset?: string,
-    midnightRollover = false
-  ) => {
+  const createCollection = (key: string, preset?: string) => {
     const hass = createMockHass();
     hass.locale = energyPeriodLocale;
     hass.config = { ...hass.config, time_zone: "America/New_York" };
@@ -1143,7 +1040,6 @@ describe("getEnergyDataCollection live day", () => {
       collection: getEnergyDataCollection(hass, {
         key,
         prefs: EMPTY_PREFERENCES,
-        midnightRollover,
       }),
       callWS,
     };
@@ -1152,10 +1048,18 @@ describe("getEnergyDataCollection live day", () => {
   const energyInfoFetches = (callWS: ReturnType<typeof vi.fn>) =>
     callWS.mock.calls.filter((call) => call[0].type === "energy/info");
 
-  it("advances hour-0 yesterday to today at 01:00 and fetches the new day", async () => {
+  it("starts today during hour 0 and rolls over at midnight", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-20T00:30:00-04:00"));
 
+    assert.equal(
+      createCollection("energy_hour0").collection.start.getTime(),
+      energyPeriodDay(new Date()).start.getTime()
+    );
+
+    // Create near end of day so a 30-minute advance hits midnight without
+    // also firing many hourly :20 refreshes.
+    vi.setSystemTime(new Date("2026-06-20T23:30:00-04:00"));
     const { collection, callWS } = createCollection("energy_timer");
     const refresh = vi.spyOn(collection, "refresh");
     const unsub = collection.subscribe(() => undefined);
@@ -1165,7 +1069,7 @@ describe("getEnergyDataCollection live day", () => {
 
     assert.equal(
       collection.start.getTime(),
-      energyPeriodDay(new Date(), -1).start.getTime()
+      energyPeriodDay(new Date()).start.getTime()
     );
 
     await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
@@ -1175,7 +1079,7 @@ describe("getEnergyDataCollection live day", () => {
       energyPeriodDay(new Date()).start.getTime()
     );
     // Cards render EnergyData from the websocket store, not collection.start.
-    // The 01:00 callback must refresh() so getEnergyData runs for today.
+    // The midnight callback must refresh() so getEnergyData runs for the new day.
     assert.equal(refresh.mock.calls.length, 1);
     assert.equal(energyInfoFetches(callWS).length, 1);
 
@@ -1274,26 +1178,6 @@ describe("getEnergyDataCollection live day", () => {
     vi.setSystemTime(new Date("2026-06-18T15:00:00-04:00"));
 
     const { collection } = createCollection("energy_week_stored", "this_week");
-    const weekStart = collection.start.getTime();
-    const unsub = collection.subscribe(() => undefined);
-
-    vi.setSystemTime(new Date("2026-06-20T10:00:00-04:00"));
-    vi.advanceTimersByTime(48 * 60 * 60 * 1000);
-
-    assert.equal(collection.start.getTime(), weekStart);
-
-    unsub();
-  });
-
-  it("does not roll a remembered week preset over to today with midnightRollover", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-18T15:00:00-04:00"));
-
-    const { collection } = createCollection(
-      "energy_week_stored_now",
-      "this_week",
-      true
-    );
     const weekStart = collection.start.getTime();
     const unsub = collection.subscribe(() => undefined);
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Energy data collections always roll to today at midnight. Previously the Overview stayed on yesterday until 01:00 so hourly long-term statistics would not leave an empty graph; that meant the first hour of the day still showed yesterday's totals.

This PR removes the `midnightRollover` option and the 01:00 yesterday fallback so every energy collection tracks today after midnight.

Incomplete current-hour data for `period: hour` / `day` comes from Core: [home-assistant/core#181829](https://github.com/home-assistant/core/pull/181829) fills the unfinished current hour from short-term (5-minute) stats inside `statistics_during_period`. The frontend therefore keeps requesting `period: hour` after midnight (no hour-0 switch to `5minute` for the whole day). Earlier commits on this branch briefly added that frontend `5minute` path; it has been removed in favor of the Core stitch.

Energy panel still uses two collection keys (`energy_dashboard` vs `energy_dashboard_now`) so Overview dates stay independent of Now. Lovelace power cards remain on the shared dashboard collection so `energy-date-selection` keeps working without a `collection_key`.

This replaces the approach in #54071 (do not depend on merging that PR).

**Behavior change:** Energy Overview between 00:00 and 01:00 now shows today. Charts use hourly periods; after Core #181829, the current incomplete hour appears as one partial hour bar (not many 5-minute bars) once short-term buckets exist. Before the first short-term bucket, totals/charts can still be empty/zeros briefly.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Earlier screenshots on this PR were captured when the frontend still switched to `period: 5minute` in hour 0 (thin full-day axis bars). With Core #181829, hour-0 should show a single partial hour bar instead — screenshots below may need a refresh after that Core change is available in the test stack.

### ~00:01 — today, no completed short-term bucket yet
Overview stays on the new day with zeros / empty charts until the first short-term interval finishes (and Core can stitch a partial hour).

![Overview at 00:01](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pr-overview-0001-b60714f4.png)

![Electricity graph at 00:01](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pr-electricity-0001-c8070463.png)

### ~00:06 — first short-term data available (previous frontend path)
After the first completed 5-minute interval, Overview totals/distribution populate. Under the old frontend-only path these were 5-minute bars; with Core stitch expect one partial hour bucket instead.

![Overview at 00:06](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pr-overview-0006-ad8f3d03.png)

![Electricity graph at 00:06](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pr-electricity-0006-60922c87.png)

![Distribution and totals at 00:06](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pr-top-0006-13b08cb1.png)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: replaces approach of #54071
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/181829

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr