### PR TITLE
Reserve min-height for view header to prevent layout shift

### DIFF
--- a/src/panels/lovelace/views/hui-view-header.ts
+++ b/src/panels/lovelace/views/hui-view-header.ts
@@ -346,6 +346,9 @@ export class HuiViewHeader extends LitElement {
       width: 100%;
       max-width: 700px;
       display: flex;
+      min-height: calc(
+        var(--ha-font-size-xl) * var(--ha-line-height-condensed) + 4px
+      );
     }
 
     .heading > * {

--- a/src/panels/lovelace/views/hui-view-header.ts
+++ b/src/panels/lovelace/views/hui-view-header.ts
@@ -356,6 +356,10 @@ export class HuiViewHeader extends LitElement {
       height: 100%;
     }
 
+    .container:not(.edit-mode) .heading:has(> *[hidden]) {
+      display: none;
+    }
+
     .badges {
       position: relative;
       flex: 1;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--

-->
The Home overview's welcome message ("Welcome, {name}") is rendered as a markdown header card whose content is a template string resolved asynchronously over the WebSocket connection. Until that resolves, the card has no content and collapses to near-zero height, so the header pops in and pushes the rest of the dashboard down once the greeting text arrives. 

This fix reserves a minimum height on the view header's .heading container, sized off the same font-size/line-height variables the header text already uses, so the header holds its layout while the templated title is still resolving. This addresses the specific single-line templated title case described in #53358 . It doesn't address layout shift from other header card types whose content naturally resolves after mount (e.g. images, entity state) — I tested a Gauge/Picture card as a header and confirmed the behavior is identical with or without this change, out-of-scope problem (tracked under #53333 ).


## Screenshots
<!--
-->
Tested by setting the throttle to Slow 4G
**Before** 

https://github.com/user-attachments/assets/71c57693-9e91-469a-96b6-600683e7f4cb


**After**

https://github.com/user-attachments/assets/4892c218-d063-4612-91ed-c2b07e947523


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53358 
- This PR is related to issue or discussion: #53333 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
