### PR TITLE
Add Stacks to Sections View

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,15 @@ dist/
 /translations/
 /.compress-cache/
 /.rspack-cache/
+
+# Build archives
+*.zip
+*.tar
+*.tar.gz
+*.tar.bz2
+*.tar.xz
+*.tgz
+*.whl
 # Composite action source, not build output
 !/.github/actions/build/
 

--- a/src/components/ha-sortable.ts
+++ b/src/components/ha-sortable.ts
@@ -7,6 +7,11 @@ import { fireEvent } from "../common/dom/fire_event";
 import type { SortableInstance } from "../resources/sortable";
 
 declare global {
+  interface HTMLElement {
+    /** Data returned by ha-sortable when this item moves to another container. */
+    sortableData?: unknown;
+  }
+
   interface HASSDomEvents {
     "item-moved": {
       oldIndex: number;

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -2,6 +2,7 @@ import type { Connection, HassEventBase } from "home-assistant-js-websocket";
 import { getCollection } from "home-assistant-js-websocket";
 import type { HuiBadge } from "../panels/lovelace/badges/hui-badge";
 import type { HuiCard } from "../panels/lovelace/cards/hui-card";
+import type { LovelaceSectionPath } from "../panels/lovelace/editor/lovelace-path";
 import type { HuiSection } from "../panels/lovelace/sections/hui-section";
 import type { Lovelace } from "../panels/lovelace/types";
 import type { HomeAssistant } from "../types";
@@ -28,6 +29,7 @@ export interface LovelaceViewElement extends HTMLElement {
 }
 
 export interface LovelaceSectionElement extends HTMLElement {
+  sectionPath?: LovelaceSectionPath;
   hass?: HomeAssistant;
   lovelace?: Lovelace;
   preview?: boolean;

--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -27,12 +27,24 @@ export interface LovelaceSectionConfig extends LovelaceBaseSectionConfig {
   cards?: LovelaceCardConfig[];
 }
 
+export interface LovelaceStackSectionConfig extends LovelaceSectionConfig {
+  type: "stack";
+  sections: LovelaceSectionRawConfig[];
+}
+
+export const isStackSection = (
+  section: LovelaceSectionRawConfig
+): section is LovelaceStackSectionConfig =>
+  "type" in section && section.type === "stack";
+
 export interface LovelaceStrategySectionConfig extends LovelaceBaseSectionConfig {
   strategy: LovelaceStrategyConfig;
 }
 
 export type LovelaceSectionRawConfig =
-  LovelaceSectionConfig | LovelaceStrategySectionConfig;
+  | LovelaceSectionConfig
+  | LovelaceStrategySectionConfig
+  | LovelaceStackSectionConfig;
 
 export function resolveSectionBackground(
   background: boolean | LovelaceSectionBackgroundConfig | undefined

--- a/src/panels/lovelace/common/check-lovelace-config.ts
+++ b/src/panels/lovelace/common/check-lovelace-config.ts
@@ -1,5 +1,8 @@
 import type { LovelaceSectionRawConfig } from "../../../data/lovelace/config/section";
-import { isStrategySection } from "../../../data/lovelace/config/section";
+import {
+  isStackSection,
+  isStrategySection,
+} from "../../../data/lovelace/config/section";
 import type { LovelaceRawConfig } from "../../../data/lovelace/config/types";
 import { isStrategyDashboard } from "../../../data/lovelace/config/types";
 import type { LovelaceViewRawConfig } from "../../../data/lovelace/config/view";
@@ -47,6 +50,13 @@ export const checkSectionConfig = (
   section: LovelaceSectionRawConfig
 ): LovelaceSectionRawConfig => {
   const updatedSection = { ...section };
+
+  if (isStackSection(updatedSection)) {
+    return {
+      ...updatedSection,
+      sections: updatedSection.sections.map(checkSectionConfig),
+    };
+  }
 
   // Move title to a heading card
   if (section.title) {

--- a/src/panels/lovelace/components/hui-section-edit-mode.ts
+++ b/src/panels/lovelace/components/hui-section-edit-mode.ts
@@ -3,11 +3,13 @@ import {
   mdiDelete,
   mdiDotsVertical,
   mdiDragHorizontalVariant,
+  mdiFormatListGroupPlus,
   mdiPencil,
+  mdiPlaylistMinus,
   mdiPlusCircleMultipleOutline,
 } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult } from "lit";
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import "../../../components/ha-dropdown";
 import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
@@ -17,7 +19,14 @@ import "../../../components/ha-svg-icon";
 import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
-import { deleteSection, duplicateSection } from "../editor/config-util";
+import {
+  deleteSection,
+  duplicateSection,
+  moveSection,
+  wrapSectionInStack,
+} from "../editor/config-util";
+import type { LovelaceSectionPath } from "../editor/lovelace-path";
+import { isStackSection } from "../../../data/lovelace/config/section";
 import { findLovelaceContainer } from "../editor/lovelace-path";
 import { showEditSectionDialog } from "../editor/section-editor/show-edit-section-dialog";
 import type { Lovelace } from "../types";
@@ -32,7 +41,19 @@ export class HuiSectionEditMode extends LitElement {
 
   @property({ attribute: false }) public viewIndex!: number;
 
-  protected render(): TemplateResult {
+  @property({ attribute: false }) public stackIndex?: number;
+
+  @property({ type: Boolean, reflect: true }) public stack = false;
+
+  private get _path(): LovelaceSectionPath {
+    return this.stackIndex === undefined
+      ? [this.viewIndex, this.index]
+      : [this.viewIndex, this.stackIndex, this.index];
+  }
+
+  protected render(): TemplateResult | typeof nothing {
+    // Sortable's temporary clone does not have the component properties.
+    if (!this.hass || !this.lovelace) return nothing;
     return html`
       <div class="section-header">
         <div class="section-actions">
@@ -61,6 +82,32 @@ export class HuiSectionEditMode extends LitElement {
               ></ha-svg-icon>
               ${this.hass.localize("ui.common.duplicate")}
             </ha-dropdown-item>
+            ${
+              !this.stack && this.stackIndex === undefined
+                ? html`
+                    <ha-dropdown-item value="wrap-in-stack">
+                      <ha-svg-icon
+                        slot="icon"
+                        .path=${mdiFormatListGroupPlus}
+                      ></ha-svg-icon>
+                      ${this.hass.localize("ui.panel.lovelace.editor.section.wrap_in_stack")}
+                    </ha-dropdown-item>
+                  `
+                : nothing
+            }
+            ${
+              this.stackIndex !== undefined
+                ? html`
+                    <ha-dropdown-item value="remove-from-stack">
+                      <ha-svg-icon
+                        slot="icon"
+                        .path=${mdiPlaylistMinus}
+                      ></ha-svg-icon>
+                      ${this.hass.localize("ui.panel.lovelace.editor.section.remove_from_stack")}
+                    </ha-dropdown-item>
+                  `
+                : nothing
+            }
             <wa-divider></wa-divider>
             <ha-dropdown-item value="delete" variant="danger">
               <ha-svg-icon slot="icon" .path=${mdiDelete}></ha-svg-icon>
@@ -85,6 +132,12 @@ export class HuiSectionEditMode extends LitElement {
       case "duplicate":
         this._duplicateSection();
         break;
+      case "wrap-in-stack":
+        this._wrapInStack();
+        break;
+      case "remove-from-stack":
+        this._removeFromStack();
+        break;
       case "delete":
         this._deleteSection();
         break;
@@ -98,8 +151,7 @@ export class HuiSectionEditMode extends LitElement {
       saveConfig: (newConfig) => {
         this.lovelace!.saveConfig(newConfig);
       },
-      viewIndex: this.viewIndex,
-      sectionIndex: this.index,
+      path: this._path,
     });
   }
 
@@ -107,19 +159,37 @@ export class HuiSectionEditMode extends LitElement {
     const newConfig = duplicateSection(
       this.lovelace!.config,
       this.viewIndex,
-      this.index
+      this.index,
+      this.stackIndex
     );
     this.lovelace!.saveConfig(newConfig);
   }
 
+  private _wrapInStack(): void {
+    if (this.stackIndex !== undefined) return;
+    this.lovelace.saveConfig(
+      wrapSectionInStack(this.lovelace.config, this.viewIndex, this.index)
+    );
+  }
+
+  private _removeFromStack(): void {
+    if (this.stackIndex === undefined) return;
+    this.lovelace.saveConfig(
+      moveSection(this.lovelace.config, this._path, [
+        this.viewIndex,
+        this.stackIndex + 1,
+      ])
+    );
+  }
+
   private async _deleteSection() {
-    const path = [this.viewIndex, this.index] as [number, number];
+    const path = this._path;
 
     const section = findLovelaceContainer(this.lovelace!.config, path);
 
     const cardCount = "cards" in section && section.cards?.length;
 
-    if (cardCount) {
+    if (cardCount || (isStackSection(section) && section.sections.length > 0)) {
       const confirm = await showConfirmationDialog(this, {
         title: this.hass.localize(
           "ui.panel.lovelace.editor.delete_section.title"
@@ -137,7 +207,8 @@ export class HuiSectionEditMode extends LitElement {
     const newConfig = deleteSection(
       this.lovelace!.config,
       this.viewIndex,
-      this.index
+      this.index,
+      this.stackIndex
     );
     this.lovelace!.saveConfig(newConfig);
   }
@@ -181,6 +252,11 @@ export class HuiSectionEditMode extends LitElement {
         .handle {
           cursor: grab;
           padding: 8px;
+        }
+
+        :host([stack]) .section-wrapper {
+          padding: 0;
+          border-color: var(--cyan-color);
         }
 
         .section-wrapper {

--- a/src/panels/lovelace/create-element/create-section-element.ts
+++ b/src/panels/lovelace/create-element/create-section-element.ts
@@ -6,7 +6,9 @@ import { createLovelaceElement } from "./create-element-base";
 
 const ALWAYS_LOADED_LAYOUTS = new Set(["grid"]);
 
-const LAZY_LOAD_LAYOUTS = {};
+const LAZY_LOAD_LAYOUTS = {
+  stack: () => import("../sections/hui-stack-section"),
+};
 
 export const createSectionElement = (
   config: LovelaceSectionConfig

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
@@ -17,7 +17,7 @@ import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
 import { haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import { addCard } from "../config-util";
-import { findLovelaceContainer } from "../lovelace-path";
+import { findLovelaceContainer, getCardSectionConfig } from "../lovelace-path";
 import "./hui-card-picker";
 import "./hui-suggestion-picker";
 import type { CreateCardDialogParams } from "./show-create-card-dialog";
@@ -261,8 +261,8 @@ export class HuiCreateDialogCard
     const saveConfig = this._params!.saveConfig;
 
     const sectionConfig =
-      containerPath.length === 2
-        ? findLovelaceContainer(lovelaceConfig, containerPath)
+      containerPath.length !== 1
+        ? getCardSectionConfig(lovelaceConfig, containerPath)
         : undefined;
 
     showEditCardDialog(this, {

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
@@ -257,7 +257,7 @@ export class HuiDialogSuggestCard extends LitElement {
     const newCards = this._sectionConfig
       ? this._sectionConfig.cards || []
       : this._cardConfig!;
-    return addCards(config, [viewIndex, sectionIndex], newCards);
+    return addCards(config, path, newCards);
   }
 
   private async _save(): Promise<void> {

--- a/src/panels/lovelace/editor/config-util.ts
+++ b/src/panels/lovelace/editor/config-util.ts
@@ -2,18 +2,22 @@ import deepClone from "deep-clone-simple";
 import type { LovelaceBadgeConfig } from "../../../data/lovelace/config/badge";
 import { ensureBadgeConfig } from "../../../data/lovelace/config/badge";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
+import { isStackSection } from "../../../data/lovelace/config/section";
 import type { LovelaceSectionRawConfig } from "../../../data/lovelace/config/section";
 import type { LovelaceConfig } from "../../../data/lovelace/config/types";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import { isStrategyView } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
-import type { LovelaceCardPath, LovelaceContainerPath } from "./lovelace-path";
+import type {
+  LovelaceCardPath,
+  LovelaceContainerPath,
+  LovelaceSectionPath,
+} from "./lovelace-path";
 import {
   findLovelaceContainer,
   findLovelaceItems,
   getLovelaceContainerPath,
   parseLovelaceCardPath,
-  parseLovelaceContainerPath,
   updateLovelaceContainer,
   updateLovelaceItems,
 } from "./lovelace-path";
@@ -139,19 +143,15 @@ export const moveCardToContainer = (
   fromPath: LovelaceCardPath,
   toPath: LovelaceContainerPath
 ): LovelaceConfig => {
-  const {
-    cardIndex: fromCardIndex,
-    viewIndex: fromViewIndex,
-    sectionIndex: fromSectionIndex,
-  } = parseLovelaceCardPath(fromPath);
-  const { viewIndex: toViewIndex, sectionIndex: toSectionIndex } =
-    parseLovelaceContainerPath(toPath);
-
-  if (fromViewIndex === toViewIndex && fromSectionIndex === toSectionIndex) {
+  const { cardIndex: fromCardIndex } = parseLovelaceCardPath(fromPath);
+  const fromContainerPath = getLovelaceContainerPath(fromPath);
+  if (
+    fromContainerPath.length === toPath.length &&
+    fromContainerPath.every((index, i) => index === toPath[i])
+  ) {
     throw new Error("You cannot move a card to the view or section it is in.");
   }
 
-  const fromContainerPath = getLovelaceContainerPath(fromPath);
   const cards = findLovelaceItems("cards", config, fromContainerPath);
   const card = cards![fromCardIndex];
 
@@ -264,95 +264,146 @@ export const moveViewToDashboard = (
   ];
 };
 
+const sectionContainerPath = (
+  viewIndex: number,
+  stackIndex?: number
+): [number] | [number, number] =>
+  stackIndex === undefined ? [viewIndex] : [viewIndex, stackIndex];
+
+const findSectionContainer = (
+  config: LovelaceConfig,
+  path: [number] | [number, number]
+) => {
+  if (path.length === 1) {
+    const view = findLovelaceContainer(config, path);
+    if (isStrategyView(view)) {
+      throw new Error("Editing sections in a strategy is not supported.");
+    }
+    return view;
+  }
+  const stack = findLovelaceContainer(config, path);
+  if (!isStackSection(stack)) throw new Error("Section is not a stack");
+  return stack;
+};
+
 export const addSection = (
   config: LovelaceConfig,
   viewIndex: number,
-  sectionConfig: LovelaceSectionRawConfig
+  sectionConfig: LovelaceSectionRawConfig,
+  stackIndex?: number
 ): LovelaceConfig => {
-  const view = findLovelaceContainer(config, [viewIndex]);
-  if (isStrategyView(view)) {
-    throw new Error("Deleting sections in a strategy is not supported.");
-  }
-  const sections = view.sections
-    ? [...view.sections, sectionConfig]
-    : [sectionConfig];
-
-  const newConfig = updateLovelaceContainer(config, [viewIndex], {
-    ...view,
-    sections,
-  });
-  return newConfig;
+  const container = findSectionContainer(
+    config,
+    sectionContainerPath(viewIndex, stackIndex)
+  );
+  return insertSection(
+    config,
+    viewIndex,
+    container.sections?.length ?? 0,
+    sectionConfig,
+    stackIndex
+  );
 };
 
 export const deleteSection = (
   config: LovelaceConfig,
   viewIndex: number,
-  sectionIndex: number
+  sectionIndex: number,
+  stackIndex?: number
 ): LovelaceConfig => {
-  const view = findLovelaceContainer(config, [viewIndex]);
-  if (isStrategyView(view)) {
-    throw new Error("Deleting sections in a strategy is not supported.");
-  }
-  const sections = view.sections?.filter(
-    (_origSection, index) => index !== sectionIndex
-  );
-
-  const newConfig = updateLovelaceContainer(config, [viewIndex], {
-    ...view,
-    sections,
+  const path = sectionContainerPath(viewIndex, stackIndex);
+  const container = findSectionContainer(config, path);
+  return updateLovelaceContainer(config, path, {
+    ...container,
+    sections: container.sections?.filter((_, index) => index !== sectionIndex),
   });
-  return newConfig;
 };
 
 export const duplicateSection = (
   config: LovelaceConfig,
   viewIndex: number,
-  sectionIndex: number
+  sectionIndex: number,
+  stackIndex?: number
 ): LovelaceConfig => {
-  const view = findLovelaceContainer(config, [viewIndex]);
-  if (isStrategyView(view)) {
-    throw new Error("Duplicating sections in a strategy is not supported.");
-  }
-  const clone = deepClone(view.sections![sectionIndex]);
-  return insertSection(config, viewIndex, sectionIndex + 1, clone);
+  const container = findSectionContainer(
+    config,
+    sectionContainerPath(viewIndex, stackIndex)
+  );
+  const clone = deepClone(container.sections![sectionIndex]);
+  return insertSection(config, viewIndex, sectionIndex + 1, clone, stackIndex);
 };
 
 export const insertSection = (
   config: LovelaceConfig,
   viewIndex: number,
   sectionIndex: number,
-  sectionConfig: LovelaceSectionRawConfig
+  sectionConfig: LovelaceSectionRawConfig,
+  stackIndex?: number
 ): LovelaceConfig => {
-  const view = findLovelaceContainer(config, [viewIndex]);
-  if (isStrategyView(view)) {
-    throw new Error("Inserting sections in a strategy is not supported.");
+  const path = sectionContainerPath(viewIndex, stackIndex);
+  const container = findSectionContainer(config, path);
+  if (stackIndex !== undefined && isStackSection(sectionConfig)) {
+    throw new Error("Nested section stacks are not supported");
   }
-  const sections = view.sections
-    ? [
-        ...view.sections.slice(0, sectionIndex),
-        sectionConfig,
-        ...view.sections.slice(sectionIndex),
-      ]
-    : [sectionConfig];
-
-  const newConfig = updateLovelaceContainer(config, [viewIndex], {
-    ...view,
-    sections,
+  const sections = container.sections ?? [];
+  return updateLovelaceContainer(config, path, {
+    ...container,
+    sections: [
+      ...sections.slice(0, sectionIndex),
+      sectionConfig,
+      ...sections.slice(sectionIndex),
+    ],
   });
-  return newConfig;
+};
+
+export const wrapSectionInStack = (
+  config: LovelaceConfig,
+  viewIndex: number,
+  sectionIndex: number
+): LovelaceConfig => {
+  const path: [number, number] = [viewIndex, sectionIndex];
+  const section = findLovelaceContainer(config, path);
+  if (isStackSection(section)) {
+    throw new Error("Nested section stacks are not supported");
+  }
+  return updateLovelaceContainer(config, path, {
+    type: "stack",
+    ...(section.column_span === undefined
+      ? {}
+      : { column_span: section.column_span }),
+    sections: [section],
+  });
 };
 
 export const moveSection = (
   config: LovelaceConfig,
-  fromPath: [number, number],
-  toPath: [number, number]
+  fromPath: LovelaceSectionPath,
+  toPath: LovelaceSectionPath
 ): LovelaceConfig => {
   const section = findLovelaceContainer(config, fromPath);
-
-  let newConfig = deleteSection(config, fromPath[0], fromPath[1]);
-  newConfig = insertSection(newConfig, toPath[0], toPath[1], section);
-
-  return newConfig;
+  const fromIndex = fromPath[fromPath.length - 1];
+  const toIndex = toPath[toPath.length - 1];
+  const fromStackIndex = fromPath.length === 3 ? fromPath[1] : undefined;
+  let toStackIndex = toPath.length === 3 ? toPath[1] : undefined;
+  if (isStackSection(section) && toStackIndex !== undefined) {
+    throw new Error("Nested section stacks are not supported");
+  }
+  // Removing a top-level section shifts a later destination stack left.
+  if (
+    fromPath[0] === toPath[0] &&
+    fromStackIndex === undefined &&
+    toStackIndex !== undefined &&
+    fromIndex < toStackIndex
+  ) {
+    toStackIndex--;
+  }
+  const newConfig = deleteSection(
+    config,
+    fromPath[0],
+    fromIndex,
+    fromStackIndex
+  );
+  return insertSection(newConfig, toPath[0], toIndex, section, toStackIndex);
 };
 
 export const addBadge = (

--- a/src/panels/lovelace/editor/lovelace-path.ts
+++ b/src/panels/lovelace/editor/lovelace-path.ts
@@ -1,17 +1,31 @@
 import type { LovelaceBadgeConfig } from "../../../data/lovelace/config/badge";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import type { LovelaceSectionRawConfig } from "../../../data/lovelace/config/section";
-import { isStrategySection } from "../../../data/lovelace/config/section";
+import { isStackSection } from "../../../data/lovelace/config/section";
 import type { LovelaceConfig } from "../../../data/lovelace/config/types";
 import type { LovelaceViewRawConfig } from "../../../data/lovelace/config/view";
 import { isStrategyView } from "../../../data/lovelace/config/view";
 
-export type LovelaceCardPath = [number, number] | [number, number, number];
-export type LovelaceContainerPath = [number] | [number, number];
+export type LovelaceSectionPath = [number, number] | [number, number, number];
+export type LovelaceCardPath = [...LovelaceContainerPath, number];
+export type LovelaceContainerPath = [number] | LovelaceSectionPath;
 
 export const parseLovelaceCardPath = (
   path: LovelaceCardPath
-): { viewIndex: number; sectionIndex?: number; cardIndex: number } => {
+): {
+  viewIndex: number;
+  sectionIndex?: number;
+  subsectionIndex?: number;
+  cardIndex: number;
+} => {
+  if (path.length === 4) {
+    return {
+      viewIndex: path[0],
+      sectionIndex: path[1],
+      subsectionIndex: path[2],
+      cardIndex: path[3],
+    };
+  }
   if (path.length === 2) {
     return {
       viewIndex: path[0],
@@ -27,7 +41,14 @@ export const parseLovelaceCardPath = (
 
 export const parseLovelaceContainerPath = (
   path: LovelaceContainerPath
-): { viewIndex: number; sectionIndex?: number } => {
+): { viewIndex: number; sectionIndex?: number; subsectionIndex?: number } => {
+  if (path.length === 3) {
+    return {
+      viewIndex: path[0],
+      sectionIndex: path[1],
+      subsectionIndex: path[2],
+    };
+  }
   if (path.length === 1) {
     return {
       viewIndex: path[0],
@@ -45,7 +66,7 @@ export const getLovelaceContainerPath = (
 
 interface FindLovelaceContainer {
   (config: LovelaceConfig, path: [number]): LovelaceViewRawConfig;
-  (config: LovelaceConfig, path: [number, number]): LovelaceSectionRawConfig;
+  (config: LovelaceConfig, path: LovelaceSectionPath): LovelaceSectionRawConfig;
   (
     config: LovelaceConfig,
     path: LovelaceContainerPath
@@ -74,6 +95,12 @@ export const findLovelaceContainer: FindLovelaceContainer = ((
   if (!section) {
     throw new Error("Section does not exist");
   }
+  if (path.length === 3) {
+    if (!isStackSection(section)) throw new Error("Section is not a stack");
+    const child = section.sections[path[2]];
+    if (!child) throw new Error("Section does not exist");
+    return child;
+  }
   return section;
 }) as FindLovelaceContainer;
 
@@ -82,6 +109,23 @@ export const updateLovelaceContainer = (
   path: LovelaceContainerPath,
   containerConfig: LovelaceViewRawConfig | LovelaceSectionRawConfig
 ): LovelaceConfig => {
+  if (path.length === 3) {
+    const stackPath: LovelaceSectionPath = [path[0], path[1]];
+    const stack = findLovelaceContainer(config, stackPath);
+    if (!isStackSection(stack)) throw new Error("Section is not a stack");
+    if (!stack.sections[path[2]]) throw new Error("Section does not exist");
+    if ("type" in containerConfig && containerConfig.type === "stack") {
+      throw new Error("Nested section stacks are not supported");
+    }
+    return updateLovelaceContainer(config, stackPath, {
+      ...stack,
+      sections: stack.sections.map((section, index) =>
+        index === path[2]
+          ? (containerConfig as LovelaceSectionRawConfig)
+          : section
+      ),
+    });
+  }
   const { viewIndex, sectionIndex } = parseLovelaceContainerPath(path);
 
   let updated = false;
@@ -132,50 +176,14 @@ export const updateLovelaceItems = <T extends keyof LovelaceItemKeys>(
   path: LovelaceContainerPath,
   items: LovelaceItemKeys[T]
 ): LovelaceConfig => {
-  const { viewIndex, sectionIndex } = parseLovelaceContainerPath(path);
-
-  let updated = false;
-  const newViews = config.views.map((view, vIndex) => {
-    if (vIndex !== viewIndex) return view;
-    if (isStrategyView(view)) {
-      throw new Error(`Can not update ${key} in a strategy view`);
-    }
-    if (sectionIndex === undefined) {
-      updated = true;
-      return {
-        ...view,
-        [key]: items,
-      };
-    }
-
-    if (view.sections === undefined) {
-      throw new Error("Section does not exist");
-    }
-
-    const newSections = view.sections.map((section, sIndex) => {
-      if (sIndex !== sectionIndex) return section;
-      if (isStrategySection(section)) {
-        throw new Error(`Can not update ${key} in a strategy section`);
-      }
-      updated = true;
-      return {
-        ...section,
-        [key]: items,
-      };
-    });
-    return {
-      ...view,
-      sections: newSections,
-    };
-  });
-
-  if (!updated) {
-    throw new Error(`Can not update ${key} in a non-existing view/section`);
+  const container = findLovelaceContainer(config, path);
+  if ("strategy" in container) {
+    throw new Error(`Can not update ${key} in a strategy view/section`);
   }
-  return {
-    ...config,
-    views: newViews,
-  };
+  if ("type" in container && container.type === "stack") {
+    throw new Error("Cards must be added to a section inside the stack");
+  }
+  return updateLovelaceContainer(config, path, { ...container, [key]: items });
 };
 
 export const findLovelaceItems = <T extends keyof LovelaceItemKeys>(
@@ -183,30 +191,26 @@ export const findLovelaceItems = <T extends keyof LovelaceItemKeys>(
   config: LovelaceConfig,
   path: LovelaceContainerPath
 ): LovelaceItemKeys[T] | undefined => {
-  const { viewIndex, sectionIndex } = parseLovelaceContainerPath(path);
-
-  const view = config.views[viewIndex];
-
-  if (!view) {
-    throw new Error("View does not exist");
+  const container = findLovelaceContainer(config, path);
+  if ("strategy" in container) {
+    throw new Error("Can not find cards in a strategy view/section");
   }
-  if (isStrategyView(view)) {
-    throw new Error("Can not find cards in a strategy view");
+  if ("type" in container && container.type === "stack") {
+    throw new Error("Cards must be added to a section inside the stack");
   }
-  if (sectionIndex === undefined) {
-    return view[key] as LovelaceItemKeys[T] | undefined;
-  }
-
-  const section = view.sections?.[sectionIndex];
-
-  if (!section) {
-    throw new Error("Section does not exist");
-  }
-  if (isStrategySection(section)) {
-    throw new Error("Can not find cards in a strategy section");
-  }
-  if (key === "cards") {
-    return section[key as "cards"] as LovelaceItemKeys[T] | undefined;
+  if (path.length === 1 || key === "cards") {
+    return container[key as "cards"] as LovelaceItemKeys[T] | undefined;
   }
   throw new Error(`${key} is not supported in section`);
+};
+
+/** Card editors use the stack's width without changing the child's saved config. */
+export const getCardSectionConfig = (
+  config: LovelaceConfig,
+  path: LovelaceSectionPath
+): LovelaceSectionRawConfig => {
+  const section = findLovelaceContainer(config, path);
+  if (path.length === 2) return section;
+  const stack = findLovelaceContainer(config, [path[0], path[1]]);
+  return { ...section, column_span: stack.column_span };
 };

--- a/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
@@ -21,6 +21,7 @@ import "../../../../components/ha-tab-group";
 import "../../../../components/ha-tab-group-tab";
 import "../../../../components/ha-yaml-editor";
 import type { HaYamlEditor } from "../../../../components/ha-yaml-editor";
+import { isStackSection } from "../../../../data/lovelace/config/section";
 import type { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/section";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
 import { saveConfig } from "../../../../data/lovelace/config/types";
@@ -91,12 +92,12 @@ export class HuiDialogEditSection
 
     this.lovelace = params.lovelace;
 
-    this._config = findLovelaceContainer(this._params.lovelaceConfig, [
-      this._params.viewIndex,
-      this._params.sectionIndex,
-    ]);
+    this._config = findLovelaceContainer(
+      this._params.lovelaceConfig,
+      this._params.path
+    );
     this._viewConfig = findLovelaceContainer(this._params.lovelaceConfig, [
-      this._params.viewIndex,
+      this._params.path[0],
     ]);
     this._initDirtyTracking({ type: "deep" }, this._config);
   }
@@ -140,6 +141,7 @@ export class HuiDialogEditSection
             <hui-section-settings-editor
               .config=${this._config}
               .viewConfig=${this._viewConfig}
+              .inStack=${this._params.path.length === 3}
               @value-changed=${this._configChanged}
             >
             </hui-section-settings-editor>
@@ -207,7 +209,10 @@ export class HuiDialogEditSection
             !this._yamlMode
               ? html`
                   <ha-tab-group @wa-tab-show=${this._handleTabChanged}>
-                    ${TABS.map(
+                    ${(isStackSection(this._config)
+                      ? TABS.slice(0, 1)
+                      : TABS
+                    ).map(
                       (tab) => html`
                         <ha-tab-group-tab
                           slot="nav"
@@ -316,8 +321,10 @@ export class HuiDialogEditSection
       return;
     }
 
-    const fromViewIndex = this._params.viewIndex;
-    const fromSectionIndex = this._params.sectionIndex;
+    const fromPath = this._params.path;
+    const fromViewIndex = fromPath[0];
+    const fromSectionIndex = fromPath[fromPath.length - 1];
+    const fromStackIndex = fromPath.length === 3 ? fromPath[1] : undefined;
 
     // Same dashboard
     if (urlPath === this.lovelace.urlPath) {
@@ -325,11 +332,7 @@ export class HuiDialogEditSection
       const toIndex = toView.sections?.length ?? 0;
       try {
         await this.lovelace.saveConfig(
-          moveSection(
-            oldConfig,
-            [fromViewIndex, fromSectionIndex],
-            [viewIndex, toIndex]
-          )
+          moveSection(oldConfig, fromPath, [viewIndex, toIndex])
         );
         this.lovelace.showToast({
           message: this.hass!.localize(
@@ -361,10 +364,10 @@ export class HuiDialogEditSection
     const oldFromConfig = this.lovelace.config;
     const oldToConfig = selectedDashConfig;
     try {
-      const section = findLovelaceContainer(oldFromConfig, [
-        fromViewIndex,
-        fromSectionIndex,
-      ]) as LovelaceSectionRawConfig;
+      const section = findLovelaceContainer(
+        oldFromConfig,
+        fromPath
+      ) as LovelaceSectionRawConfig;
 
       await saveConfig(
         this.hass!,
@@ -373,7 +376,12 @@ export class HuiDialogEditSection
       );
 
       await this.lovelace.saveConfig(
-        deleteSection(oldFromConfig, fromViewIndex, fromSectionIndex)
+        deleteSection(
+          oldFromConfig,
+          fromViewIndex,
+          fromSectionIndex,
+          fromStackIndex
+        )
       );
 
       this.lovelace.showToast({
@@ -428,7 +436,7 @@ export class HuiDialogEditSection
     }
     const newConfig = updateLovelaceContainer(
       this._params.lovelaceConfig,
-      [this._params.viewIndex, this._params.sectionIndex],
+      this._params.path,
       this._config
     );
 

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -13,6 +13,7 @@ import type {
 import {
   DEFAULT_SECTION_BACKGROUND_OPACITY,
   resolveSectionBackground,
+  isStackSection,
   type LovelaceSectionRawConfig,
 } from "../../../../data/lovelace/config/section";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
@@ -33,6 +34,8 @@ export class HuiDialogEditSection extends LitElement {
   @property({ attribute: false }) public config!: LovelaceSectionRawConfig;
 
   @property({ attribute: false }) public viewConfig!: LovelaceViewConfig;
+
+  @property({ type: Boolean, attribute: "in-stack" }) public inStack = false;
 
   private _schema = memoizeOne(
     (maxColumns: number, localize: LocalizeFunc) =>
@@ -115,6 +118,10 @@ export class HuiDialogEditSection extends LitElement {
     const schema = this._schema(
       this.viewConfig.max_columns || 4,
       this._localize
+    ).filter((field) =>
+      isStackSection(this.config)
+        ? field.name === "column_span"
+        : !this.inStack || field.name !== "column_span"
     );
 
     return html`
@@ -148,8 +155,13 @@ export class HuiDialogEditSection extends LitElement {
 
     const newConfig: LovelaceSectionRawConfig = {
       ...this.config,
-      column_span: newData.column_span,
+      column_span: this.inStack ? this.config.column_span : newData.column_span,
     };
+
+    if (isStackSection(this.config)) {
+      fireEvent(this, "value-changed", { value: newConfig });
+      return;
+    }
 
     if (newData.background_enabled) {
       const hasCustomColor =

--- a/src/panels/lovelace/editor/section-editor/show-edit-section-dialog.ts
+++ b/src/panels/lovelace/editor/section-editor/show-edit-section-dialog.ts
@@ -1,13 +1,13 @@
 import { fireEvent } from "../../../../common/dom/fire_event";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
+import type { LovelaceSectionPath } from "../lovelace-path";
 import type { Lovelace } from "../../types";
 
 export interface EditSectionDialogParams {
   lovelace: Lovelace;
   lovelaceConfig: LovelaceConfig;
   saveConfig: (config: LovelaceConfig) => void;
-  viewIndex: number;
-  sectionIndex: number;
+  path: LovelaceSectionPath;
 }
 
 const importEditSectionDialog = () => import("./hui-dialog-edit-section");

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -18,7 +18,10 @@ import type { HuiCard } from "../cards/hui-card";
 import { computeCardGridSize } from "../common/compute-card-grid-size";
 import "../components/hui-card-edit-mode";
 import { moveCard } from "../editor/config-util";
-import type { LovelaceCardPath } from "../editor/lovelace-path";
+import type {
+  LovelaceCardPath,
+  LovelaceSectionPath,
+} from "../editor/lovelace-path";
 import type { Lovelace } from "../types";
 
 const CARD_SORTABLE_OPTIONS: HaSortableOptions = {
@@ -47,6 +50,12 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
   @property({ type: Number }) public index?: number;
 
   @property({ attribute: false }) public viewIndex?: number;
+
+  @property({ attribute: false }) public sectionPath?: LovelaceSectionPath;
+
+  private get _path(): LovelaceSectionPath {
+    return this.sectionPath ?? [this.viewIndex!, this.index!];
+  }
 
   @property({ attribute: false }) public isStrategy = false;
 
@@ -110,11 +119,7 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
 
               const { rows, columns } = computeCardGridSize(gridOptions);
 
-              const cardPath: LovelaceCardPath = [
-                this.viewIndex!,
-                this.index!,
-                idx,
-              ];
+              const cardPath: LovelaceCardPath = [...this._path, idx];
               return html`
                 <div
                   style=${styleMap({
@@ -176,16 +181,17 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
     const { oldIndex, newIndex } = ev.detail;
     const newConfig = moveCard(
       this.lovelace!.config,
-      [this.viewIndex!, this.index!, oldIndex],
-      [this.viewIndex!, this.index!, newIndex]
+      [...this._path, oldIndex],
+      [...this._path, newIndex]
     );
     this.lovelace!.saveConfig(newConfig);
   }
 
   private _cardAdded(ev) {
+    ev.stopPropagation();
     const { index, data } = ev.detail;
     const oldPath = data as LovelaceCardPath;
-    const newPath = [this.viewIndex!, this.index!, index] as LovelaceCardPath;
+    const newPath = [...this._path, index] as LovelaceCardPath;
     const newConfig = moveCard(this.lovelace!.config, oldPath, newPath);
     this.lovelace!.saveConfig(newConfig);
   }

--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -14,7 +14,10 @@ import type {
   LovelaceSectionConfig,
   LovelaceSectionRawConfig,
 } from "../../../data/lovelace/config/section";
-import { isStrategySection } from "../../../data/lovelace/config/section";
+import {
+  isStackSection,
+  isStrategySection,
+} from "../../../data/lovelace/config/section";
 import type { HomeAssistant } from "../../../types";
 import { ConditionalListenerMixin } from "../../../mixins/conditional-listener-mixin";
 import "../cards/hui-card";
@@ -24,7 +27,11 @@ import { showCreateCardDialog } from "../editor/card-editor/show-create-card-dia
 import { showEditCardDialog } from "../editor/card-editor/show-edit-card-dialog";
 import { addCard, replaceCard } from "../editor/config-util";
 import { performDeleteCard } from "../editor/delete-card";
-import { parseLovelaceCardPath } from "../editor/lovelace-path";
+import type { LovelaceSectionPath } from "../editor/lovelace-path";
+import {
+  getCardSectionConfig,
+  parseLovelaceCardPath,
+} from "../editor/lovelace-path";
 import {
   checkStrategyShouldRegenerate,
   generateLovelaceSectionStrategy,
@@ -56,6 +63,12 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
   @property({ type: Number }) public index!: number;
 
   @property({ attribute: false }) public viewIndex!: number;
+
+  @property({ attribute: false }) public sectionPath?: LovelaceSectionPath;
+
+  public get path(): LovelaceSectionPath {
+    return this.sectionPath ?? [this.viewIndex, this.index];
+  }
 
   @state() private _cards: HuiCard[] = [];
 
@@ -165,6 +178,15 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
 
     // If no layout element, we're still creating one
     if (this._layoutElement) {
+      if (
+        changedProperties.has("sectionPath") ||
+        changedProperties.has("index") ||
+        changedProperties.has("viewIndex")
+      ) {
+        this._layoutElement.sectionPath = this.path;
+        this._layoutElement.index = this.index;
+        this._layoutElement.viewIndex = this.viewIndex;
+      }
       // Config has not changed. Just props
       if (changedProperties.has("hass")) {
         this._cards.forEach((element) => {
@@ -251,6 +273,8 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
     this._layoutElement!.isStrategy = isStrategy;
     this._layoutElement!.hass = this.hass;
     this._layoutElement!.lovelace = this.lovelace;
+    this._layoutElement!.sectionPath = this.path;
+    this._layoutElement!.preview = this.preview;
     this._layoutElement!.index = this.index;
     this._layoutElement!.viewIndex = this.viewIndex;
     this._layoutElement!.cards = this._cards;
@@ -293,7 +317,9 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
     const allCardsHidden =
       this._cards.length > 0 && this._cards.every((card) => card.hidden);
 
-    this._setElementVisibility(!allCardsHidden);
+    const allSectionsHidden =
+      isStackSection(this._config) && this._layoutElement.hidden;
+    this._setElementVisibility(!allCardsHidden && !allSectionsHidden);
   }
 
   private _setElementVisibility(visible: boolean) {
@@ -317,13 +343,17 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       config
     ) as LovelaceSectionElement;
     this._layoutElementType = config.type;
+    this._layoutElement.addEventListener("section-visibility-changed", (ev) => {
+      ev.stopPropagation();
+      this._updateVisibility();
+    });
     this._layoutElement.addEventListener("ll-create-card", (ev) => {
       ev.stopPropagation();
       if (!this.lovelace) return;
       showCreateCardDialog(this, {
         lovelaceConfig: this.lovelace.config,
         saveConfig: this.lovelace.saveConfig,
-        path: [this.viewIndex, this.index],
+        path: this.path,
         suggestedCards: ev.detail?.suggested,
       });
     });
@@ -331,7 +361,10 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       ev.stopPropagation();
       if (!this.lovelace) return;
       const { cardIndex } = parseLovelaceCardPath(ev.detail.path);
-      const sectionConfig = this.config;
+      const sectionConfig = getCardSectionConfig(
+        this.lovelace.config,
+        this.path
+      );
       if (isStrategySection(sectionConfig)) {
         return;
       }
@@ -341,7 +374,7 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
         saveCardConfig: async (newCardConfig) => {
           const newConfig = replaceCard(
             this.lovelace!.config,
-            [this.viewIndex, this.index, cardIndex],
+            [...this.path, cardIndex],
             newCardConfig
           );
           await this.lovelace!.saveConfig(newConfig);
@@ -359,7 +392,10 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       ev.stopPropagation();
       if (!this.lovelace) return;
       const { cardIndex } = parseLovelaceCardPath(ev.detail.path);
-      const sectionConfig = this.config;
+      const sectionConfig = getCardSectionConfig(
+        this.lovelace.config,
+        this.path
+      );
       if (isStrategySection(sectionConfig)) {
         return;
       }
@@ -370,7 +406,7 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
         saveCardConfig: async (newCardConfig) => {
           const newConfig = addCard(
             this.lovelace!.config,
-            [this.viewIndex, this.index],
+            this.path,
             newCardConfig
           );
           await this.lovelace!.saveConfig(newConfig);
@@ -384,7 +420,10 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       ev.stopPropagation();
       if (!this.lovelace) return;
       const { cardIndex } = parseLovelaceCardPath(ev.detail.path);
-      const sectionConfig = this.config;
+      const sectionConfig = getCardSectionConfig(
+        this.lovelace.config,
+        this.path
+      );
 
       if (isStrategySection(sectionConfig)) {
         return;

--- a/src/panels/lovelace/sections/hui-stack-section.ts
+++ b/src/panels/lovelace/sections/hui-stack-section.ts
@@ -1,0 +1,275 @@
+import type { PropertyValues } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+import { repeat } from "lit/directives/repeat";
+import type { HASSDomEvent } from "../../../common/dom/fire_event";
+import { fireEvent } from "../../../common/dom/fire_event";
+import "../../../components/ha-sortable";
+import type { HaSortableOptions } from "../../../components/ha-sortable";
+import type { LovelaceSectionElement } from "../../../data/lovelace";
+import type {
+  LovelaceSectionConfig,
+  LovelaceSectionRawConfig,
+} from "../../../data/lovelace/config/section";
+import { isStackSection } from "../../../data/lovelace/config/section";
+import type { HomeAssistant } from "../../../types";
+import "../components/hui-section-edit-mode";
+import { addSection, moveSection } from "../editor/config-util";
+import type { LovelaceSectionPath } from "../editor/lovelace-path";
+import { findLovelaceContainer } from "../editor/lovelace-path";
+import type { Lovelace } from "../types";
+import { generateDefaultSection } from "../views/default-section";
+import type { HuiSection } from "./hui-section";
+import { SECTION_SORTABLE_OPTIONS } from "./section-sortable-options";
+import {
+  renderCreateSectionButton,
+  createSectionButtonStyles,
+} from "./render-create-section-button";
+import { renderSection, sectionStyles } from "./render-section";
+
+@customElement("hui-stack-section")
+export class StackSection extends LitElement implements LovelaceSectionElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public lovelace?: Lovelace;
+
+  @property({ attribute: false }) public viewIndex?: number;
+
+  @property({ attribute: false }) public index?: number;
+
+  @property({ attribute: false }) public sectionPath?: LovelaceSectionPath;
+
+  @property({ attribute: false }) public isStrategy = false;
+
+  @property({ type: Boolean }) public preview = false;
+
+  @state() private _sections: HuiSection[] = [];
+
+  private readonly _sortableOptions: HaSortableOptions = {
+    ...SECTION_SORTABLE_OPTIONS,
+    group: {
+      name: "section",
+      put: (_to, _from, item) => {
+        if (
+          !this.lovelace ||
+          !("sortableData" in item) ||
+          !Array.isArray(item.sortableData)
+        ) {
+          return false;
+        }
+        const path = item.sortableData as LovelaceSectionPath;
+        return !isStackSection(
+          findLovelaceContainer(this.lovelace.config, path)
+        );
+      },
+    },
+  };
+
+  public setConfig(config: LovelaceSectionConfig): void {
+    if (!isStackSection(config) || !Array.isArray(config.sections)) {
+      throw new Error("A section stack requires a sections array");
+    }
+    if (config.sections.some(isStackSection)) {
+      throw new Error("Nested section stacks are not supported");
+    }
+    this._sections = config.sections.map((section) =>
+      this._createSection(section)
+    );
+  }
+
+  private _createSection(config: LovelaceSectionRawConfig): HuiSection {
+    const section = document.createElement("hui-section");
+    section.config = config;
+    section.addEventListener(
+      "ll-rebuild",
+      (ev) => {
+        ev.stopPropagation();
+        this._sections = this._sections.map((current) =>
+          current === section ? this._createSection(config) : current
+        );
+      },
+      { once: true }
+    );
+    return section;
+  }
+
+  protected willUpdate(changed: PropertyValues): void {
+    if (
+      changed.has("_sections") ||
+      changed.has("hass") ||
+      changed.has("lovelace") ||
+      changed.has("preview") ||
+      changed.has("index") ||
+      changed.has("viewIndex")
+    ) {
+      this._sections.forEach((section, index) => {
+        section.hass = this.hass;
+        section.lovelace = this.lovelace;
+        section.preview = this.preview;
+        section.viewIndex = this.viewIndex!;
+        section.index = index;
+        if (
+          changed.has("_sections") ||
+          changed.has("index") ||
+          changed.has("viewIndex")
+        ) {
+          section.sectionPath = [this.viewIndex!, this.index!, index];
+        }
+      });
+    }
+  }
+
+  protected updated(): void {
+    this._updateVisibility();
+  }
+
+  protected render() {
+    const editMode = Boolean(this.lovelace?.editMode && !this.isStrategy);
+    return html`
+      <ha-sortable
+        .disabled=${!editMode}
+        .options=${this._sortableOptions}
+        draggable-selector=".section"
+        handle-selector=".handle"
+        @item-moved=${this._sectionMoved}
+        @item-added=${this._sectionAdded}
+        @item-removed=${this._sectionRemoved}
+      >
+        <div
+          class="sections ${classMap({ empty: editMode && this._sections.length === 0 })}"
+          @section-visibility-changed=${this._sectionVisibilityChanged}
+        >
+          ${repeat(
+            this._sections,
+            (section) => section,
+            (section, index) => html`
+              <div class="section" .sortableData=${section.path}>
+                ${
+                  editMode
+                    ? html`
+                        <hui-section-edit-mode
+                          .hass=${this.hass}
+                          .lovelace=${this.lovelace!}
+                          .viewIndex=${this.viewIndex!}
+                          .index=${index}
+                          .stackIndex=${this.index}
+                        >
+                          ${renderSection(this.hass, section)}
+                        </hui-section-edit-mode>
+                      `
+                    : renderSection(this.hass, section)
+                }
+              </div>
+            `
+          )}
+          ${
+            editMode
+              ? renderCreateSectionButton(
+                  this.hass.localize(
+                    "ui.panel.lovelace.editor.section.create_section"
+                  ),
+                  this._addSection
+                )
+              : nothing
+          }
+        </div>
+      </ha-sortable>
+    `;
+  }
+
+  private _sectionVisibilityChanged(
+    ev: HASSDomEvent<HASSDomEvents["section-visibility-changed"]>
+  ): void {
+    ev.stopPropagation();
+    this._updateVisibility();
+  }
+
+  private _updateVisibility(): void {
+    const hidden =
+      !this.preview &&
+      this._sections.length > 0 &&
+      this._sections.every((section) => section.hidden);
+    if (this.hidden === hidden) return;
+    this.hidden = hidden;
+    fireEvent(this, "section-visibility-changed", { value: !hidden });
+  }
+
+  private _sectionMoved(ev: HASSDomEvent<HASSDomEvents["item-moved"]>): void {
+    ev.stopPropagation();
+    const { oldIndex, newIndex } = ev.detail;
+    this.lovelace!.saveConfig(
+      moveSection(
+        this.lovelace!.config,
+        [this.viewIndex!, this.index!, oldIndex],
+        [this.viewIndex!, this.index!, newIndex]
+      )
+    );
+  }
+
+  private _sectionAdded(ev: HASSDomEvent<HASSDomEvents["item-added"]>): void {
+    ev.stopPropagation();
+    this.lovelace!.saveConfig(
+      moveSection(
+        this.lovelace!.config,
+        ev.detail.data as LovelaceSectionPath,
+        [this.viewIndex!, this.index!, ev.detail.index]
+      )
+    );
+  }
+
+  private _sectionRemoved(
+    ev: HASSDomEvent<HASSDomEvents["item-removed"]>
+  ): void {
+    ev.stopPropagation();
+    // The receiving container saves the move.
+  }
+
+  private _addSection(): void {
+    this.lovelace!.saveConfig(
+      addSection(
+        this.lovelace!.config,
+        this.viewIndex!,
+        generateDefaultSection(this.hass.localize),
+        this.index
+      )
+    );
+  }
+
+  static styles = [
+    sectionStyles,
+    createSectionButtonStyles,
+    css`
+      :host {
+        display: block;
+      }
+      :host([hidden]) {
+        display: none;
+      }
+      ha-sortable {
+        display: contents;
+      }
+      .sections {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ha-view-sections-row-gap, 24px);
+      }
+      .create-section {
+        margin: var(--ha-space-2);
+        width: auto;
+      }
+      .sections.empty {
+        padding: var(--ha-space-4);
+      }
+      .section {
+        min-width: 0;
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-stack-section": StackSection;
+  }
+}

--- a/src/panels/lovelace/sections/render-create-section-button.ts
+++ b/src/panels/lovelace/sections/render-create-section-button.ts
@@ -1,0 +1,51 @@
+import { mdiViewGridPlus } from "@mdi/js";
+import { css, html } from "lit";
+import "../../../components/ha-ripple";
+import "../../../components/ha-svg-icon";
+
+export const renderCreateSectionButton = (
+  label: string,
+  action: () => void,
+  icon = mdiViewGridPlus,
+  kind: "section" | "stack" = "section"
+) => html`
+  <button
+    class="create-section ${kind === "stack" ? "create-stack" : ""}"
+    @click=${action}
+    aria-label=${label}
+    .title=${label}
+  >
+    <ha-ripple></ha-ripple>
+    <ha-svg-icon .path=${icon}></ha-svg-icon>
+  </button>
+`;
+
+export const createSectionButtonStyles = css`
+  .create-section {
+    display: block;
+    position: relative;
+    outline: none;
+    background: none;
+    cursor: pointer;
+    border-radius: var(--ha-section-border-radius, var(--ha-border-radius-xl));
+    border: 2px dashed var(--primary-color);
+    order: 1;
+    height: calc(var(--row-height) + 2 * (var(--row-gap) + 2px));
+    padding: 8px;
+    box-sizing: border-box;
+    width: 100%;
+    --ha-ripple-color: var(--primary-color);
+    --ha-ripple-hover-opacity: 0.04;
+    --ha-ripple-pressed-opacity: 0.12;
+  }
+
+  .create-section:focus {
+    border: 2px solid var(--primary-color);
+  }
+
+  .create-stack,
+  .create-stack:focus {
+    border-color: var(--cyan-color);
+    --ha-ripple-color: var(--cyan-color);
+  }
+`;

--- a/src/panels/lovelace/sections/render-section.ts
+++ b/src/panels/lovelace/sections/render-section.ts
@@ -1,0 +1,53 @@
+import { css, html, nothing } from "lit";
+import { classMap } from "lit/directives/class-map";
+import type { HomeAssistant } from "../../../types";
+import type { HuiSection } from "./hui-section";
+import "./hui-section-background";
+
+export const renderSection = (
+  hass: HomeAssistant,
+  section: HuiSection,
+  alignBackground = false
+) => {
+  const hasBackground = section.config.background !== undefined;
+
+  return html`
+    <div
+      class="section-container ${classMap({
+        "has-background": hasBackground,
+        "align-background": alignBackground,
+      })}"
+    >
+      ${
+        hasBackground
+          ? html`<hui-section-background
+              .hass=${hass}
+              .background=${section.config.background}
+              .theme=${section.config.theme}
+            ></hui-section-background>`
+          : nothing
+      }
+      ${section}
+    </div>
+  `;
+};
+
+export const sectionStyles = css`
+  .section:has(> .section-container > hui-section[hidden]) {
+    display: none;
+  }
+
+  .section-container {
+    position: relative;
+  }
+
+  .section-container.has-background {
+    padding: var(--ha-space-2);
+    border-radius: var(--ha-section-border-radius, var(--ha-border-radius-xl));
+  }
+
+  .section-container.align-background {
+    margin-top: var(--ha-space-2);
+    margin-bottom: var(--ha-space-2);
+  }
+`;

--- a/src/panels/lovelace/sections/section-sortable-options.ts
+++ b/src/panels/lovelace/sections/section-sortable-options.ts
@@ -1,0 +1,7 @@
+import type { HaSortableOptions } from "../../../components/ha-sortable";
+
+// Fallback dragging resolves drop targets through the sections' shadow roots.
+export const SECTION_SORTABLE_OPTIONS: HaSortableOptions = {
+  forceFallback: true,
+  fallbackOnBody: true,
+};

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -1,6 +1,6 @@
 import { ResizeController } from "@lit-labs/observers/resize-controller";
 import { ContextProvider } from "@lit/context";
-import { mdiEyeOff, mdiViewGridPlus } from "@mdi/js";
+import { mdiEyeOff, mdiFormatListGroupPlus } from "@mdi/js";
 import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -11,12 +11,12 @@ import memoizeOne from "memoize-one";
 import { clamp } from "../../../common/number/clamp";
 import { getHistoryState, updateHistoryState } from "../../../common/navigate";
 import "../../../components/ha-icon-button";
-import "../../../components/ha-ripple";
 import "../../../components/ha-sortable";
 import "../../../components/ha-svg-icon";
 import { maxColumnsContext } from "../common/context";
 import type { LovelaceViewElement } from "../../../data/lovelace";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
+import { isStackSection } from "../../../data/lovelace/config/section";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
 import type { HuiBadge } from "../badges/hui-badge";
@@ -24,14 +24,22 @@ import type { HuiCard } from "../cards/hui-card";
 import "../components/hui-badge-edit-mode";
 import "../components/hui-section-edit-mode";
 import { addSection, moveCard, moveSection } from "../editor/config-util";
-import type { LovelaceCardPath } from "../editor/lovelace-path";
+import type {
+  LovelaceCardPath,
+  LovelaceSectionPath,
+} from "../editor/lovelace-path";
 import {
   findLovelaceItems,
   getLovelaceContainerPath,
   parseLovelaceCardPath,
 } from "../editor/lovelace-path";
 import type { HuiSection } from "../sections/hui-section";
-import "../sections/hui-section-background";
+import { SECTION_SORTABLE_OPTIONS } from "../sections/section-sortable-options";
+import {
+  renderCreateSectionButton,
+  createSectionButtonStyles,
+} from "../sections/render-create-section-button";
+import { renderSection, sectionStyles } from "../sections/render-section";
 import type { Lovelace } from "../types";
 import { generateDefaultSection } from "./default-section";
 import "./hui-view-footer";
@@ -253,7 +261,9 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
         <div class="container">
           <ha-sortable
             .disabled=${!editMode}
+            .options=${SECTION_SORTABLE_OPTIONS}
             @item-moved=${this._sectionMoved}
+            @item-added=${this._sectionAdded}
             group="section"
             handle-selector=".handle"
             draggable-selector=".section"
@@ -277,6 +287,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
                   return html`
                     <div
                       class="section"
+                      .sortableData=${section.path}
                       style=${styleMap({
                         "--column-span": columnSpan,
                         "--row-span": rowSpan,
@@ -290,14 +301,17 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
                                 .lovelace=${this.lovelace}
                                 .index=${idx}
                                 .viewIndex=${this.index}
+                                .stack=${isStackSection(section.config)}
                               >
-                                ${this._renderSection(
+                                ${renderSection(
+                                  this.hass,
                                   section,
                                   sectionNeedsMargin.has(idx)
                                 )}
                               </hui-section-edit-mode>
                             `
-                          : this._renderSection(
+                          : renderSection(
+                              this.hass,
                               section,
                               sectionNeedsMargin.has(idx)
                             )
@@ -323,19 +337,20 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
                               )}
                             </p>
                           </div>
-                          <button
-                            class="create-section"
-                            @click=${this._createSection}
-                            aria-label=${this.hass.localize(
+                          ${renderCreateSectionButton(
+                            this.hass.localize(
                               "ui.panel.lovelace.editor.section.create_section"
-                            )}
-                            .title=${this.hass.localize(
-                              "ui.panel.lovelace.editor.section.create_section"
-                            )}
-                          >
-                            <ha-ripple></ha-ripple>
-                            <ha-svg-icon .path=${mdiViewGridPlus}></ha-svg-icon>
-                          </button>
+                            ),
+                            this._createSection
+                          )}
+                          ${renderCreateSectionButton(
+                            this.hass.localize(
+                              "ui.panel.lovelace.editor.section.create_stack"
+                            ),
+                            this._createStack,
+                            mdiFormatListGroupPlus,
+                            "stack"
+                          )}
                         </div>
                       </ha-sortable>
                     `
@@ -445,30 +460,6 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     })
   );
 
-  private _renderSection(section: HuiSection, alignBackground: boolean) {
-    const hasBackground = section.config.background !== undefined;
-
-    return html`
-      <div
-        class="section-container ${classMap({
-          "has-background": hasBackground,
-          "align-background": alignBackground,
-        })}"
-      >
-        ${
-          hasBackground
-            ? html`<hui-section-background
-                .hass=${this.hass}
-                .background=${section.config.background}
-                .theme=${section.config.theme}
-              ></hui-section-background>`
-            : nothing
-        }
-        ${section}
-      </div>
-    `;
-  }
-
   private _createSection(): void {
     const newConfig = addSection(
       this.lovelace!.config,
@@ -476,6 +467,26 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       generateDefaultSection(this.hass.localize, true)
     );
     this.lovelace!.saveConfig(newConfig);
+  }
+
+  private _createStack(): void {
+    this.lovelace!.saveConfig(
+      addSection(this.lovelace!.config, this.index!, {
+        type: "stack",
+        sections: [],
+      })
+    );
+  }
+
+  private _sectionAdded(ev: CustomEvent<HASSDomEvents["item-added"]>): void {
+    ev.stopPropagation();
+    this.lovelace!.saveConfig(
+      moveSection(
+        this.lovelace!.config,
+        ev.detail.data as LovelaceSectionPath,
+        [this.index!, ev.detail.index]
+      )
+    );
   }
 
   private _sectionMoved(ev: CustomEvent) {
@@ -532,6 +543,8 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
   };
 
   static styles = css`
+    ${sectionStyles}
+    ${createSectionButtonStyles}
     :host {
       --row-height: var(--ha-view-sections-row-height, 56px);
       --row-gap: var(--ha-view-sections-row-gap, 24px);
@@ -574,27 +587,6 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       );
       grid-column: span var(--column-span);
       grid-row: span var(--row-span);
-    }
-
-    .section:has(hui-section[hidden]) {
-      display: none;
-    }
-
-    .section-container {
-      position: relative;
-    }
-
-    .section-container.has-background {
-      padding: var(--ha-space-2);
-      border-radius: var(
-        --ha-section-border-radius,
-        var(--ha-border-radius-xl)
-      );
-    }
-
-    .section-container.align-background {
-      margin-top: var(--ha-space-2);
-      margin-bottom: var(--ha-space-2);
     }
 
     .container {
@@ -694,6 +686,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       display: flex;
       flex-direction: column;
       margin-top: 36px;
+      gap: var(--row-gap);
     }
 
     .create-section-container .card {
@@ -736,31 +729,6 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       font-weight: var(--ha-font-weight-normal);
       line-height: var(--ha-line-height-normal);
       text-align: center;
-    }
-
-    .create-section {
-      display: block;
-      position: relative;
-      outline: none;
-      background: none;
-      cursor: pointer;
-      border-radius: var(
-        --ha-section-border-radius,
-        var(--ha-border-radius-xl)
-      );
-      border: 2px dashed var(--primary-color);
-      order: 1;
-      height: calc(var(--row-height) + 2 * (var(--row-gap) + 2px));
-      padding: 8px;
-      box-sizing: border-box;
-      width: 100%;
-      --ha-ripple-color: var(--primary-color);
-      --ha-ripple-hover-opacity: 0.04;
-      --ha-ripple-pressed-opacity: 0.12;
-    }
-
-    .create-section:focus {
-      border: 2px solid var(--primary-color);
     }
 
     .sortable-ghost {

--- a/src/panels/lovelace/views/sections-background-alignment.ts
+++ b/src/panels/lovelace/views/sections-background-alignment.ts
@@ -1,3 +1,4 @@
+import { isStackSection } from "../../../data/lovelace/config/section";
 import type { HuiSection } from "../sections/hui-section";
 
 /**
@@ -17,6 +18,11 @@ export function computeSectionsBackgroundAlignment(
 
   // Single column layout never has side-by-side sections
   if (columnCount <= 1) return sectionsNeedingMargin;
+
+  // The first child supplies the background at the top of an invisible stack.
+  const backgrounds = sections.map(({ config }) =>
+    isStackSection(config) ? config.sections[0]?.background : config.background
+  );
 
   // Group visible sections into rows by accumulating column spans
   const rows: { indices: number[]; hasBackground: boolean }[] = [];
@@ -39,7 +45,7 @@ export function computeSectionsBackgroundAlignment(
     columnsUsed += span;
     currentRow.indices.push(idx);
 
-    if (section.config.background !== undefined) {
+    if (backgrounds[idx] !== undefined) {
       currentRow.hasBackground = true;
     }
   }
@@ -49,7 +55,7 @@ export function computeSectionsBackgroundAlignment(
   for (const row of rows) {
     if (!row.hasBackground) continue;
     for (const idx of row.indices) {
-      if (sections[idx].config.background === undefined) {
+      if (backgrounds[idx] === undefined) {
         sectionsNeedingMargin.add(idx);
       }
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9832,6 +9832,9 @@
             "add_card": "[%key:ui::panel::lovelace::editor::edit_card::add%]",
             "drop_card_create_section": "Drop card here to create a new section",
             "create_section": "Create section",
+            "create_stack": "Add stack",
+            "wrap_in_stack": "Wrap in stack",
+            "remove_from_stack": "Remove from stack",
             "default_section_title": "New section",
             "imported_cards_title": "Imported cards",
             "imported_cards_description": "These cards are imported from another view. They will only be displayed in edit mode. Move them into sections to display them in your view."

--- a/test/panels/lovelace/editor/section-stack.test.ts
+++ b/test/panels/lovelace/editor/section-stack.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import deepFreeze from "deep-freeze";
+import type { LovelaceConfig } from "../../../../src/data/lovelace/config/types";
+import type { LovelaceStackSectionConfig } from "../../../../src/data/lovelace/config/section";
+import {
+  addCard,
+  addSection,
+  deleteCard,
+  deleteSection,
+  duplicateSection,
+  moveCard,
+  moveCardToContainer,
+  moveSection,
+  replaceCard,
+  wrapSectionInStack,
+} from "../../../../src/panels/lovelace/editor/config-util";
+import {
+  findLovelaceContainer,
+  findLovelaceItems,
+  getCardSectionConfig,
+  parseLovelaceCardPath,
+  updateLovelaceContainer,
+} from "../../../../src/panels/lovelace/editor/lovelace-path";
+
+const fixture = (): LovelaceConfig =>
+  deepFreeze({
+    views: [
+      {
+        type: "sections",
+        sections: [
+          { type: "grid", cards: [{ type: "heading", heading: "Outside" }] },
+          {
+            type: "stack",
+            column_span: 2,
+            sections: [
+              {
+                type: "grid",
+                column_span: 3,
+                background: { color: "red" },
+                cards: [{ type: "heading", heading: "A" }],
+              },
+              { type: "grid", cards: [{ type: "heading", heading: "B" }] },
+            ],
+          },
+          { type: "stack", sections: [{ type: "grid", cards: [] }] },
+        ],
+      },
+    ],
+  });
+const stack = (config: LovelaceConfig, index = 1) =>
+  findLovelaceContainer(config, [0, index]) as LovelaceStackSectionConfig;
+
+describe("section stack editing", () => {
+  it("wraps a section in place without losing its settings or saved width", () => {
+    const config = updateLovelaceContainer(fixture(), [0, 0], {
+      type: "grid",
+      column_span: 2,
+      background: { color: "blue", opacity: 30 },
+      theme: "Night",
+      cards: [{ type: "heading", heading: "Original" }],
+    });
+    deepFreeze(config);
+    const section = findLovelaceContainer(config, [0, 0]);
+    const updated = wrapSectionInStack(config, 0, 0);
+    expect(stack(updated, 0).column_span).toBe(2);
+    expect(stack(updated, 0).sections).toEqual([section]);
+    expect(stack(updated, 0).sections[0]).toBe(section);
+    expect(stack(updated, 0).background).toBeUndefined();
+    expect(stack(updated, 0).theme).toBeUndefined();
+    expect(findLovelaceContainer(updated, [0, 1])).toBe(stack(config));
+    expect(findLovelaceContainer(config, [0, 0])).toBe(section);
+  });
+
+  it("removes a wrapped section immediately after its stack and retains the empty stack", () => {
+    const config = fixture();
+    const wrapped = wrapSectionInStack(config, 0, 0);
+    const removed = moveSection(wrapped, [0, 0, 0], [0, 1]);
+    expect(stack(removed, 0).sections).toEqual([]);
+    expect(findLovelaceContainer(removed, [0, 1])).toBe(
+      findLovelaceContainer(config, [0, 0])
+    );
+    expect(stack(removed, 2)).toBe(stack(config));
+  });
+
+  it("rejects wrapping an existing stack", () => {
+    expect(() => wrapSectionInStack(fixture(), 0, 1)).toThrow(
+      "Nested section stacks"
+    );
+  });
+
+  it("addresses a child and its cards without mutating the configuration", () => {
+    const config = fixture();
+    expect(parseLovelaceCardPath([0, 1, 0, 0])).toEqual({
+      viewIndex: 0,
+      sectionIndex: 1,
+      subsectionIndex: 0,
+      cardIndex: 0,
+    });
+    const updated = replaceCard(config, [0, 1, 0, 0], {
+      type: "heading",
+      heading: "Edited",
+    });
+    expect(findLovelaceItems("cards", updated, [0, 1, 0])).toEqual([
+      { type: "heading", heading: "Edited" },
+    ]);
+    expect(stack(updated).sections[1]).toBe(stack(config).sections[1]);
+    expect(stack(config).sections[0].column_span).toBe(3);
+  });
+
+  it("reuses card add, delete, and move operations for children", () => {
+    let config = addCard(fixture(), [0, 1, 0], { type: "button" });
+    config = moveCard(config, [0, 1, 0, 1], [0, 1, 1, 0]);
+    expect(findLovelaceItems("cards", config, [0, 1, 1])?.[0].type).toBe(
+      "button"
+    );
+    config = deleteCard(config, [0, 1, 1, 0]);
+    expect(findLovelaceItems("cards", config, [0, 1, 1])).toHaveLength(1);
+  });
+
+  it("allows moving cards between children of the same stack", () => {
+    const updated = moveCardToContainer(fixture(), [0, 1, 0, 0], [0, 1, 1]);
+    expect(findLovelaceItems("cards", updated, [0, 1, 0])).toHaveLength(0);
+    expect(findLovelaceItems("cards", updated, [0, 1, 1])).toHaveLength(2);
+    expect(() =>
+      moveCardToContainer(fixture(), [0, 1, 0, 0], [0, 1, 0])
+    ).toThrow();
+  });
+
+  it("moves cards between ordinary sections and stack children", () => {
+    let config = moveCard(fixture(), [0, 0, 0], [0, 1, 0, 1]);
+    config = moveCard(config, [0, 1, 0, 0], [0, 0, 0]);
+    expect(findLovelaceItems("cards", config, [0, 0])).toEqual([
+      { type: "heading", heading: "A" },
+    ]);
+    expect(findLovelaceItems("cards", config, [0, 1, 0])).toEqual([
+      { type: "heading", heading: "Outside" },
+    ]);
+  });
+
+  it("uses the stack width in card editors without overwriting the child", () => {
+    const config = fixture();
+    expect(getCardSectionConfig(config, [0, 1, 0]).column_span).toBe(2);
+    expect(stack(config).sections[0].column_span).toBe(3);
+    expect(getCardSectionConfig(config, [0, 0])).toBe(
+      findLovelaceContainer(config, [0, 0])
+    );
+  });
+
+  it("updates only the selected child's settings", () => {
+    const config = fixture();
+    const child = findLovelaceContainer(config, [0, 1, 0]);
+    const updated = updateLovelaceContainer(config, [0, 1, 0], {
+      ...child,
+      theme: "Night",
+    });
+    expect(stack(updated).sections[0].theme).toBe("Night");
+    expect(stack(updated).sections[1]).toBe(stack(config).sections[1]);
+    expect(stack(updated).column_span).toBe(2);
+  });
+
+  it("adds, duplicates, and deletes children through existing section helpers", () => {
+    let config = addSection(fixture(), 0, { type: "grid", cards: [] }, 1);
+    config = duplicateSection(config, 0, 0, 1);
+    expect(stack(config).sections).toHaveLength(4);
+    expect(stack(config).sections[1]).toEqual(stack(config).sections[0]);
+    expect(stack(config).sections[1]).not.toBe(stack(config).sections[0]);
+    config = deleteSection(config, 0, 1, 1);
+    expect(stack(config).sections).toHaveLength(3);
+  });
+
+  it("duplicates an entire stack independently", () => {
+    const config = duplicateSection(fixture(), 0, 1);
+    expect(stack(config, 2)).toEqual(stack(config));
+    expect(stack(config, 2).sections[0]).not.toBe(stack(config).sections[0]);
+  });
+
+  it("reorders children inside a stack", () => {
+    const config = fixture();
+    const updated = moveSection(config, [0, 1, 0], [0, 1, 1]);
+    expect(stack(updated).sections).toEqual(
+      [...stack(config).sections].reverse()
+    );
+  });
+
+  it("accounts for a top-level removal before the destination stack", () => {
+    const config = fixture();
+    const updated = moveSection(config, [0, 0], [0, 1, 1]);
+    expect(stack(updated, 0).sections[1]).toBe(
+      findLovelaceContainer(config, [0, 0])
+    );
+    expect(stack(updated, 0).sections).toHaveLength(3);
+  });
+
+  it("moves a child between stacks", () => {
+    const config = fixture();
+    const updated = moveSection(config, [0, 1, 0], [0, 2, 0]);
+    expect(stack(updated).sections).toHaveLength(1);
+    expect(stack(updated, 2).sections[0]).toBe(stack(config).sections[0]);
+  });
+
+  it("restores the saved width when a child moves to the main view", () => {
+    const config = moveSection(fixture(), [0, 1, 0], [0, 0]);
+    expect(findLovelaceContainer(config, [0, 0]).column_span).toBe(3);
+    expect(stack(config, 2).sections).toHaveLength(1);
+  });
+
+  it("keeps an emptied stack editable", () => {
+    const config = moveSection(fixture(), [0, 2, 0], [0, 0]);
+    expect(stack(config, 3).sections).toEqual([]);
+  });
+
+  it("rejects nesting through adding, moving, and editing", () => {
+    const config = fixture();
+    expect(() => addSection(config, 0, stack(config), 2)).toThrow(
+      "Nested section stacks"
+    );
+    expect(() => moveSection(config, [0, 1], [0, 2, 0])).toThrow(
+      "Nested section stacks"
+    );
+    expect(() =>
+      updateLovelaceContainer(config, [0, 1, 0], stack(config))
+    ).toThrow("Nested section stacks");
+  });
+
+  it("rejects cards placed directly in a stack", () => {
+    expect(() => addCard(fixture(), [0, 1], { type: "button" })).toThrow();
+  });
+
+  it("does not interpret an ordinary section as a stack", () => {
+    expect(() => findLovelaceContainer(fixture(), [0, 0, 0])).toThrow(
+      "Section is not a stack"
+    );
+  });
+});

--- a/test/panels/lovelace/sections/hui-stack-section.test.ts
+++ b/test/panels/lovelace/sections/hui-stack-section.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LovelaceViewConfig } from "../../../../src/data/lovelace/config/view";
+import type { LovelaceConfig } from "../../../../src/data/lovelace/config/types";
+import type { LovelaceStackSectionConfig } from "../../../../src/data/lovelace/config/section";
+import type { LovelaceSectionPath } from "../../../../src/panels/lovelace/editor/lovelace-path";
+import { StackSection } from "../../../../src/panels/lovelace/sections/hui-stack-section";
+import type { HuiSection } from "../../../../src/panels/lovelace/sections/hui-section";
+import type { Lovelace } from "../../../../src/panels/lovelace/types";
+import type { HomeAssistant } from "../../../../src/types";
+import { fireEvent } from "../../../../src/common/dom/fire_event";
+
+// Exercise the stack's lifecycle and editing events independently of card rendering.
+vi.mock("../../../../src/components/ha-ripple", () => ({}));
+vi.mock("../../../../src/components/ha-svg-icon", () => ({}));
+vi.mock("../../../../src/components/ha-sortable", () => ({}));
+vi.mock(
+  "../../../../src/panels/lovelace/components/hui-section-edit-mode",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/panels/lovelace/sections/hui-section-background",
+  () => ({})
+);
+
+customElements.define(
+  "hui-section",
+  class extends HTMLElement {
+    sectionPath?: LovelaceSectionPath;
+    get path() {
+      return this.sectionPath;
+    }
+  }
+);
+
+const config: LovelaceStackSectionConfig = {
+  type: "stack",
+  column_span: 2,
+  sections: [
+    { type: "grid", column_span: 3, cards: [] },
+    { type: "grid", cards: [] },
+  ],
+};
+let stack: StackSection;
+const mount = async (editMode = false) => {
+  stack = new StackSection();
+  stack.hass = { localize: (key: string) => key } as HomeAssistant;
+  stack.viewIndex = 0;
+  stack.index = 0;
+  stack.preview = editMode;
+  stack.lovelace = {
+    config: { views: [{ type: "sections", sections: [config] }] },
+    editMode,
+    saveConfig: vi.fn(),
+  } as unknown as Lovelace;
+  stack.setConfig(config);
+  document.body.append(stack);
+  await stack.updateComplete;
+  return [...stack.shadowRoot!.querySelectorAll<HuiSection>("hui-section")];
+};
+afterEach(() => stack?.remove());
+
+describe("section stack lifecycle", () => {
+  it("forwards state and editor paths while preserving child config", async () => {
+    const children = await mount();
+    expect(children.map((child) => child.sectionPath)).toEqual([
+      [0, 0, 0],
+      [0, 0, 1],
+    ]);
+    expect(children[0].config).toBe(config.sections[0]);
+    stack.hass = { ...stack.hass };
+    await stack.updateComplete;
+    expect(children[0].hass).toBe(stack.hass);
+    expect(stack.shadowRoot!.querySelector("hui-section")).toBe(children[0]);
+    stack.index = 2;
+    await stack.updateComplete;
+    expect(children[1].sectionPath).toEqual([0, 2, 1]);
+  });
+
+  it("hides only when all children are hidden, keeping them mounted to recover", async () => {
+    const children = await mount();
+    children[0].hidden = true;
+    fireEvent(children[0], "section-visibility-changed", { value: false });
+    expect(stack.hidden).toBe(false);
+    children[1].hidden = true;
+    fireEvent(children[1], "section-visibility-changed", { value: false });
+    expect(stack.hidden).toBe(true);
+    expect(children.every((child) => child.isConnected)).toBe(true);
+    children[0].hidden = false;
+    fireEvent(children[0], "section-visibility-changed", { value: true });
+    expect(stack.hidden).toBe(false);
+  });
+
+  it("shows hidden children for editing and restores visibility afterwards", async () => {
+    const children = await mount();
+    children.forEach((child) => {
+      child.hidden = true;
+    });
+    stack.preview = true;
+    await stack.updateComplete;
+    expect(stack.hidden).toBe(false);
+    expect(children.every((child) => child.preview)).toBe(true);
+    stack.preview = false;
+    await stack.updateComplete;
+    expect(stack.hidden).toBe(true);
+  });
+
+  it("rebuilds only the child whose custom layout became available", async () => {
+    const children = await mount();
+    fireEvent(children[0], "ll-rebuild");
+    await stack.updateComplete;
+    const rebuilt = [
+      ...stack.shadowRoot!.querySelectorAll<HuiSection>("hui-section"),
+    ];
+    expect(rebuilt[0]).not.toBe(children[0]);
+    expect(rebuilt[0].config).toBe(children[0].config);
+    expect(rebuilt[1]).toBe(children[1]);
+    expect(rebuilt[0].sectionPath).toEqual([0, 0, 0]);
+  });
+
+  it("adds ordinary sections through the existing add-section helper", async () => {
+    await mount(true);
+    stack.shadowRoot!.querySelector<HTMLButtonElement>("button")!.click();
+    expect(stack.lovelace!.saveConfig).toHaveBeenCalledOnce();
+    const saved = vi.mocked(stack.lovelace!.saveConfig).mock
+      .calls[0][0] as LovelaceConfig;
+    expect(
+      (
+        (saved.views[0] as LovelaceViewConfig)
+          .sections![0] as LovelaceStackSectionConfig
+      ).sections
+    ).toHaveLength(3);
+  });
+
+  it("saves nested reorder paths and stops the event reaching the outer grid", async () => {
+    await mount(true);
+    const outer = vi.fn();
+    stack.addEventListener("item-moved", outer);
+    fireEvent(stack.shadowRoot!.querySelector("ha-sortable")!, "item-moved", {
+      oldIndex: 0,
+      newIndex: 1,
+    });
+    const saved = vi.mocked(stack.lovelace!.saveConfig).mock
+      .calls[0][0] as LovelaceConfig;
+    expect(
+      (
+        (saved.views[0] as LovelaceViewConfig)
+          .sections![0] as LovelaceStackSectionConfig
+      ).sections
+    ).toEqual([...config.sections].reverse());
+    expect(outer).not.toHaveBeenCalled();
+  });
+
+  it("rejects nested stacks when loading YAML", () => {
+    stack = new StackSection();
+    expect(() =>
+      stack.setConfig({
+        type: "stack",
+        sections: [config],
+      } as LovelaceStackSectionConfig)
+    ).toThrow("Nested section stacks");
+  });
+});

--- a/test/panels/lovelace/views/sections-background-alignment.test.ts
+++ b/test/panels/lovelace/views/sections-background-alignment.test.ts
@@ -19,6 +19,30 @@ function mockSection(
 }
 
 describe("computeSectionsBackgroundAlignment", () => {
+  it.each([
+    [true, true],
+    [true, undefined],
+    [undefined, true],
+    [undefined, undefined],
+  ])(
+    "preserves row alignment when a section becomes a stack (%s, %s)",
+    (background, adjacentBackground) => {
+      const first = mockSection({ background, column_span: 2 });
+      const adjacent = mockSection({ background: adjacentBackground });
+      const stack = {
+        hidden: false,
+        config: {
+          type: "stack",
+          column_span: 2,
+          sections: [first.config, { background: true }],
+        },
+      } as unknown as HuiSection;
+      expect(computeSectionsBackgroundAlignment([stack, adjacent], 3)).toEqual(
+        computeSectionsBackgroundAlignment([first, adjacent], 3)
+      );
+    }
+  );
+
   it("returns empty set for single column layout", () => {
     const sections = [mockSection(), mockSection({ background: true })];
     const result = computeSectionsBackgroundAlignment(sections, 1);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This feature adds a new pseudo element to the section view that allows for the creation of *stacks* of sections within a single grid row, with the goal of facilitating a more compact section view with less wasted vertical space. This approach came about through discussion on my previous PR #54098 . This new approach allows building truly dense section views with full WYSIWYG editing, and no inferred behaviour. 

This new stack element was built to be as unobtrusive as possible. The edit UI/UX matches as closely to the current section UI/UX as possible. Drag & Drop continue to work seamlessly into and out of a stack. New menu actions were added to the section menu to conditionally wrap a section in a stack, or to remove it from the stack (placing the section directly after the current stack).

Currently the Stack's only configuration is Width (column span) which supersedes the child Sections' widths; i.e. the child section widths are always the parent stack's width. The goal was to be as uncomplicated as possible, so there is no nesting of stacks, and stacks are not meant to duplicate the section's 'card grid' behaviour.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Editing UX:
<img width="1564" height="1087" alt="Screenshot 2026-09-10 at 14 48 42" src="https://github.com/user-attachments/assets/628594a4-1598-4f94-9eda-705485614ed7" />
This shows the new 'Create Stack' button, an empty stack, and stacks with multiple sections

Conditional Menus:
<img width="300" alt="Screenshot 2026-09-10 at 14 48 58" src="https://github.com/user-attachments/assets/37a6992c-48cf-4e56-8328-8c78818dbb24" /><img width="300" alt="Screenshot 2026-09-10 at 14 49 31" src="https://github.com/user-attachments/assets/5699ffa1-fb3b-4d82-9ee2-13e7dc7493d3" />

Resulting Dashboard:
<img width="1536" height="1320" alt="Screenshot 2026-09-10 at 14 50 17" src="https://github.com/user-attachments/assets/256223ee-6b2e-465f-a613-33c121ec8b1d" />

Stack Column Span Example:
<img width="1532" height="910" alt="Screenshot 2026-09-10 at 15 15 17" src="https://github.com/user-attachments/assets/0af7e521-1290-484b-aeed-76fb1e1fbf77" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [~] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
