### PR TITLE
Add state position option to tile card

### DIFF
--- a/gallery/src/pages/lovelace/tile-card.ts
+++ b/gallery/src/pages/lovelace/tile-card.ts
@@ -163,6 +163,24 @@ const ENTITIES = [
         FanEntityFeature.OSCILLATE,
     },
   },
+  {
+    entity_id: "select.home_mode",
+    state: "Away",
+    attributes: {
+      friendly_name: "Home mode",
+      options: ["Home", "Away", "Night", "Vacation"],
+    },
+  },
+  {
+    entity_id: "sensor.outside_temperature",
+    state: "15.6",
+    attributes: {
+      friendly_name: "Outside temperature sensor on the north wall",
+      device_class: "temperature",
+      state_class: "measurement",
+      unit_of_measurement: "°C",
+    },
+  },
 ];
 
 const CONFIGS = [
@@ -416,6 +434,61 @@ const CONFIGS = [
         { type: "climate-swing-modes", style: "dropdown" },
         { type: "climate-swing-horizontal-modes", style: "dropdown" },
       ],
+    },
+  },
+  {
+    heading: "Secondary state, the default",
+    config: {
+      type: "tile",
+      entity: "select.home_mode",
+    },
+  },
+  {
+    heading: "Inline state",
+    config: {
+      type: "tile",
+      entity: "select.home_mode",
+      state_position: "inline",
+    },
+  },
+  {
+    heading: "Inline state: long name and long value",
+    config: {
+      type: "tile",
+      entity: "sensor.outside_temperature",
+      state_position: "inline",
+      state_content: ["state", "last_changed"],
+    },
+  },
+  {
+    heading: "Inline state with a bottom feature",
+    config: {
+      type: "tile",
+      entity: "climate.dual_thermostat",
+      state_position: "inline",
+      features: [{ type: "climate-hvac-modes", style: "dropdown" }],
+    },
+  },
+  {
+    heading: "Inline state moves inline features below",
+    config: {
+      type: "tile",
+      entity: "climate.dual_thermostat",
+      state_position: "inline",
+      features_position: "inline",
+      features: [
+        { type: "climate-hvac-modes", style: "dropdown" },
+        { type: "climate-preset-modes", style: "dropdown" },
+      ],
+    },
+  },
+  {
+    heading: "Inline state is ignored in the vertical layout",
+    config: {
+      type: "tile",
+      entity: "select.home_mode",
+      state_position: "inline",
+      vertical: true,
     },
   },
 ] satisfies DemoCardConfig<TileCardConfig>[];

--- a/public/static/images/form/tile_state_position_inline.svg
+++ b/public/static/images/form/tile_state_position_inline.svg
@@ -1,0 +1,7 @@
+<svg width="94" height="40" viewBox="0 0 94 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="94" height="40" rx="8" fill="white"/>
+<rect x="0.5" y="0.5" width="93" height="39" rx="7.5" stroke="black" stroke-opacity="0.12"/>
+<circle cx="20" cy="20" r="12" fill="black" fill-opacity="0.12"/>
+<rect x="40" y="14" width="24" height="12" rx="6" fill="black" fill-opacity="0.32"/>
+<rect x="70" y="16" width="16" height="8" rx="4" fill="black" fill-opacity="0.32"/>
+</svg>

--- a/public/static/images/form/tile_state_position_inline_dark.svg
+++ b/public/static/images/form/tile_state_position_inline_dark.svg
@@ -1,0 +1,7 @@
+<svg width="94" height="40" viewBox="0 0 94 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="94" height="40" rx="8" fill="#1C1C1C"/>
+<rect x="0.5" y="0.5" width="93" height="39" rx="7.5" stroke="white" stroke-opacity="0.24"/>
+<circle cx="20" cy="20" r="12" fill="white" fill-opacity="0.24"/>
+<rect x="40" y="14" width="24" height="12" rx="6" fill="white" fill-opacity="0.48"/>
+<rect x="70" y="16" width="16" height="8" rx="4" fill="white" fill-opacity="0.48"/>
+</svg>

--- a/public/static/images/form/tile_state_position_secondary.svg
+++ b/public/static/images/form/tile_state_position_secondary.svg
@@ -1,0 +1,7 @@
+<svg width="94" height="40" viewBox="0 0 94 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="94" height="40" rx="8" fill="white"/>
+<rect x="0.5" y="0.5" width="93" height="39" rx="7.5" stroke="black" stroke-opacity="0.12"/>
+<circle cx="20" cy="20" r="12" fill="black" fill-opacity="0.12"/>
+<rect x="40" y="8" width="31" height="12" rx="6" fill="black" fill-opacity="0.32"/>
+<rect x="40" y="24" width="41" height="8" rx="4" fill="black" fill-opacity="0.32"/>
+</svg>

--- a/public/static/images/form/tile_state_position_secondary_dark.svg
+++ b/public/static/images/form/tile_state_position_secondary_dark.svg
@@ -1,0 +1,7 @@
+<svg width="94" height="40" viewBox="0 0 94 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="94" height="40" rx="8" fill="#1C1C1C"/>
+<rect x="0.5" y="0.5" width="93" height="39" rx="7.5" stroke="white" stroke-opacity="0.24"/>
+<circle cx="20" cy="20" r="12" fill="white" fill-opacity="0.24"/>
+<rect x="40" y="8" width="31" height="12" rx="6" fill="white" fill-opacity="0.48"/>
+<rect x="40" y="24" width="41" height="8" rx="4" fill="white" fill-opacity="0.48"/>
+</svg>

--- a/src/components/tile/ha-tile-container.ts
+++ b/src/components/tile/ha-tile-container.ts
@@ -59,7 +59,7 @@ export class HaTileContainer extends LitElement {
         class="background"
         role=${ifDefined(this.interactive ? "button" : undefined)}
         tabindex=${ifDefined(this.interactive ? "0" : undefined)}
-        aria-labelledby="info"
+        aria-labelledby="info state"
         .actionHandler=${actionHandler(this.actionHandlerOptions)}
         @focus=${this._handleFocus}
         @blur=${this._handleBlur}
@@ -75,6 +75,9 @@ export class HaTileContainer extends LitElement {
           <div class="content ${classMap(contentClasses)}">
             <slot name="icon"></slot>
             <slot name="info" id="info"></slot>
+            <!-- part of the accessible name, so an inline state is announced
+                 the same way the secondary state is -->
+            <slot name="state" id="state"></slot>
           </div>
           <slot name="features-inline"></slot>
         </div>
@@ -171,6 +174,20 @@ export class HaTileContainer extends LitElement {
       min-width: 0;
       transition: background-color 180ms ease-in-out;
       box-sizing: border-box;
+    }
+    ::slotted([slot="state"]) {
+      position: relative;
+      /* keep the natural width so the info block is the one that shrinks */
+      flex: none;
+      max-width: 50%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      text-align: end;
+      font-size: var(--ha-font-size-m);
+      font-weight: var(--ha-font-weight-normal);
+      line-height: var(--ha-line-height-condensed);
+      color: var(--primary-text-color);
     }
     ::slotted([slot="features"]) {
       padding: 0 var(--ha-space-3) var(--ha-space-3) var(--ha-space-3);

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -40,7 +40,21 @@ import type {
 } from "../types";
 import { renderTileBadge } from "./tile/badges/tile-badge";
 import { tileCardStyle } from "./tile/tile-card-style";
-import type { TileCardConfig } from "./types";
+import type { TileCardConfig, TileCardStatePosition } from "./types";
+
+/**
+ * Where the tile card renders the entity state. A hidden state and the vertical
+ * content layout both win over `state_position`. The card and its editor share
+ * this so the editor never disables an option the card still honors.
+ */
+export const computeTileStatePosition = (
+  config: Pick<TileCardConfig, "hide_state" | "vertical" | "state_position">
+): TileCardStatePosition => {
+  if (config.hide_state || config.vertical) {
+    return "secondary";
+  }
+  return config.state_position || "secondary";
+};
 
 export const getEntityDefaultTileIconAction = (entityId: string) => {
   const domain = computeDomain(entityId);
@@ -251,8 +265,14 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     );
   }
 
+  private _statePosition = memoizeOne(computeTileStatePosition);
+
   private _featurePosition = memoizeOne((config: TileCardConfig) => {
     if (config.vertical) {
+      return "bottom";
+    }
+    // the inline state owns the right side of the name row, so features move below
+    if (this._statePosition(config) === "inline") {
       return "bottom";
     }
     return config.features_position || "bottom";
@@ -308,6 +328,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       : undefined;
 
     const featurePosition = this._featurePosition(this._config);
+    const statePosition = this._statePosition(this._config);
     const features = this._featureLayout(this._config);
 
     const hasImage = Boolean(imageUrl);
@@ -361,11 +382,16 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
           <ha-tile-info slot="info">
             <span slot="primary" class="primary">${name}</span>
             ${
-              stateDisplay
+              statePosition === "secondary" && stateDisplay
                 ? html`<span slot="secondary">${stateDisplay}</span>`
                 : nothing
             }
           </ha-tile-info>
+          ${
+            statePosition === "inline"
+              ? html`<span slot="state">${stateDisplay}</span>`
+              : nothing
+          }
           ${
             features.inline.length > 0
               ? html`

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -683,11 +683,14 @@ export interface WeatherForecastCardConfig extends LovelaceCardConfig {
   double_tap_action?: ActionConfig;
 }
 
+export type TileCardStatePosition = "secondary" | "inline";
+
 export interface TileCardConfig extends LovelaceCardConfig {
   entity: string;
   name?: string | EntityNameItem | EntityNameItem[];
   hide_state?: boolean;
   state_content?: string | string[];
+  state_position?: TileCardStatePosition;
   icon?: string;
   color?: string;
   show_entity_picture?: boolean;

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -31,7 +31,10 @@ import type {
   LovelaceCardFeatureContext,
 } from "../../card-features/types";
 import { ACTION_RELATED_CONTEXT } from "../../components/hui-action-editor";
-import { getEntityDefaultTileIconAction } from "../../cards/hui-tile-card";
+import {
+  computeTileStatePosition,
+  getEntityDefaultTileIconAction,
+} from "../../cards/hui-tile-card";
 import type { TileCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
 import { actionConfigStruct } from "../structs/action-struct";
@@ -53,6 +56,7 @@ const cardConfigStruct = assign(
     show_entity_picture: optional(boolean()),
     hide_state: optional(boolean()),
     state_content: optional(union([string(), array(string())])),
+    state_position: optional(enums(["secondary", "inline"])),
     vertical: optional(boolean()),
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),
@@ -88,11 +92,19 @@ export class HuiTileCardEditor
     })
   );
 
+  private get _inlineState(): boolean {
+    return (
+      !!this._config && computeTileStatePosition(this._config) === "inline"
+    );
+  }
+
   private _schema = memoizeOne(
     (
       localize: LocalizeFunc,
       entityId: string | undefined,
-      showTimeFormat: boolean
+      showTimeFormat: boolean,
+      vertical: boolean,
+      inlineState: boolean
     ) =>
       [
         { name: "entity", selector: { entity: {} } },
@@ -163,6 +175,31 @@ export class HuiTileCardEditor
               },
             },
             {
+              name: "state_position",
+              required: true,
+              visible: { field: "hide_state", operator: "not_eq", value: true },
+              selector: {
+                select: {
+                  mode: "box",
+                  options: ["secondary", "inline"].map((value) => ({
+                    label: localize(
+                      `ui.panel.lovelace.editor.card.tile.state_position_options.${value}`
+                    ),
+                    description: localize(
+                      `ui.panel.lovelace.editor.card.tile.state_position_options.${value}_description`
+                    ),
+                    value,
+                    image: {
+                      src: `/static/images/form/tile_state_position_${value}.svg`,
+                      src_dark: `/static/images/form/tile_state_position_${value}_dark.svg`,
+                      flip_rtl: true,
+                    },
+                    disabled: vertical && value === "inline",
+                  })),
+                },
+              },
+            },
+            {
               name: "content_layout",
               required: true,
               selector: {
@@ -178,6 +215,7 @@ export class HuiTileCardEditor
                       src_dark: `/static/images/form/tile_content_layout_${value}_dark.svg`,
                       flip_rtl: true,
                     },
+                    disabled: inlineState && value === "vertical",
                   })),
                 },
               },
@@ -241,7 +279,7 @@ export class HuiTileCardEditor
   );
 
   private _featuresSchema = memoizeOne(
-    (localize: LocalizeFunc, vertical: boolean) =>
+    (localize: LocalizeFunc, vertical: boolean, inlineState: boolean) =>
       [
         {
           name: "features_position",
@@ -262,7 +300,7 @@ export class HuiTileCardEditor
                   src_dark: `/static/images/form/tile_features_position_${value}_dark.svg`,
                   flip_rtl: true,
                 },
-                disabled: vertical && value === "inline",
+                disabled: (vertical || inlineState) && value === "inline",
               })),
             },
           },
@@ -290,19 +328,37 @@ export class HuiTileCardEditor
         this._config.state_content
       );
 
-    const schema = this._schema(this.hass.localize, entityId, showTimeFormat);
-
     const vertical = this._config.vertical ?? false;
-
-    const featuresSchema = this._featuresSchema(this.hass.localize, vertical);
 
     const data = {
       ...this._config,
       content_layout: vertical ? "vertical" : "horizontal",
     };
 
-    // Default features position to bottom and force it to bottom in vertical mode
-    if (!data.features_position || vertical) {
+    // Show the position the card actually uses, not the raw config value
+    data.state_position = computeTileStatePosition(data);
+
+    // The two positions exclude each other, so each one disables the other in
+    // the editor. A hidden state and the vertical layout both keep this false.
+    const inlineState = data.state_position === "inline";
+
+    const schema = this._schema(
+      this.hass.localize,
+      entityId,
+      showTimeFormat,
+      vertical,
+      inlineState
+    );
+
+    const featuresSchema = this._featuresSchema(
+      this.hass.localize,
+      vertical,
+      inlineState
+    );
+
+    // Default features position to bottom, and force it to bottom in vertical
+    // mode or when the inline state already owns the name row
+    if (!data.features_position || vertical || inlineState) {
       data.features_position = "bottom";
     }
 
@@ -369,10 +425,16 @@ export class HuiTileCardEditor
 
     if (config.hide_state) {
       delete config.state_content;
+      delete config.state_position;
     }
 
     if (!config.state_content) {
       delete config.state_content;
+    }
+
+    // Keep the default out of the saved config, so existing tiles stay untouched
+    if (config.state_position === "secondary") {
+      delete config.state_position;
     }
 
     // Convert content_layout to vertical
@@ -444,6 +506,7 @@ export class HuiTileCardEditor
       case "show_entity_picture":
       case "hide_state":
       case "state_content":
+      case "state_position":
       case "content_layout":
       case "features_position":
         return this.hass!.localize(
@@ -466,10 +529,29 @@ export class HuiTileCardEditor
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.tile.${schema.name}_helper`
         );
+      case "state_position":
+        if (this._config?.vertical) {
+          return this.hass!.localize(
+            `ui.panel.lovelace.editor.card.tile.${schema.name}_helper_vertical`
+          );
+        }
+        return undefined;
+      case "content_layout":
+        if (this._inlineState) {
+          return this.hass!.localize(
+            `ui.panel.lovelace.editor.card.tile.${schema.name}_helper_inline_state`
+          );
+        }
+        return undefined;
       case "features_position":
         if (this._config?.vertical) {
           return this.hass!.localize(
             `ui.panel.lovelace.editor.card.tile.${schema.name}_helper_vertical`
+          );
+        }
+        if (this._inlineState) {
+          return this.hass!.localize(
+            `ui.panel.lovelace.editor.card.tile.${schema.name}_helper_inline_state`
           );
         }
         return undefined;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10734,6 +10734,14 @@
               "show_entity_picture": "Show entity picture",
               "hide_state": "Hide state",
               "state_content": "State content",
+              "state_position": "State position",
+              "state_position_options": {
+                "secondary": "Secondary",
+                "secondary_description": "Displays the state below the name",
+                "inline": "Inline",
+                "inline_description": "Displays the state next to the name"
+              },
+              "state_position_helper_vertical": "Always displayed below the name if the content layout is vertical",
               "features_position": "Features position",
               "features_position_options": {
                 "bottom": "Bottom",
@@ -10742,11 +10750,13 @@
                 "inline_description": "Displays features in two columns, starting next to the name"
               },
               "features_position_helper_vertical": "Always displayed at the bottom if the content layout is vertical",
+              "features_position_helper_inline_state": "Always displayed at the bottom if the state position is inline",
               "content_layout": "Content layout",
               "content_layout_options": {
                 "horizontal": "Horizontal",
                 "vertical": "Vertical"
-              }
+              },
+              "content_layout_helper_inline_state": "Always horizontal if the state position is inline"
             },
             "vertical-stack": {
               "name": "Vertical stack",

--- a/test/panels/lovelace/cards/hui-tile-card.test.ts
+++ b/test/panels/lovelace/cards/hui-tile-card.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import "../../../../src/panels/lovelace/cards/hui-tile-card";
+import { computeTileStatePosition } from "../../../../src/panels/lovelace/cards/hui-tile-card";
 import type { LovelaceCardFeatureConfig } from "../../../../src/panels/lovelace/card-features/types";
 import type {
   LovelaceCard,
@@ -40,6 +40,32 @@ const makeCard = (config: Partial<TileCardConfig>): LovelaceCard => {
   } as TileCardConfig);
   return card;
 };
+
+// The card and its editor both read the state position through this helper. If
+// they disagree, the editor greys out options the card still honors.
+describe("computeTileStatePosition", () => {
+  it("defaults to secondary", () => {
+    expect(computeTileStatePosition({})).toBe("secondary");
+  });
+
+  it("returns the configured position", () => {
+    expect(computeTileStatePosition({ state_position: "inline" })).toBe(
+      "inline"
+    );
+  });
+
+  it("falls back to secondary when the state is hidden", () => {
+    expect(
+      computeTileStatePosition({ state_position: "inline", hide_state: true })
+    ).toBe("secondary");
+  });
+
+  it("falls back to secondary in the vertical layout", () => {
+    expect(
+      computeTileStatePosition({ state_position: "inline", vertical: true })
+    ).toBe("secondary");
+  });
+});
 
 describe("hui-tile-card getCardSize", () => {
   it("is 1 for a bare tile", () => {
@@ -97,6 +123,29 @@ describe("hui-tile-card getCardSize", () => {
       }).getCardSize()
     ).toBe(4);
   });
+
+  it("ignores inline mode when the state takes the name row", () => {
+    // an inline state forces bottom positioning, so all features are stacked
+    expect(
+      makeCard({
+        state_position: "inline",
+        features_position: "inline",
+        features: features(2),
+      }).getCardSize()
+    ).toBe(3);
+  });
+
+  it("keeps inline mode when the state is hidden", () => {
+    // hide_state drops the state, so the features keep the name row
+    expect(
+      makeCard({
+        hide_state: true,
+        state_position: "inline",
+        features_position: "inline",
+        features: features(2),
+      }).getCardSize()
+    ).toBe(2);
+  });
 });
 
 describe("hui-tile-card getGridOptions", () => {
@@ -151,6 +200,22 @@ describe("hui-tile-card getGridOptions", () => {
       rows: 1,
       min_columns: 12,
       min_rows: 1,
+    });
+  });
+
+  it("stacks all features and stays 6 columns wide when the state is inline", () => {
+    // an inline state forces bottom positioning, so the tile never needs 12 columns
+    expect(
+      gridOptions({
+        state_position: "inline",
+        features_position: "inline",
+        features: features(2),
+      })
+    ).toEqual({
+      columns: 6,
+      rows: 3,
+      min_columns: 6,
+      min_rows: 3,
     });
   });
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This adds a `state_position` option to the tile card. The default value `secondary` keeps the state under the name, exactly as it is today. `state_position: inline` moves the state to the right of the name.

This follows the feedback on #54051. The objection there was that a card feature which renders the state lets a card show the same information twice. This option moves the state rather than adding a second copy, so duplication is impossible by construction. It also matches the suggestion in that thread about an alternative position for the state in the tile card.

```yaml
type: tile
entity: select.home_mode
state_position: inline
```

The rules around it:

- An inline state owns the right side of the name row, so features fall back to the bottom position. The editor disables the inline features option and explains why.
- `hide_state: true` keeps its current meaning. The position option is then hidden in the editor and ignored by the card.
- The vertical content layout forces the state back to `secondary`, the same rule that `features_position` already uses. The editor disables each of the two options while the other one is set, so the pair reads the same in both directions.
- The editor writes nothing when the value is the default, so existing tile configurations stay untouched.

The value name follows existing Home Assistant naming. `ha-tile-info` calls that line the `secondary` slot, and the entities card calls the same line `secondary_info`.

`getCardSize` and `getGridOptions` both read the feature position through one helper, so the grid arithmetic follows the fallback with no extra code. The existing tile card tests pin that arithmetic down and this PR adds cases for the new rule.

Two things I would like your call on:

- Typography of the inline state. It currently uses the name font size at normal weight and the primary text color, which reads as more prominent than the small secondary line. Tell me what you want here and I will change it.
- The two editor images follow the style of the existing ones in `public/static/images/form`. Replace them if you have proper artwork.

## Screenshots

<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

All images come from a Home Assistant instance with the demo integration, on a dashboard built for this change.

Default position on the left, inline position on the right. Light theme:

![Tile state position on a dashboard, light theme](https://raw.githubusercontent.com/pszypowicz/frontend/pr-screenshots/screenshots/tile-state-position-dashboard-light.png)

Dark theme:

![Tile state position on a dashboard, dark theme](https://raw.githubusercontent.com/pszypowicz/frontend/pr-screenshots/screenshots/tile-state-position-dashboard-dark.png)

The three rules, light theme. A long name gives way to the value, inline features move to the bottom, and the vertical layout keeps the state below the name:

![Tile state position edge cases, light theme](https://raw.githubusercontent.com/pszypowicz/frontend/pr-screenshots/screenshots/tile-state-position-edge-cases-light.png)

The same three rules in the dark theme:

![Tile state position edge cases, dark theme](https://raw.githubusercontent.com/pszypowicz/frontend/pr-screenshots/screenshots/tile-state-position-edge-cases-dark.png)

The new selector in the card editor, in the Content section. The vertical content layout is disabled while the state is inline, which mirrors the existing rule in the other direction:

![State position selector in the tile card editor](https://raw.githubusercontent.com/pszypowicz/frontend/pr-screenshots/screenshots/tile-state-position-editor.png)

The features position selector while the state is inline. The inline option is disabled and the helper text says why:

![Features position selector with the inline option disabled](https://raw.githubusercontent.com/pszypowicz/frontend/pr-screenshots/screenshots/tile-state-position-features-editor.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/54051, https://community.home-assistant.io/t/make-it-possible-to-set-tile-card-features-in-lovelace-as-read-only-or-ignore-input-without-a-preceeding-long-press/680537
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/48064
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


