### PR TITLE
Migrate legacy sun and calendar offsets in the trigger editor

### DIFF
--- a/src/data/trigger/migrate_platform_trigger.ts
+++ b/src/data/trigger/migrate_platform_trigger.ts
@@ -1,0 +1,106 @@
+import { durationDataToSeconds } from "../../common/datetime/duration_to_seconds";
+import { durationValueToData } from "../../common/datetime/duration_value_to_data";
+import type { HaDurationData } from "../../components/ha-duration-input";
+import type { PlatformTrigger } from "../automation";
+import { TRIGGER_ROW_CONFIG_KEYS } from "../automation";
+import type { OffsetSelectorValue } from "../selector";
+import type { TriggerDescription } from "../trigger";
+
+const TRIGGER_KEYS: (keyof PlatformTrigger)[] = [
+  ...TRIGGER_ROW_CONFIG_KEYS,
+  "trigger",
+  "target",
+  "options",
+];
+
+const isOffsetSelectorValue = (value: unknown): value is OffsetSelectorValue =>
+  typeof value === "object" && value !== null && "type" in value;
+
+const absDuration = (duration: HaDurationData): HaDurationData =>
+  Object.fromEntries(
+    Object.entries(duration).map(([field, amount]) => [
+      field,
+      Math.abs(amount ?? 0),
+    ])
+  );
+
+const migrateLegacyOffsetOptions = (
+  options: Record<string, unknown>,
+  fields: TriggerDescription["fields"]
+): Record<string, unknown> => {
+  let migrated: Record<string, unknown> | undefined;
+
+  for (const [key, field] of Object.entries(fields)) {
+    if (!field.selector || !("offset" in field.selector)) {
+      continue;
+    }
+    const typeKey = `${key}_type`;
+    const value = options[key] as OffsetSelectorValue["duration"] | undefined;
+    const hasLegacyType = typeKey in options;
+    if (
+      !hasLegacyType &&
+      (value === undefined || isOffsetSelectorValue(value))
+    ) {
+      continue;
+    }
+    migrated ??= { ...options };
+    delete migrated[typeKey];
+    if (isOffsetSelectorValue(value)) {
+      continue;
+    }
+
+    const duration = durationValueToData(value ?? 0);
+    if (!duration || Object.values(duration).some((amount) => isNaN(amount))) {
+      continue;
+    }
+    let seconds = durationDataToSeconds(duration);
+    // The released trigger schema defaulted offset_type to before
+    if (options[typeKey] !== "after") {
+      seconds = -seconds;
+    }
+    migrated[key] =
+      seconds === 0
+        ? { type: "none" }
+        : {
+            type: seconds < 0 ? "before" : "after",
+            duration: absDuration(duration),
+          };
+  }
+
+  return migrated ?? options;
+};
+
+const moveStrayKeysToOptions = (
+  trigger: PlatformTrigger
+): PlatformTrigger | undefined => {
+  let migrated: PlatformTrigger | undefined;
+  for (const key in trigger) {
+    if (TRIGGER_KEYS.includes(key as keyof PlatformTrigger)) {
+      continue;
+    }
+    migrated ??= { ...trigger, options: { ...trigger.options } };
+    migrated.options![key] = trigger[key];
+    delete migrated[key];
+  }
+  return migrated;
+};
+
+export const migratePlatformTrigger = (
+  trigger: PlatformTrigger,
+  description?: TriggerDescription
+): PlatformTrigger | undefined => {
+  let migrated = moveStrayKeysToOptions(trigger);
+
+  const options = (migrated ?? trigger).options;
+  if (options && description?.fields) {
+    const migratedOptions = migrateLegacyOffsetOptions(
+      options,
+      description.fields
+    );
+    if (migratedOptions !== options) {
+      migrated = { ...(migrated ?? trigger), options: migratedOptions };
+    }
+  }
+
+  return migrated;
+};

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
@@ -10,7 +10,6 @@ import { getSelectorFallbackValue } from "../../../../../components/ha-form/get-
 import "../../../../../components/ha-selector/ha-selector";
 import "../../../../../components/ha-settings-row";
 import type { PlatformTrigger } from "../../../../../data/automation";
-import { TRIGGER_ROW_CONFIG_KEYS } from "../../../../../data/automation";
 import type { IntegrationManifest } from "../../../../../data/integration";
 import { fetchIntegrationManifest } from "../../../../../data/integration";
 import type { TargetSelector } from "../../../../../data/selector";
@@ -20,6 +19,7 @@ import {
   getTriggerObjectId,
   type TriggerDescription,
 } from "../../../../../data/trigger";
+import { migratePlatformTrigger } from "../../../../../data/trigger/migrate_platform_trigger";
 import type { HomeAssistant } from "../../../../../types";
 import { documentationUrl } from "../../../../../util/documentation-url";
 
@@ -27,13 +27,6 @@ const showOptionalToggle = (field: TriggerDescription["fields"][string]) =>
   field.selector &&
   !field.required &&
   !("boolean" in field.selector && field.default);
-
-const DEFAULT_KEYS: (keyof PlatformTrigger)[] = [
-  ...TRIGGER_ROW_CONFIG_KEYS,
-  "trigger",
-  "target",
-  "options",
-];
 
 @customElement("ha-automation-trigger-platform")
 export class HaPlatformTrigger extends LitElement {
@@ -61,32 +54,19 @@ export class HaPlatformTrigger extends LitElement {
       this.hass.loadBackendTranslation("triggers");
       this.hass.loadBackendTranslation("selector");
     }
+    if (
+      changedProperties.has("trigger") ||
+      changedProperties.has("description")
+    ) {
+      const migrated = migratePlatformTrigger(this.trigger, this.description);
+      if (migrated) {
+        fireEvent(this, "value-changed", { value: migrated });
+        this.trigger = migrated;
+      }
+    }
+
     if (!changedProperties.has("trigger")) {
       return;
-    }
-
-    let newValue: PlatformTrigger | undefined;
-
-    for (const key in this.trigger) {
-      // Migrate old options to `options`
-      if (DEFAULT_KEYS.includes(key as keyof PlatformTrigger)) {
-        continue;
-      }
-      if (newValue === undefined) {
-        newValue = {
-          ...this.trigger,
-          options: { [key]: this.trigger[key] },
-        };
-      } else {
-        newValue.options![key] = this.trigger[key];
-      }
-      delete newValue[key];
-    }
-    if (newValue !== undefined) {
-      fireEvent(this, "value-changed", {
-        value: newValue,
-      });
-      this.trigger = newValue;
     }
 
     const oldValue = changedProperties.get("trigger") as


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The sun and calendar triggers now use the offset selector instead of the separate `offset` and `offset_type` fields. The trigger editor converts existing automations to the new format when they are loaded, so a stored "30 minutes before" keeps showing as such instead of "No offset". The conversion of legacy top-level keys into `options` moves into the same pure function.

Stored automation, before:

```yaml
triggers:
  - trigger: sun.sunset
    options:
      offset:
        minutes: 30
      offset_type: before
```

After, as written by the editor once loaded and saved:

```yaml
triggers:
  - trigger: sun.sunset
    options:
      offset:
        type: before
        duration:
          minutes: 30
```


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: stacked on #54104
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/181839

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

