### PR TITLE
Move history-graph card timeline names under the bars

### DIFF
--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -80,7 +80,7 @@ export class StateHistoryChartTimeline extends LitElement {
         .options=${this._chartOptions}
         .height=${`${
           this.data.length *
-            (this.insideLabels && this.showNames
+            (this.insideLabels && (this.chunked || this.showNames)
               ? ROW_HEIGHT_INSIDE_LABELS
               : ROW_HEIGHT) +
           GRID_BOTTOM

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -80,7 +80,9 @@ export class StateHistoryChartTimeline extends LitElement {
         .options=${this._chartOptions}
         .height=${`${
           this.data.length *
-            (this.insideLabels ? ROW_HEIGHT_INSIDE_LABELS : ROW_HEIGHT) +
+            (this.insideLabels && this.showNames
+              ? ROW_HEIGHT_INSIDE_LABELS
+              : ROW_HEIGHT) +
           GRID_BOTTOM
         }px`}
         .data=${this._chartData as HaECSeries}

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -44,7 +44,8 @@ export class StateHistoryChartTimeline extends LitElement {
   @property({ attribute: "show-names", type: Boolean }) public showNames = true;
 
   // Render each row's name inside the plot (under its bar) instead of in a
-  // left-hand category-label column. Opt-in; used by the history panel.
+  // left-hand category-label column. Opt-in; used by the history panel and
+  // history-graph card.
   @property({ attribute: "inside-labels", type: Boolean })
   public insideLabels = false;
 

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -80,7 +80,7 @@ export class StateHistoryCharts extends LitElement {
   @property({ attribute: "show-names", type: Boolean }) public showNames = true;
 
   // Render timeline row names inside the plot (under each bar) instead of in a
-  // left-hand column. Opt-in; used by the history panel.
+  // left-hand column. Opt-in; used by the history panel and history-graph card.
   @property({ attribute: "inside-labels", type: Boolean })
   public insideLabels = false;
 

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -105,10 +105,17 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
     }
     this._names = {};
     this._entities.forEach((entity) => {
+      // Leave unset so timeline/line charts use computeHistory's Device ▸ Entity
+      // labels. Only YAML `name` overrides that default.
+      if (entity.name === undefined) {
+        return;
+      }
       const stateObj = this.hass!.states[entity.entity];
       this._names[entity.entity] = stateObj
         ? this.hass!.formatEntityName(stateObj, entity.name)
-        : entity.entity;
+        : typeof entity.name === "string"
+          ? entity.name
+          : entity.entity;
     });
   }
 
@@ -365,6 +372,7 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
                         ? this._config.show_names
                         : true
                     }
+                    inside-labels
                     .logarithmicScale=${this._config.logarithmic_scale || false}
                     .minYAxis=${this._config.min_y_axis}
                     .maxYAxis=${this._config.max_y_axis}

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -322,6 +322,7 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
     const columns = this._config.grid_options?.columns ?? 12;
     const narrow = typeof columns === "number" && columns <= 12;
     const hasFixedHeight = typeof this._config.grid_options?.rows === "number";
+    const showNames = this._config.show_names !== false;
 
     return html`
       <ha-card>
@@ -367,12 +368,8 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
                     .names=${this._names}
                     up-to-now
                     .hoursToShow=${this._hoursToShow}
-                    .showNames=${
-                      this._config.show_names !== undefined
-                        ? this._config.show_names
-                        : true
-                    }
-                    inside-labels
+                    .showNames=${showNames}
+                    ?inside-labels=${showNames}
                     .logarithmicScale=${this._config.logarithmic_scale || false}
                     .minYAxis=${this._config.min_y_axis}
                     .maxYAxis=${this._config.max_y_axis}

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -2,6 +2,7 @@ import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import type { HassEntity } from "home-assistant-js-websocket";
 import { theme2hex } from "../../../common/color/convert-color";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { createSearchParam } from "../../../common/url/search-params";
@@ -110,17 +111,17 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
       if (entity.name === undefined) {
         return;
       }
-      const stateObj = this.hass!.states[entity.entity];
-      if (stateObj) {
-        this._names[entity.entity] = this.hass!.formatEntityName(
-          stateObj,
-          entity.name
-        );
-        return;
-      }
-      if (typeof entity.name === "string") {
-        this._names[entity.entity] = entity.name;
-      }
+      const stateObj =
+        this.hass!.states[entity.entity] ??
+        ({
+          entity_id: entity.entity,
+          state: "unavailable",
+          attributes: {},
+        } as HassEntity);
+      this._names[entity.entity] = this.hass!.formatEntityName(
+        stateObj,
+        entity.name
+      );
     });
   }
 

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -111,11 +111,16 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
         return;
       }
       const stateObj = this.hass!.states[entity.entity];
-      this._names[entity.entity] = stateObj
-        ? this.hass!.formatEntityName(stateObj, entity.name)
-        : typeof entity.name === "string"
-          ? entity.name
-          : entity.entity;
+      if (stateObj) {
+        this._names[entity.entity] = this.hass!.formatEntityName(
+          stateObj,
+          entity.name
+        );
+        return;
+      }
+      if (typeof entity.name === "string") {
+        this._names[entity.entity] = entity.name;
+      }
     });
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Follow-up to #54086. The History panel now draws timeline names under the bars so the plot can use the full width. The Lovelace history-graph card used the same left-column layout, so it gets the same treatment.

This change:

- Enables `inside-labels` on the history-graph card so timeline names sit under each bar, matching the History panel and the line-chart legends already on this card.
- Leaves custom YAML `name` values in place. When an entity has no override, both timeline rows and line-chart legends use the same **Device ▸ Entity** labels as the History panel (`computeHistory`) instead of overwriting them with the friendly name.
- Does not change more-info history, which still hides names.
- Does not change the line-chart layout. Numeric history-graph cards still draw the plot with the legend underneath.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

History-graph card with timeline names under the bars:

![History-graph card with names under timeline bars](https://cursor.com/artifacts/c/art-16bca3de-2af0-437b-bf2a-bbc95feb548d)

Dashboard context:

![Sections dashboard showing the history-graph card](https://cursor.com/artifacts/c/art-812b89f8-6786-4ece-93bb-a9d47cff0559)

Narrow viewport:

![History-graph card on a phone-width viewport](https://cursor.com/artifacts/c/art-e45f3062-71ef-4dfc-8bc2-9cec66681929)

Clicking a timeline name still opens more-info:

![More-info dialog opened from a history-graph timeline name](https://cursor.com/artifacts/c/art-128bce24-3906-49c1-ac75-fb811fa8596e)

<a href="https://cursor.com/agents/bc-dc2a8557-e8a3-4351-bed2-d5dad337f5e2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_graph_card_click_label_more_info.mp4"><img src="https://cursor.com/artifacts/c/art-db03fe9f-02b7-4320-8de9-0366e2af72ed" alt="history_graph_card_click_label_more_info.mp4" /></a>

`show_names: false` still hides the labels:

![History-graph card with show_names false](https://cursor.com/artifacts/c/art-8ef93365-a9ef-4db6-9e08-1a470962a96c)

Line-only history-graph cards still use legends under the plot:

![Teachingbirds line history-graph cards still using legends under the plot](https://cursor.com/artifacts/c/art-a70e62fb-8a61-4ce6-9ccd-520cd8d5c0b1)

Please add a screenshot from a real instance if you want additional review evidence. The demo has no device registry, so Device ▸ Entity labels show more clearly there.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #54034
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc2a8557-e8a3-4351-bed2-d5dad337f5e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc2a8557-e8a3-4351-bed2-d5dad337f5e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

