### PR TITLE
feature: Enable suspending of automations for a time

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -36,6 +36,7 @@ export interface AutomationEntity extends HassEntityBase {
   attributes: HassEntityAttributeBase & {
     id?: string;
     last_triggered: string;
+    suspended_until?: string;
   };
 }
 

--- a/src/panels/config/automation/automation-suspend-dialog/dialog-automation-suspend.ts
+++ b/src/panels/config/automation/automation-suspend-dialog/dialog-automation-suspend.ts
@@ -1,0 +1,275 @@
+import { addDays, addHours, addWeeks } from "date-fns";
+import type { CSSResultGroup } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { formatDateNumeric } from "../../../../common/datetime/format_date";
+import { formatTime24h } from "../../../../common/datetime/format_time";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/chips/ha-assist-chip";
+import "../../../../components/chips/ha-chip-set";
+import "../../../../components/ha-button";
+import "../../../../components/ha-date-input";
+import "../../../../components/ha-dialog";
+import "../../../../components/ha-dialog-footer";
+import "../../../../components/ha-dialog-header";
+import "../../../../components/ha-time-input";
+import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
+import { haStyle, haStyleDialog } from "../../../../resources/styles";
+import type { HomeAssistant } from "../../../../types";
+import type { AutomationSuspendDialogParams } from "./show-dialog-automation-suspend";
+
+@customElement("ha-dialog-automation-suspend")
+class DialogAutomationSuspend extends LitElement implements HassDialog {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _open = false;
+
+  @state() private _params?: AutomationSuspendDialogParams;
+
+  @state() private _date = "";
+
+  @state() private _time = "";
+
+  @state() private _saving = false;
+
+  public showDialog(params: AutomationSuspendDialogParams): void {
+    this._params = params;
+    this._open = true;
+    this._saving = false;
+
+    let initialDate = new Date();
+    if (params.suspendedUntil) {
+      const parsed = new Date(params.suspendedUntil);
+      if (!isNaN(parsed.getTime())) {
+        initialDate = parsed;
+      }
+    } else {
+      // Default to +1 hour
+      initialDate = addHours(initialDate, 1);
+    }
+
+    this._setDateAndTime(initialDate);
+  }
+
+  public closeDialog(): boolean {
+    this._open = false;
+    return true;
+  }
+
+  private _dialogClosed(): void {
+    this._open = false;
+    this._params = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  private _setDateAndTime(dateObj: Date): void {
+    const year = dateObj.getFullYear();
+    const month = String(dateObj.getMonth() + 1).padStart(2, "0");
+    const day = String(dateObj.getDate()).padStart(2, "0");
+    this._date = `${year}-${month}-${day}`;
+
+    const hours = String(dateObj.getHours()).padStart(2, "0");
+    const minutes = String(dateObj.getMinutes()).padStart(2, "0");
+    const seconds = String(dateObj.getSeconds()).padStart(2, "0");
+    this._time = `${hours}:${minutes}:${seconds}`;
+  }
+
+  private _applyPreset(amount: "1h" | "1d" | "1w"): void {
+    const now = new Date();
+    let target: Date;
+    switch (amount) {
+      case "1h":
+        target = addHours(now, 1);
+        break;
+      case "1d":
+        target = addDays(now, 1);
+        break;
+      case "1w":
+        target = addWeeks(now, 1);
+        break;
+    }
+    this._setDateAndTime(target);
+  }
+
+  private _dateChanged(ev: CustomEvent): void {
+    this._date = ev.detail.value;
+  }
+
+  private _timeChanged(ev: CustomEvent): void {
+    this._time = ev.detail.value;
+  }
+
+  private async _save(): Promise<void> {
+    if (!this._params || !this._date || !this._time) {
+      return;
+    }
+
+    this._saving = true;
+    try {
+      const untilDate = new Date(`${this._date}T${this._time}`);
+      await this.hass.callService("automation", "suspend", {
+        entity_id: this._params.entityId,
+        until: untilDate.toISOString(),
+      });
+      this.closeDialog();
+    } catch (err: any) {
+      this._saving = false;
+    }
+  }
+
+  private async _removeSuspend(): Promise<void> {
+    if (!this._params) {
+      return;
+    }
+
+    this._saving = true;
+    try {
+      await this.hass.callService("automation", "suspend", {
+        entity_id: this._params.entityId,
+      });
+      this.closeDialog();
+    } catch (err: any) {
+      this._saving = false;
+    }
+  }
+
+  protected render() {
+    if (!this._params) {
+      return nothing;
+    }
+
+    const isCurrentlySuspended = Boolean(this._params.suspendedUntil);
+
+    return html`
+      <ha-dialog
+        .open=${this._open}
+        @closed=${this._dialogClosed}
+        .headerTitle=${this.hass.localize(
+          "ui.panel.config.automation.editor.suspend_dialog.title"
+        )}
+      >
+        <div class="content">
+          <p class="description">
+            ${this.hass.localize(
+              "ui.panel.config.automation.editor.suspend_dialog.description",
+              { name: this._params.name || this._params.entityId }
+            )}
+          </p>
+
+          <ha-chip-set>
+            <ha-assist-chip
+              .label="+1 hour"
+              @click=${() => this._applyPreset("1h")}
+            >
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.suspend_dialog.presets.one_hour"
+              )}
+            </ha-assist-chip>
+            <ha-assist-chip
+              .label="+1 day"
+              @click=${() => this._applyPreset("1d")}
+            >
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.suspend_dialog.presets.one_day"
+              )}
+            </ha-assist-chip>
+            <ha-assist-chip
+              .label="+1 week"
+              @click=${() => this._applyPreset("1w")}
+            >
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.suspend_dialog.presets.one_week"
+              )}
+            </ha-assist-chip>
+          </ha-chip-set>
+
+          <div class="date-time-container">
+            <ha-date-input
+              .label=${this.hass.localize(
+                "ui.panel.config.automation.editor.suspend_dialog.end_date"
+              )}
+              .locale=${this.hass.locale}
+              .value=${this._date}
+              @value-changed=${this._dateChanged}
+            ></ha-date-input>
+            <ha-time-input
+              .label=${this.hass.localize(
+                "ui.panel.config.automation.editor.suspend_dialog.end_time"
+              )}
+              .locale=${this.hass.locale}
+              .value=${this._time}
+              @value-changed=${this._timeChanged}
+            ></ha-time-input>
+          </div>
+        </div>
+
+        <ha-dialog-footer slot="footer">
+          ${isCurrentlySuspended
+            ? html`
+                <ha-button
+                  slot="secondaryAction"
+                  variant="danger"
+                  .disabled=${this._saving}
+                  @click=${this._removeSuspend}
+                >
+                  ${this.hass.localize(
+                    "ui.panel.config.automation.editor.suspend_dialog.remove_suspend"
+                  )}
+                </ha-button>
+              `
+            : html`
+                <ha-button
+                  slot="secondaryAction"
+                  appearance="plain"
+                  @click=${this.closeDialog}
+                >
+                  ${this.hass.localize("ui.common.cancel")}
+                </ha-button>
+              `}
+          <ha-button
+            slot="primaryAction"
+            .loading=${this._saving}
+            .disabled=${this._saving || !this._date || !this._time}
+            @click=${this._save}
+          >
+            ${this.hass.localize("ui.common.save")}
+          </ha-button>
+        </ha-dialog-footer>
+      </ha-dialog>
+    `;
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      haStyleDialog,
+      css`
+        .content {
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+        }
+        .description {
+          margin: 0;
+          color: var(--secondary-text-color);
+        }
+        .date-time-container {
+          display: flex;
+          gap: 16px;
+          flex-wrap: wrap;
+        }
+        ha-date-input,
+        ha-time-input {
+          flex: 1;
+          min-width: 150px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-dialog-automation-suspend": DialogAutomationSuspend;
+  }
+}

--- a/src/panels/config/automation/automation-suspend-dialog/show-dialog-automation-suspend.ts
+++ b/src/panels/config/automation/automation-suspend-dialog/show-dialog-automation-suspend.ts
@@ -1,0 +1,21 @@
+import { fireEvent } from "../../../../common/dom/fire_event";
+
+export interface AutomationSuspendDialogParams {
+  entityId: string;
+  name?: string;
+  suspendedUntil?: string;
+}
+
+export const loadAutomationSuspendDialog = () =>
+  import("./dialog-automation-suspend");
+
+export const showAutomationSuspendDialog = (
+  element: HTMLElement,
+  dialogParams: AutomationSuspendDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "ha-dialog-automation-suspend",
+    dialogImport: loadAutomationSuspendDialog,
+    dialogParams,
+  });
+};

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -1,6 +1,7 @@
 import "@home-assistant/webawesome/dist/components/divider/divider";
 import {
   mdiAppleKeyboardCommand,
+  mdiClockOutline,
   mdiCog,
   mdiContentSave,
   mdiDebugStepOver,
@@ -77,6 +78,7 @@ import { showAssignCategoryDialog } from "../category/show-dialog-assign-categor
 import { showAutomationModeDialog } from "./automation-mode-dialog/show-dialog-automation-mode";
 import { showAutomationSaveDialog } from "./automation-save-dialog/show-dialog-automation-save";
 import { showAutomationSaveTimeoutDialog } from "./automation-save-timeout-dialog/show-dialog-automation-save-timeout";
+import { showAutomationSuspendDialog } from "./automation-suspend-dialog/show-dialog-automation-suspend";
 import { ADD_AUTOMATION_ELEMENT_QUERY_PARAM } from "./show-add-automation-element-dialog";
 import "./blueprint-automation-editor";
 import type { EditorDomainHooks } from "./ha-automation-script-editor-mixin";
@@ -440,6 +442,20 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
                   ? mdiPlayCircleOutline
                   : mdiStopCircleOutline
               }
+            ></ha-svg-icon>
+          </ha-dropdown-item>
+
+          <ha-dropdown-item .disabled=${!stateObj} value="suspend">
+            ${
+              stateObj?.attributes.suspended_until
+                ? this.hass.localize(
+                    "ui.panel.config.automation.editor.suspended"
+                  )
+                : this.hass.localize("ui.panel.config.automation.editor.suspend")
+            }
+            <ha-svg-icon
+              slot="icon"
+              .path=${mdiClockOutline}
             ></ha-svg-icon>
           </ha-dropdown-item>
 
@@ -853,6 +869,18 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
     });
   }
 
+  private _suspend(): void {
+    if (!this.hass || !this.currentEntityId) {
+      return;
+    }
+    const stateObj = this.hass.states[this.currentEntityId];
+    showAutomationSuspendDialog(this, {
+      entityId: stateObj.entity_id,
+      name: stateObj.attributes.friendly_name || this.config?.alias,
+      suspendedUntil: stateObj.attributes.suspended_until,
+    });
+  }
+
   private _preprocessYaml() {
     if (!this.config) {
       return {};
@@ -1250,6 +1278,9 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
         break;
       case "disable":
         this._toggle();
+        break;
+      case "suspend":
+        this._suspend();
         break;
       case "delete":
         this._deleteConfirm();

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -2,6 +2,7 @@ import "@home-assistant/webawesome/dist/components/divider/divider";
 import { ResizeController } from "@lit-labs/observers/resize-controller";
 import { consume } from "@lit/context";
 import {
+  mdiClockOutline,
   mdiCloseThick,
   mdiCog,
   mdiContentDuplicate,
@@ -115,6 +116,7 @@ import { turnOnOffEntity } from "../../lovelace/common/entity/turn-on-off-entity
 import { showAreaRegistryDetailDialog } from "../areas/show-dialog-area-registry-detail";
 import { showAssignCategoryDialog } from "../category/show-dialog-assign-category";
 import { showCategoryRegistryDetailDialog } from "../category/show-dialog-category-registry-detail";
+import { showAutomationSuspendDialog } from "./automation-suspend-dialog/show-dialog-automation-suspend";
 import {
   getAreaTableColumn,
   getCategoryTableColumn,
@@ -834,6 +836,19 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
               : this.hass.localize("ui.panel.config.automation.editor.disable")
           }
         </ha-dropdown-item>
+        <ha-dropdown-item value="suspend">
+          <ha-svg-icon
+            .path=${mdiClockOutline}
+            slot="icon"
+          ></ha-svg-icon>
+          ${
+            this._overflowAutomation?.attributes?.suspended_until
+              ? this.hass.localize(
+                  "ui.panel.config.automation.editor.suspended"
+                )
+              : this.hass.localize("ui.panel.config.automation.editor.suspend")
+          }
+        </ha-dropdown-item>
         <ha-dropdown-item value="delete" variant="danger">
           <ha-svg-icon .path=${mdiDelete} slot="icon"></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.automation.picker.delete")}
@@ -1061,6 +1076,9 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
       case "toggle":
         this._toggle(this._overflowAutomation);
         break;
+      case "suspend":
+        this._suspend(this._overflowAutomation);
+        break;
       case "delete":
         this._deleteConfirm(this._overflowAutomation);
         break;
@@ -1105,6 +1123,14 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
     showAssignCategoryDialog(this, {
       scope: "automation",
       entityReg,
+    });
+  };
+
+  private _suspend = (automation: AutomationItem) => {
+    showAutomationSuspendDialog(this, {
+      entityId: automation.entity_id,
+      name: automation.name,
+      suspendedUntil: automation.attributes.suspended_until,
     });
   };
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5236,6 +5236,20 @@
           "editor": {
             "enable": "[%key:ui::common::enable%]",
             "disable": "[%key:ui::common::disable%]",
+            "suspend": "Suspend",
+            "suspended": "Suspended",
+            "suspend_dialog": {
+              "title": "Suspend automation",
+              "description": "Suspend {name} until a specific date and time. The automation will be disabled and will automatically re-enable when the time is reached.",
+              "end_date": "End date",
+              "end_time": "End time",
+              "remove_suspend": "Remove suspend",
+              "presets": {
+                "one_hour": "+1 hour",
+                "one_day": "+1 day",
+                "one_week": "+1 week"
+              }
+            },
             "disabled": "Automation is disabled",
             "read_only": "This automation cannot be edited from the UI, because it is not stored in the automations.yaml file, or doesn't have an ID.",
             "unavailable": "Automation is unavailable",


### PR DESCRIPTION
## Proposed change

Automations can be suspended by specifying suspend end time. This will disable the automation now and re-enable it when the suspend end time is reached. Any manual toggling of the state of the automation removes the suspend state and timer.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/2735
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/181857

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
