### PR TITLE
Align stacked statistics lines across recorder gaps

### DIFF
--- a/src/components/chart/down-sample.ts
+++ b/src/components/chart/down-sample.ts
@@ -1,4 +1,5 @@
 import type { LineSeriesOption } from "echarts";
+import { addSafe } from "echarts/lib/util/number";
 
 export type Point = NonNullable<LineSeriesOption["data"]>[number];
 
@@ -357,7 +358,7 @@ export function downSampleAlignedLineData(
                   : value <= 0
                     ? negative
                     : undefined;
-      if (below !== undefined) value += below;
+      if (below !== undefined) value = addSafe(value, below);
       previous = value;
       if (value > 0) positive = value;
       if (value < 0) negative = value;

--- a/src/components/chart/down-sample.ts
+++ b/src/components/chart/down-sample.ts
@@ -5,6 +5,10 @@ export type Point = NonNullable<LineSeriesOption["data"]>[number];
 interface AlignedFrame {
   min: (number | undefined)[];
   max: (number | undefined)[];
+  stackMin: (number | undefined)[];
+  stackMax: (number | undefined)[];
+  stackMinIndex: (number | undefined)[];
+  stackMaxIndex: (number | undefined)[];
 }
 
 interface MeanFrame {
@@ -241,7 +245,8 @@ export function downSampleAlignedLineData(
   dataSets: readonly Point[][],
   maxDetails: number,
   minX?: number,
-  maxX?: number
+  maxX?: number,
+  stackStrategies: readonly LineSeriesOption["stackStrategy"][] = []
 ): Point[][] {
   if (!dataSets.length || dataSets.some((data) => !data.length)) {
     return dataSets.map((data) => data.slice());
@@ -284,6 +289,10 @@ export function downSampleAlignedLineData(
         frame = {
           min: Array(dataSets.length),
           max: Array(dataSets.length),
+          stackMin: Array(dataSets.length),
+          stackMax: Array(dataSets.length),
+          stackMinIndex: Array(dataSets.length),
+          stackMaxIndex: Array(dataSets.length),
         };
         frames.set(frameIndex, frame);
       }
@@ -315,6 +324,61 @@ export function downSampleAlignedLineData(
       }
     }
   }
+  // Stacked ECharts lines display the cumulative value at each shared
+  // timestamp. Preserve extrema of that displayed sum as well as each member
+  // peak; otherwise a combined peak can disappear during reduction.
+  for (let pointIndex = 0; pointIndex < length; pointIndex++) {
+    const frameIndex = Math.floor(
+      Number(getPointData(dataSets[0][pointIndex])[0]) / step
+    );
+    const frame = frames.get(frameIndex);
+    if (!frame) continue;
+    // ECharts adds the nearest preceding cumulative value accepted by this
+    // member's strategy. Remember each sign to avoid rescanning the stack.
+    let previous: number | undefined;
+    let positive: number | undefined;
+    let negative: number | undefined;
+    let nonzero: number | undefined;
+    for (let seriesIndex = 0; seriesIndex < dataSets.length; seriesIndex++) {
+      const raw = getPointData(dataSets[seriesIndex][pointIndex])[1];
+      let value = raw === null ? NaN : Number(raw);
+      const strategy = stackStrategies[seriesIndex] ?? "samesign";
+      const below =
+        strategy === "all"
+          ? previous
+          : strategy === "positive"
+            ? positive
+            : strategy === "negative"
+              ? negative
+              : value === 0
+                ? nonzero
+                : value > 0 && positive !== undefined
+                  ? positive
+                  : value <= 0
+                    ? negative
+                    : undefined;
+      if (below !== undefined) value += below;
+      previous = value;
+      if (value > 0) positive = value;
+      if (value < 0) negative = value;
+      if (value > 0 || value < 0) nonzero = value;
+      if (!Number.isFinite(value)) continue;
+      if (
+        frame.stackMin[seriesIndex] === undefined ||
+        value < frame.stackMin[seriesIndex]!
+      ) {
+        frame.stackMin[seriesIndex] = value;
+        frame.stackMinIndex[seriesIndex] = pointIndex;
+      }
+      if (
+        frame.stackMax[seriesIndex] === undefined ||
+        value > frame.stackMax[seriesIndex]!
+      ) {
+        frame.stackMax[seriesIndex] = value;
+        frame.stackMaxIndex[seriesIndex] = pointIndex;
+      }
+    }
+  }
   for (const frame of frames.values()) {
     for (let seriesIndex = 0; seriesIndex < dataSets.length; seriesIndex++) {
       const minIndex = frame.min[seriesIndex];
@@ -323,6 +387,9 @@ export function downSampleAlignedLineData(
         selected.add(minIndex);
         selected.add(maxIndex);
       }
+    }
+    for (const index of [...frame.stackMinIndex, ...frame.stackMaxIndex]) {
+      if (index !== undefined) selected.add(index);
     }
   }
   const indexes = [...selected].sort((a, b) => a - b);

--- a/src/components/chart/down-sample.ts
+++ b/src/components/chart/down-sample.ts
@@ -1,6 +1,11 @@
 import type { LineSeriesOption } from "echarts";
 
-type Point = NonNullable<LineSeriesOption["data"]>[number];
+export type Point = NonNullable<LineSeriesOption["data"]>[number];
+
+interface AlignedFrame {
+  min: (number | undefined)[];
+  max: (number | undefined)[];
+}
 
 interface MeanFrame {
   sumX: number;
@@ -224,6 +229,104 @@ export function downSampleLineData<
   }
 
   return result;
+}
+
+/**
+ * Downsample aligned line series with one shared index set. Stacked ECharts
+ * lines cannot be sampled independently because their values are combined by
+ * index. Every member contributes its extrema and gap markers to the shared
+ * set; the resulting point arrays therefore remain index-aligned.
+ */
+export function downSampleAlignedLineData(
+  dataSets: readonly Point[][],
+  maxDetails: number,
+  minX?: number,
+  maxX?: number
+): Point[][] {
+  if (!dataSets.length || dataSets.some((data) => !data.length)) {
+    return dataSets.map((data) => data.slice());
+  }
+  const length = dataSets[0].length;
+  if (
+    dataSets.some(
+      (data) =>
+        data.length !== length ||
+        data.some(
+          (point, index) =>
+            Number(getPointData(point)[0]) !==
+            Number(getPointData(dataSets[0][index])[0])
+        )
+    ) ||
+    length <= maxDetails
+  ) {
+    return dataSets.map((data) => data.slice());
+  }
+  const min = minX ?? Number(getPointData(dataSets[0][0])[0]);
+  const max = maxX ?? Number(getPointData(dataSets[0][length - 1])[0]);
+  const rawStep = Math.ceil((max - min) / Math.floor(maxDetails));
+  if (!Number.isFinite(rawStep) || rawStep <= 0) {
+    return dataSets.map((data) => data.slice());
+  }
+  const step = snapFrameSize(rawStep);
+  const selected = new Set<number>([0, length - 1]);
+  const frames = new Map<number, AlignedFrame>();
+  for (let seriesIndex = 0; seriesIndex < dataSets.length; seriesIndex++) {
+    let previousNull: boolean | undefined;
+    for (let pointIndex = 0; pointIndex < length; pointIndex++) {
+      const point = dataSets[seriesIndex][pointIndex];
+      const pointData = getPointData(point);
+      if (!Array.isArray(pointData)) continue;
+      const x = Number(pointData[0]);
+      if (isNaN(x)) continue;
+      const frameIndex = Math.floor(x / step);
+      let frame = frames.get(frameIndex);
+      if (!frame) {
+        frame = {
+          min: Array(dataSets.length),
+          max: Array(dataSets.length),
+        };
+        frames.set(frameIndex, frame);
+      }
+      const y = pointData[1] as number | null;
+      const isNull = y === null;
+      // Keep both sides of each transition, including value/null pairs at
+      // the same timestamp, without retaining every padded null in a gap.
+      if (previousNull !== undefined && previousNull !== isNull) {
+        selected.add(pointIndex - 1);
+        selected.add(pointIndex);
+      }
+      previousNull = isNull;
+      if (isNull) continue;
+      const numericY = Number(y);
+      if (isNaN(numericY)) continue;
+      const minIndex = frame.min[seriesIndex];
+      const maxIndex = frame.max[seriesIndex];
+      if (
+        minIndex === undefined ||
+        numericY < Number(getPointData(dataSets[seriesIndex][minIndex])[1])
+      ) {
+        frame.min[seriesIndex] = pointIndex;
+      }
+      if (
+        maxIndex === undefined ||
+        numericY > Number(getPointData(dataSets[seriesIndex][maxIndex])[1])
+      ) {
+        frame.max[seriesIndex] = pointIndex;
+      }
+    }
+  }
+  for (const frame of frames.values()) {
+    for (let seriesIndex = 0; seriesIndex < dataSets.length; seriesIndex++) {
+      const minIndex = frame.min[seriesIndex];
+      const maxIndex = frame.max[seriesIndex];
+      if (minIndex !== undefined && maxIndex !== undefined) {
+        selected.add(minIndex);
+        selected.add(maxIndex);
+      }
+    }
+  }
+  const indexes = [...selected].sort((a, b) => a - b);
+  return dataSets.map((data) => indexes.map((index) => data[index]));
 }
 
 function getPointData(point: NonNullable<LineSeriesOption["data"]>[number]) {

--- a/src/components/chart/down-sample.ts
+++ b/src/components/chart/down-sample.ts
@@ -359,6 +359,8 @@ export function downSampleAlignedLineData(
                     ? negative
                     : undefined;
       if (below !== undefined) value = addSafe(value, below);
+      // "all" uses even a null preceding level; only sign-sensitive
+      // strategies skip it when searching for an earlier cumulative value.
       previous = value;
       if (value > 0) positive = value;
       if (value < 0) negative = value;

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -1228,7 +1228,10 @@ export class HaChartBase extends LitElement {
             dataSets,
             (this.clientWidth || DEFAULT_CHART_WIDTH) * window.devicePixelRatio,
             min,
-            max
+            max,
+            indexes.map(
+              (index) => (series[index] as LineSeriesOption).stackStrategy
+            )
           )
         : dataSets.map((data) =>
             downSampleLineData(

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -1209,6 +1209,11 @@ export class HaChartBase extends LitElement {
       stackGroups.set(key, group);
     });
     for (const indexes of stackGroups.values()) {
+      if (
+        (series[indexes[0]] as LineSeriesOption).stackOrder === "seriesDesc"
+      ) {
+        indexes.reverse();
+      }
       const dataSets = indexes.map((index) => series[index].data as Point[]);
       const first = dataSets[0];
       const aligned =

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -50,7 +50,8 @@ import "../ha-icon-button";
 import { formatTimeLabel } from "./axis-label";
 import type { ChartSonification } from "./chart-sonification";
 import { canSonifyChart, sonifyChart } from "./chart-sonification";
-import { downSampleLineData } from "./down-sample";
+import { downSampleAlignedLineData, downSampleLineData } from "./down-sample";
+import type { Point } from "./down-sample";
 import { wrapLitTooltipFormatter } from "./lit-tooltip-formatter";
 
 export const MIN_TIME_BETWEEN_UPDATES = 60 * 5 * 1000;
@@ -1134,8 +1135,32 @@ export class HaChartBase extends LitElement {
   }
 
   private _getSeries() {
-    const xAxis = (this.options?.xAxis?.[0] ?? this.options?.xAxis) as
-      XAXisOption | undefined;
+    const xAxes = ensureArray(this.options?.xAxis) as XAXisOption[];
+    const getAxisBounds = (axisIndex: unknown) => {
+      const axis = xAxes[typeof axisIndex === "number" ? axisIndex : 0];
+      return {
+        min:
+          axis?.min instanceof Date
+            ? axis.min.getTime()
+            : typeof axis?.min === "number"
+              ? axis.min
+              : undefined,
+        max:
+          axis?.max instanceof Date
+            ? axis.max.getTime()
+            : typeof axis?.max === "number"
+              ? axis.max
+              : undefined,
+      };
+    };
+    const pointX = (point: Point) =>
+      Number(
+        Array.isArray(point)
+          ? point[0]
+          : point && typeof point === "object" && "value" in point
+            ? point.value?.[0]
+            : NaN
+      );
     const series = ensureArray(this.data).map((s) => {
       const data = this._hiddenDatasets.has(String(s.id ?? s.name))
         ? undefined
@@ -1145,21 +1170,13 @@ export class HaChartBase extends LitElement {
         data,
       } as HaECSeriesItem;
       if (data && s.type === "line") {
-        if ((s as LineSeriesOption).sampling === "minmax") {
-          const minX = xAxis?.min
-            ? xAxis.min instanceof Date
-              ? xAxis.min.getTime()
-              : typeof xAxis.min === "number"
-                ? xAxis.min
-                : undefined
-            : undefined;
-          const maxX = xAxis?.max
-            ? xAxis.max instanceof Date
-              ? xAxis.max.getTime()
-              : typeof xAxis.max === "number"
-                ? xAxis.max
-                : undefined
-            : undefined;
+        if (
+          (s as LineSeriesOption).sampling === "minmax" &&
+          !(s as LineSeriesOption).stack
+        ) {
+          const { min: minX, max: maxX } = getAxisBounds(
+            (s as LineSeriesOption).xAxisIndex
+          );
           result = {
             ...result,
             sampling: undefined,
@@ -1176,6 +1193,60 @@ export class HaChartBase extends LitElement {
       }
       return processSeriesTooltipFormatter(result);
     });
+    const stackGroups = new Map<string, number[]>();
+    series.forEach((s, index) => {
+      if (
+        s?.type !== "line" ||
+        s.sampling !== "minmax" ||
+        !s.stack ||
+        !Array.isArray(s.data)
+      ) {
+        return;
+      }
+      const key = `${s.stack}|${s.xAxisIndex ?? 0}|${s.yAxisIndex ?? 0}`;
+      const group = stackGroups.get(key) || [];
+      group.push(index);
+      stackGroups.set(key, group);
+    });
+    for (const indexes of stackGroups.values()) {
+      const dataSets = indexes.map((index) => series[index].data as Point[]);
+      const first = dataSets[0];
+      const aligned =
+        indexes.length > 1 &&
+        dataSets.every(
+          (data) =>
+            data.length === first.length &&
+            data.every(
+              (point, pointIndex) => pointX(point) === pointX(first[pointIndex])
+            )
+        );
+      const { min, max } = getAxisBounds(
+        (series[indexes[0]] as LineSeriesOption).xAxisIndex
+      );
+      const sampled = aligned
+        ? downSampleAlignedLineData(
+            dataSets,
+            (this.clientWidth || DEFAULT_CHART_WIDTH) * window.devicePixelRatio,
+            min,
+            max
+          )
+        : dataSets.map((data) =>
+            downSampleLineData(
+              data,
+              (this.clientWidth || DEFAULT_CHART_WIDTH) *
+                window.devicePixelRatio,
+              min,
+              max
+            )
+          );
+      indexes.forEach((index, sampledIndex) => {
+        series[index] = {
+          ...series[index],
+          sampling: undefined,
+          data: sampled[sampledIndex],
+        } as RawSeriesOption;
+      });
+    }
     return series as ECOption["series"];
   }
 

--- a/src/components/chart/statistics-chart-data.ts
+++ b/src/components/chart/statistics-chart-data.ts
@@ -54,6 +54,72 @@ export interface StatisticsChartData {
 }
 
 /**
+ * ECharts stacks line series by data index. Statistics are fetched per
+ * entity, so a recorder gap would otherwise make the next value in that
+ * entity stack against a different timestamp in its neighbours. Give every
+ * stacked line series the same (union) x-axis sequence and use null for a
+ * missing sample; this keeps the gap while making the stack time-aligned.
+ */
+type StackedLinePoint = [number, number | null];
+
+function alignStackedLineData(
+  datasets: (LineSeriesOption | BarSeriesOption)[]
+) {
+  const lineDatasets = datasets.filter(
+    (dataset): dataset is LineSeriesOption =>
+      dataset.type === "line" &&
+      Array.isArray(dataset.data) &&
+      dataset.data.length > 0
+  );
+  if (lineDatasets.length < 2) {
+    return;
+  }
+
+  const timestamps = new Set<number>();
+  const multiplicities = new Map<number, number>();
+  const pointsByDataset = lineDatasets.map((dataset) => {
+    const points = new Map<number, StackedLinePoint[]>();
+    for (const point of dataset.data as StackedLinePoint[]) {
+      if (!Array.isArray(point) || typeof point[0] !== "number") {
+        continue;
+      }
+      timestamps.add(point[0]);
+      const pointsAtTimestamp = points.get(point[0]) || [];
+      pointsAtTimestamp.push(point);
+      points.set(point[0], pointsAtTimestamp);
+      multiplicities.set(
+        point[0],
+        Math.max(multiplicities.get(point[0]) || 0, pointsAtTimestamp.length)
+      );
+    }
+    return points;
+  });
+  const orderedTimestamps = [...timestamps].sort((a, b) => a - b);
+
+  lineDatasets.forEach((dataset, index) => {
+    const points = pointsByDataset[index];
+    const aligned: StackedLinePoint[] = [];
+    orderedTimestamps.forEach((timestamp) => {
+      const pointsAtTimestamp = points.get(timestamp);
+      const multiplicity = multiplicities.get(timestamp)!;
+      if (!pointsAtTimestamp) {
+        for (let slot = 0; slot < multiplicity; slot++) {
+          aligned.push([timestamp, null]);
+        }
+        return;
+      }
+      for (let slot = 0; slot < multiplicity; slot++) {
+        aligned.push(
+          pointsAtTimestamp[slot] ||
+            pointsAtTimestamp[pointsAtTimestamp.length - 1]
+        );
+      }
+    });
+    dataset.data = aligned;
+  });
+}
+
+/**
  * Transforms raw statistics into ECharts series for `statistics-chart`.
  * Pure data processing: all environment inputs (current time, theme style,
  * hass) are injected so the transform is deterministic and benchmarkable.
@@ -438,6 +504,10 @@ export function generateStatisticsChartData(
     Array.prototype.push.apply(totalDataSets, statDataSets);
     Array.prototype.push.apply(legendData, statLegendData);
   });
+
+  if (chartType === "line" && chartStacked) {
+    alignStackedLineData(totalDataSets);
+  }
 
   if (chartType === "bar") {
     fillDataGapsAndRoundCaps(totalDataSets as BarSeriesOption[], chartStacked);

--- a/src/components/chart/statistics-chart-data.ts
+++ b/src/components/chart/statistics-chart-data.ts
@@ -204,7 +204,10 @@ export function generateStatisticsChartData(
     const statDataSets: (LineSeriesOption | BarSeriesOption)[] = [];
     const statLegendData: StatisticsChartLegendItem[] = [];
     const statHidden = hiddenStats.has(statistic_id);
-    const emittedStackedLineSlots = new Map<number, number>();
+    const emittedStackedLineSlots = new Map<
+      LineSeriesOption | BarSeriesOption,
+      Map<number, number>
+    >();
 
     const pushLineData = (
       dataset: LineSeriesOption | BarSeriesOption,
@@ -216,12 +219,17 @@ export function generateStatisticsChartData(
         dataset.data!.push([time, ...value]);
         return;
       }
-      const emittedSlots = emittedStackedLineSlots.get(time) || 0;
+      let emittedSlotsByTime = emittedStackedLineSlots.get(dataset);
+      if (!emittedSlotsByTime) {
+        emittedSlotsByTime = new Map();
+        emittedStackedLineSlots.set(dataset, emittedSlotsByTime);
+      }
+      const emittedSlots = emittedSlotsByTime.get(time) || 0;
       const point = [time, ...value];
       for (let slot = emittedSlots; slot < stackedSlot.slots; slot++) {
         dataset.data![stackedSlot.offset + slot] = point;
       }
-      emittedStackedLineSlots.set(time, emittedSlots + 1);
+      emittedSlotsByTime.set(time, emittedSlots + 1);
     };
 
     // Place bars at centre of their specified time range if this is a bar chart

--- a/src/components/chart/statistics-chart-data.ts
+++ b/src/components/chart/statistics-chart-data.ts
@@ -441,7 +441,8 @@ export function generateStatisticsChartData(
       stackedLineStatistics.has(statistic_id)
     ) {
       statDataSets.forEach((dataset) => {
-        dataset.sampling = undefined;
+        // ha-chart-base samples aligned members together before rendering.
+        dataset.sampling = "minmax";
         dataset.data = stackedLineTimeline.flatMap(([time, slots]) =>
           Array.from({ length: slots }, () => [time, null])
         );

--- a/src/components/chart/statistics-chart-data.ts
+++ b/src/components/chart/statistics-chart-data.ts
@@ -54,76 +54,6 @@ export interface StatisticsChartData {
 }
 
 /**
- * ECharts stacks line series by data index. Statistics are fetched per
- * entity, so a recorder gap would otherwise make the next value in that
- * entity stack against a different timestamp in its neighbours. Give every
- * stacked line series the same (union) x-axis sequence and use null for a
- * missing sample; this keeps the gap while making the stack time-aligned.
- */
-type StackedLinePoint = [number, number | null];
-
-function alignStackedLineData(
-  datasets: (LineSeriesOption | BarSeriesOption)[]
-) {
-  const lineDatasets = datasets.filter(
-    (dataset): dataset is LineSeriesOption =>
-      dataset.type === "line" &&
-      Array.isArray(dataset.data) &&
-      dataset.data.length > 0
-  );
-  if (lineDatasets.length < 2) {
-    return;
-  }
-
-  const timestamps = new Set<number>();
-  const multiplicities = new Map<number, number>();
-  const pointsByDataset = lineDatasets.map((dataset) => {
-    const points = new Map<number, StackedLinePoint[]>();
-    for (const point of dataset.data as StackedLinePoint[]) {
-      if (!Array.isArray(point) || typeof point[0] !== "number") {
-        continue;
-      }
-      timestamps.add(point[0]);
-      const pointsAtTimestamp = points.get(point[0]) || [];
-      pointsAtTimestamp.push(point);
-      points.set(point[0], pointsAtTimestamp);
-      multiplicities.set(
-        point[0],
-        Math.max(multiplicities.get(point[0]) || 0, pointsAtTimestamp.length)
-      );
-    }
-    return points;
-  });
-  const orderedTimestamps = [...timestamps].sort((a, b) => a - b);
-
-  lineDatasets.forEach((dataset, index) => {
-    const points = pointsByDataset[index];
-    const aligned: StackedLinePoint[] = [];
-    orderedTimestamps.forEach((timestamp) => {
-      const pointsAtTimestamp = points.get(timestamp);
-      const multiplicity = multiplicities.get(timestamp)!;
-      if (!pointsAtTimestamp) {
-        for (let slot = 0; slot < multiplicity; slot++) {
-          aligned.push([timestamp, null]);
-        }
-        return;
-      }
-      for (let slot = 0; slot < multiplicity; slot++) {
-        aligned.push(
-          pointsAtTimestamp[slot] ||
-            pointsAtTimestamp[pointsAtTimestamp.length - 1]
-        );
-      }
-    });
-    dataset.data = aligned;
-    // ha-chart-base samples each line independently when sampling is set.
-    // Keep aligned stacked data intact so its shared timestamp index survives
-    // the chart rendering pipeline.
-    dataset.sampling = undefined;
-  });
-}
-
-/**
  * Transforms raw statistics into ECharts series for `statistics-chart`.
  * Pure data processing: all environment inputs (current time, theme style,
  * hass) are injected so the transform is deterministic and benchmarkable.
@@ -169,6 +99,68 @@ export function generateStatisticsChartData(
     endTime = now;
   }
 
+  // ECharts stacks lines by data index. Derive the common timeline from raw
+  // statistic boundaries before emitting datasets, so recorder gaps retain
+  // their value/null boundary slots without a later output-data rewrite.
+  const stackedLineTimes = new Map<number, number>();
+  const stackedLineStatistics = new Set<string>();
+  if (chartType === "line" && chartStacked) {
+    for (const [statisticId, stats] of statisticsData) {
+      if (
+        hiddenStats.has(statisticId) ||
+        !params.statTypes.some((type) => statisticsHaveType(stats, type))
+      ) {
+        continue;
+      }
+      let previousStart: number | undefined;
+      let previousEnd: number | undefined;
+      const statisticTimes = new Map<number, number>();
+      const addStatisticTime = (time: number) => {
+        statisticTimes.set(time, (statisticTimes.get(time) || 0) + 1);
+      };
+      for (const stat of stats) {
+        if (previousStart === stat.start) {
+          continue;
+        }
+        previousStart = stat.start;
+        const limit = Math.min(stat.end, endTime.getTime());
+        if (stat.start > limit) {
+          continue;
+        }
+        stackedLineStatistics.add(statisticId);
+        if (previousEnd !== undefined && previousEnd !== stat.start) {
+          addStatisticTime(previousEnd);
+          addStatisticTime(previousEnd);
+        }
+        addStatisticTime(stat.start);
+        previousEnd = limit;
+      }
+      if (previousEnd !== undefined) {
+        addStatisticTime(previousEnd);
+      }
+      for (const [time, slots] of statisticTimes) {
+        stackedLineTimes.set(
+          time,
+          Math.max(stackedLineTimes.get(time) || 0, slots)
+        );
+      }
+    }
+  }
+  let stackedLineOffset = 0;
+  const stackedLineTimeline = [...stackedLineTimes]
+    .sort(([a], [b]) => a - b)
+    .map(([time, slots]) => {
+      const offset = stackedLineOffset;
+      stackedLineOffset += slots;
+      return [time, slots, offset] as const;
+    });
+  const stackedLineSlots = new Map(
+    stackedLineTimeline.map(([time, slots, offset]) => [
+      time,
+      { slots, offset },
+    ])
+  );
+
   // Check if we need to display most recent data. Allow 10m of leeway for "now",
   // because stats are 5 minute aggregated.
   // Use same now point for all statistics even if processing time means the
@@ -211,6 +203,26 @@ export function generateStatisticsChartData(
     // The datasets for the current statistic
     const statDataSets: (LineSeriesOption | BarSeriesOption)[] = [];
     const statLegendData: StatisticsChartLegendItem[] = [];
+    const statHidden = hiddenStats.has(statistic_id);
+    const emittedStackedLineSlots = new Map<number, number>();
+
+    const pushLineData = (
+      dataset: LineSeriesOption | BarSeriesOption,
+      time: number,
+      value: (number | null)[]
+    ) => {
+      const stackedSlot = stackedLineSlots.get(time);
+      if (!stackedSlot || statHidden) {
+        dataset.data!.push([time, ...value]);
+        return;
+      }
+      const emittedSlots = emittedStackedLineSlots.get(time) || 0;
+      const point = [time, ...value];
+      for (let slot = emittedSlots; slot < stackedSlot.slots; slot++) {
+        dataset.data![stackedSlot.offset + slot] = point;
+      }
+      emittedStackedLineSlots.set(time, emittedSlots + 1);
+    };
 
     // Place bars at centre of their specified time range if this is a bar chart
     // and the period is 5minute or hour.
@@ -255,10 +267,10 @@ export function generateStatisticsChartData(
           if (drawGap) {
             // if the end of the previous data doesn't match the start of the current data,
             // we have to draw a gap so add a value at the end time, and then an empty value.
-            d.data!.push([prevEndTime!.getTime(), ...prevValues![i]!]);
-            d.data!.push([prevEndTime!.getTime(), null]);
+            pushLineData(d, prevEndTime!.getTime(), prevValues![i]!);
+            pushLineData(d, prevEndTime!.getTime(), [null]);
           }
-          d.data!.push([start.getTime(), ...dataValue!]);
+          pushLineData(d, start.getTime(), dataValue!);
           // For band-top rows dataValues[i] is [diff, top]; the actual Y is
           // the last element. For regular rows it's [value]. Same call works.
           trackY(dataValue[dataValue.length - 1]);
@@ -414,7 +426,19 @@ export function generateStatisticsChartData(
       return PLAIN_KIND;
     });
     const numTypes = statTypes.length;
-    const statHidden = hiddenStats.has(statistic_id);
+    if (
+      chartType === "line" &&
+      chartStacked &&
+      !statHidden &&
+      stackedLineStatistics.has(statistic_id)
+    ) {
+      statDataSets.forEach((dataset) => {
+        dataset.sampling = undefined;
+        dataset.data = stackedLineTimeline.flatMap(([time, slots]) =>
+          Array.from({ length: slots }, () => [time, null])
+        );
+      });
+    }
 
     for (const stat of stats) {
       // Skip consecutive stats that share the same start time. Compare the raw
@@ -460,7 +484,7 @@ export function generateStatisticsChartData(
     const lastValues = prevValues;
     if (chartType === "line" && lastEndTime && lastValues) {
       statDataSets.forEach((d, i) => {
-        d.data!.push([lastEndTime.getTime(), ...lastValues[i]!]);
+        pushLineData(d, lastEndTime.getTime(), lastValues[i]!);
       });
     }
 
@@ -508,10 +532,6 @@ export function generateStatisticsChartData(
     Array.prototype.push.apply(totalDataSets, statDataSets);
     Array.prototype.push.apply(legendData, statLegendData);
   });
-
-  if (chartType === "line" && chartStacked) {
-    alignStackedLineData(totalDataSets);
-  }
 
   if (chartType === "bar") {
     fillDataGapsAndRoundCaps(totalDataSets as BarSeriesOption[], chartStacked);

--- a/src/components/chart/statistics-chart-data.ts
+++ b/src/components/chart/statistics-chart-data.ts
@@ -116,6 +116,10 @@ function alignStackedLineData(
       }
     });
     dataset.data = aligned;
+    // ha-chart-base samples each line independently when sampling is set.
+    // Keep aligned stacked data intact so its shared timestamp index survives
+    // the chart rendering pipeline.
+    dataset.sampling = undefined;
   });
 }
 

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -51,6 +51,7 @@ conclusions.
 | Transform                                                                       | Source                                                            | Benchmark                                | Characterization test                                                   |
 | ------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------- |
 | `downSampleLineData`                                                            | `src/components/chart/down-sample.ts`                             | `down-sample.bench.ts`                   | `test/components/chart/down-sample.test.ts`                             |
+| `downSampleAlignedLineData`                                                     | `src/components/chart/down-sample.ts`                             | `down-sample.bench.ts`                   | `test/components/chart/down-sample.test.ts`                             |
 | `computeHistory`                                                                | `src/data/history.ts`                                             | `history.bench.ts`                       | `test/data/history-characterization.test.ts`                            |
 | `HistoryStream.processMessage`                                                  | `src/data/history.ts`                                             | `history-stream.bench.ts`                | `test/data/history-characterization.test.ts`                            |
 | `convertStatisticsToHistory`, `mergeHistoryResults`                             | `src/data/history.ts`                                             | `statistics.bench.ts`                    | `test/data/history-characterization.test.ts`                            |
@@ -67,7 +68,8 @@ Call frequency notes (what makes a target worth optimizing):
   history graph card; `HistoryStream.processMessage` merges and purges on the
   same cadence.
 - `downSampleLineData` runs in `ha-chart-base._getSeries()` on **every chart
-  render** of every chart on screen.
+  render** of every chart on screen. `downSampleAlignedLineData` runs on the
+  same path for visible stacked line groups whose timestamp grids are aligned.
 - `generateStatisticsChartData` / `generateStateHistoryChartLineData` run on
   every data or config change of their charts (`MIN_TIME_BETWEEN_UPDATES` =
   5 minutes keeps charts refreshing even without new data).

--- a/test/benchmarks/down-sample.bench.ts
+++ b/test/benchmarks/down-sample.bench.ts
@@ -1,5 +1,8 @@
 import { describe, test } from "vitest";
-import { downSampleLineData } from "../../src/components/chart/down-sample";
+import {
+  downSampleAlignedLineData,
+  downSampleLineData,
+} from "../../src/components/chart/down-sample";
 import { FIXED_EPOCH_MS, SCALES } from "../fixtures/history-states";
 import { createSeededRandom } from "../fixtures/random";
 
@@ -35,6 +38,14 @@ const largeMostlyGaps = withGaps(
   large,
   (index) => Math.floor(index / 50) % 3 !== 0
 );
+const alignedDense = [
+  large,
+  large.map(([x, y]) => [x, y * 0.75 + 20] as [number, number]),
+] as const;
+const alignedMostlyGaps = [
+  largeMostlyGaps,
+  withGaps(large, (index) => Math.floor(index / 40) % 5 !== 0),
+] as const;
 
 describe("downSampleLineData", () => {
   test("min/max small (1k points)", async ({ bench }) => {
@@ -76,6 +87,20 @@ describe("downSampleLineData", () => {
   test("min/max large mostly gaps (100k points)", async ({ bench }) => {
     await bench("min/max large mostly gaps (100k points)", () => {
       downSampleLineData(largeMostlyGaps, MAX_DETAILS);
+    }).run({ time: 1000, warmupIterations: 2 });
+  });
+
+  test("aligned stack min/max dense (2x100k points)", async ({ bench }) => {
+    await bench("aligned stack min/max dense (2x100k points)", () => {
+      downSampleAlignedLineData(alignedDense, MAX_DETAILS);
+    }).run({ time: 1000, warmupIterations: 2 });
+  });
+
+  test("aligned stack min/max mostly gaps (2x100k points)", async ({
+    bench,
+  }) => {
+    await bench("aligned stack min/max mostly gaps (2x100k points)", () => {
+      downSampleAlignedLineData(alignedMostlyGaps, MAX_DETAILS);
     }).run({ time: 1000, warmupIterations: 2 });
   });
 });

--- a/test/components/chart/down-sample.test.ts
+++ b/test/components/chart/down-sample.test.ts
@@ -540,7 +540,7 @@ describe("downSampleAlignedLineData", () => {
       [-1, -1, 0.5, 0.4, 0.8, -0.9, -0.9, 0.6],
     ];
     const data = values.map((row) =>
-      row.map((y, x): [number, number] => [x, y])
+      row.map((y, x): [number, number] => [x / 10, y])
     );
     const sampled = downSampleAlignedLineData(data, 1, undefined, undefined, [
       "negative",
@@ -549,8 +549,8 @@ describe("downSampleAlignedLineData", () => {
       "positive",
     ]);
     // Rounding 0.2 + 0.4 - 0.6 to zero changes the preceding positive level.
-    // The last level's actual minimum is at x=5, not x=0.
-    expect(sampled[3]).toContainEqual([5, -0.9]);
+    // The last level's actual minimum is at x=0.5, not x=0.
+    expect(sampled[3]).toContainEqual([0.5, -0.9]);
   });
 
   it("does not align mismatched series by corrupting their data", () => {

--- a/test/components/chart/down-sample.test.ts
+++ b/test/components/chart/down-sample.test.ts
@@ -553,6 +553,50 @@ describe("downSampleAlignedLineData", () => {
     expect(sampled[3]).toContainEqual([0.5, -0.9]);
   });
 
+  it("preserves finite all-stack extrema after a null middle member", () => {
+    const values = [
+      [11, 8, 0, 9, 18, 3, 1, 14, 11, 15, 11, 0, 4, 14, 10, 11, 15, 15, 13, 12],
+      [
+        11,
+        4,
+        15,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        2,
+        3,
+        1,
+        1,
+        14,
+        13,
+        15,
+        13,
+      ],
+      [
+        10, 17, 16, 8, 12, 18, 10, 14, 12, 7, 4, 17, 16, 13, 10, 4, 13, 20, 9,
+        11,
+      ],
+    ];
+    const data = values.map((row) =>
+      row.map((y, x): [number, number | null] => [x / 100, y])
+    );
+    const sampled = downSampleAlignedLineData(data, 1, undefined, undefined, [
+      "all",
+      "all",
+      "all",
+    ]);
+    // With "all", ECharts propagates the middle member's null into the top
+    // level. Skipping that null invents a smaller value inside the gap and
+    // discards the real minimum of 11 + 1 + 4 = 16 at x=0.15.
+    expect(sampled[2]).toContainEqual([0.15, 4]);
+  });
+
   it("does not align mismatched series by corrupting their data", () => {
     const first: [number, number][] = Array.from({ length: 200 }, (_, x) => [
       x,

--- a/test/components/chart/down-sample.test.ts
+++ b/test/components/chart/down-sample.test.ts
@@ -462,6 +462,76 @@ describe("downSampleAlignedLineData", () => {
     expect(sampled[1]).toEqual(second);
   });
 
+  it("retains extrema of the displayed stack sum", () => {
+    const first: [number, number][] = [
+      [0, 0],
+      [1, 100],
+      [2, 60],
+      [3, 0],
+      [4, 0],
+    ];
+    const second: [number, number][] = [
+      [0, 100],
+      [1, 0],
+      [2, 60],
+      [3, 0],
+      [4, 0],
+    ];
+    const sampled = downSampleAlignedLineData([first, second], 1);
+    expect(sampled[0]).toEqual([
+      [0, 0],
+      [1, 100],
+      [2, 60],
+      [3, 0],
+      [4, 0],
+    ]);
+    expect(sampled[1]).toEqual([
+      [0, 100],
+      [1, 0],
+      [2, 60],
+      [3, 0],
+      [4, 0],
+    ]);
+  });
+
+  it.each([1, -1])(
+    "keeps intermediate stack extrema across gaps (sign %s)",
+    (sign) => {
+      const values = [
+        [0, 100, 60, 0, 0],
+        [100, 0, 60, 0, 0],
+        [null, null, null, null, null],
+        [100, 100, 80, 100, 100],
+      ];
+      const data = values.map((row) =>
+        row.map((value, x): [number, number | null] => [
+          x,
+          value === null ? null : sign * value,
+        ])
+      );
+      const sampled = downSampleAlignedLineData(data, 1);
+      // The intermediate level peaks at 120 although the final level stays 200.
+      expect(sampled[0]).toContainEqual([2, sign * 60]);
+      expect(sampled[1]).toContainEqual([2, sign * 60]);
+    }
+  );
+
+  it.each(["all", "positive", "negative"] as const)(
+    "respects the %s stack strategy",
+    (strategy) => {
+      const sign = strategy === "negative" ? -1 : 1;
+      const data: [number, number][][] = [
+        [0, 100, 60, 0, 0].map((value, x) => [x, sign * value]),
+        [100, 0, 60, 0, 0].map((value, x) => [x, sign * value]),
+      ];
+      const sampled = downSampleAlignedLineData(data, 1, undefined, undefined, [
+        strategy,
+        strategy,
+      ]);
+      expect(sampled[0]).toContainEqual([2, sign * 60]);
+    }
+  );
+
   it("does not align mismatched series by corrupting their data", () => {
     const first: [number, number][] = Array.from({ length: 200 }, (_, x) => [
       x,

--- a/test/components/chart/down-sample.test.ts
+++ b/test/components/chart/down-sample.test.ts
@@ -532,6 +532,27 @@ describe("downSampleAlignedLineData", () => {
     }
   );
 
+  it("uses ECharts decimal addition before choosing the next stack level", () => {
+    const values = [
+      [0.2, -0.8, -0.6, -0.5, 0.7, -0.2, -0.1, 0.9],
+      [0.4, -0.8, 0.5, 0.2, -0.9, 0.5, -0.7, -0.8],
+      [-0.6, 0.8, 0.1, 0, -0.6, -0.4, 0.5, 0.9],
+      [-1, -1, 0.5, 0.4, 0.8, -0.9, -0.9, 0.6],
+    ];
+    const data = values.map((row) =>
+      row.map((y, x): [number, number] => [x, y])
+    );
+    const sampled = downSampleAlignedLineData(data, 1, undefined, undefined, [
+      "negative",
+      "samesign",
+      "positive",
+      "positive",
+    ]);
+    // Rounding 0.2 + 0.4 - 0.6 to zero changes the preceding positive level.
+    // The last level's actual minimum is at x=5, not x=0.
+    expect(sampled[3]).toContainEqual([5, -0.9]);
+  });
+
   it("does not align mismatched series by corrupting their data", () => {
     const first: [number, number][] = Array.from({ length: 200 }, (_, x) => [
       x,

--- a/test/components/chart/down-sample.test.ts
+++ b/test/components/chart/down-sample.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { downSampleLineData } from "../../../src/components/chart/down-sample";
+import {
+  downSampleAlignedLineData,
+  downSampleLineData,
+} from "../../../src/components/chart/down-sample";
 import { digestResult } from "../../fixtures/digest";
 import { FIXED_EPOCH_MS, SCALES } from "../../fixtures/history-states";
 import { createSeededRandom } from "../../fixtures/random";
@@ -403,5 +406,87 @@ describe("downSampleLineData", () => {
         )
       )
     ).toMatchSnapshot();
+  });
+});
+
+describe("downSampleAlignedLineData", () => {
+  it("keeps stacked series aligned while preserving each series extrema and gaps", () => {
+    const first: [number, number | null][] = [];
+    const second: [number, number | null][] = [];
+    for (let index = 0; index < 600; index++) {
+      first.push([index, index === 211 ? 1000 : index === 350 ? null : index]);
+      second.push([
+        index,
+        index === 87 ? -100 : index === 351 ? null : 600 - index,
+      ]);
+    }
+    const sampled = downSampleAlignedLineData([first, second], 40);
+    expect((sampled[0] as [number, number | null][]).map(([x]) => x)).toEqual(
+      (sampled[1] as [number, number | null][]).map(([x]) => x)
+    );
+    expect(sampled[0]).toContainEqual([211, 1000]);
+    expect(sampled[1]).toContainEqual([87, -100]);
+    expect(sampled[0]).toContainEqual([350, null]);
+    expect(sampled[1]).toContainEqual([351, null]);
+    expect(sampled[0][0]).toEqual(first[0]);
+    expect(sampled[0][sampled[0].length - 1]).toEqual(first[first.length - 1]);
+    expect(sampled[0].length).toBeLessThanOrEqual(40 * 2 * 2 + 2);
+  });
+
+  it("bounds long null runs while retaining both sides of gap transitions", () => {
+    const first: [number, number | null][] = Array.from(
+      { length: 100000 },
+      (_, i) => [i, i < 100 || i > 99900 ? 1 : null]
+    );
+    const second: [number, number | null][] = first.map(([x]) => [x, 2]);
+    const sampled = downSampleAlignedLineData([first, second], 40);
+    expect(sampled[0].length).toBeLessThan(200);
+    for (const index of [99, 100, 99900, 99901]) {
+      expect(sampled[0]).toContainEqual(first[index]);
+    }
+    expect(sampled[0].length).toBe(sampled[1].length);
+  });
+
+  it("keeps duplicate-time value/null boundaries inside one sampling frame", () => {
+    const first: [number, number | null][] = [
+      [0, 10],
+      [1, 10],
+      [1, null],
+      [2, null],
+      [2, 20],
+      [3, 20],
+    ];
+    const second: [number, number | null][] = first.map(([x]) => [x, 30]);
+    const sampled = downSampleAlignedLineData([first, second], 1);
+    expect(sampled[0]).toEqual(first);
+    expect(sampled[1]).toEqual(second);
+  });
+
+  it("does not align mismatched series by corrupting their data", () => {
+    const first: [number, number][] = Array.from({ length: 200 }, (_, x) => [
+      x,
+      x,
+    ]);
+    const second: [number, number][] = Array.from({ length: 199 }, (_, x) => [
+      x,
+      x,
+    ]);
+    const sampled = downSampleAlignedLineData([first, second], 20);
+    expect(sampled[0]).toEqual(first);
+    expect(sampled[1]).toEqual(second);
+  });
+
+  it("does not align equal-length series with different timestamps", () => {
+    const first: [number, number][] = Array.from({ length: 200 }, (_, x) => [
+      x,
+      x,
+    ]);
+    const second: [number, number][] = Array.from({ length: 200 }, (_, x) => [
+      x + 1,
+      x,
+    ]);
+    const sampled = downSampleAlignedLineData([first, second], 20);
+    expect(sampled[0]).toEqual(first);
+    expect(sampled[1]).toEqual(second);
   });
 });

--- a/test/components/chart/statistics-chart-data.test.ts
+++ b/test/components/chart/statistics-chart-data.test.ts
@@ -80,6 +80,75 @@ describe("generateStatisticsChartData", () => {
     ).toMatchSnapshot();
   });
 
+  it("aligns stacked lines by timestamp when one statistic has a gap", () => {
+    const ids = ["sensor.charger", "sensor.pv"];
+    const start = FIXED_EPOCH_MS;
+    const period = 5 * 60 * 1000;
+    const statistics = {
+      [ids[0]]: [
+        { start, end: start + period, mean: 10 },
+        { start: start + 2 * period, end: start + 3 * period, mean: 20 },
+      ],
+      [ids[1]]: [
+        { start, end: start + period, mean: 100 },
+        { start: start + period, end: start + 2 * period, mean: 110 },
+        { start: start + 2 * period, end: start + 3 * period, mean: 120 },
+      ],
+    };
+
+    const result = generateStatisticsChartData({
+      ...baseParams,
+      statisticsData: statistics,
+      statisticsMetaData: buildMetadata(ids),
+      statTypes: ["mean"],
+      chartType: "line-stack",
+      period: "5minute",
+    });
+    const series = result!.datasets.filter((dataset) => dataset.data?.length);
+    expect(series).toHaveLength(2);
+    expect(series[0].data).toEqual([
+      [start, 10],
+      [start + period, 10],
+      [start + period, null],
+      [start + 2 * period, 20],
+      [start + 2 * period, 20],
+    ]);
+    expect(series[1].data).toEqual([
+      [start, 100],
+      [start + period, 110],
+      [start + period, 110],
+      [start + 2 * period, 120],
+      [start + 2 * period, 120],
+    ]);
+  });
+
+  it("keeps plain lines independently sampled", () => {
+    const ids = ["sensor.charger", "sensor.pv"];
+    const start = FIXED_EPOCH_MS;
+    const period = 5 * 60 * 1000;
+    const statistics = {
+      [ids[0]]: [
+        { start, end: start + period, mean: 10 },
+        { start: start + 2 * period, end: start + 3 * period, mean: 20 },
+      ],
+      [ids[1]]: [
+        { start, end: start + period, mean: 100 },
+        { start: start + period, end: start + 2 * period, mean: 110 },
+        { start: start + 2 * period, end: start + 3 * period, mean: 120 },
+      ],
+    };
+    const result = generateStatisticsChartData({
+      ...baseParams,
+      statisticsData: statistics,
+      statisticsMetaData: buildMetadata(ids),
+      statTypes: ["mean"],
+      chartType: "line",
+      period: "5minute",
+    });
+    const series = result!.datasets.filter((dataset) => dataset.data?.length);
+    expect(series[0].data!.length).not.toBe(series[1].data!.length);
+  });
+
   it("matches snapshot for a bar chart with sum statistics", () => {
     expect(
       generateStatisticsChartData({

--- a/test/components/chart/statistics-chart-data.test.ts
+++ b/test/components/chart/statistics-chart-data.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { generateStatisticsChartData } from "../../../src/components/chart/statistics-chart-data";
+import { downSampleLineData } from "../../../src/components/chart/down-sample";
 import { StatisticMeanType } from "../../../src/data/recorder";
 import type { StatisticsMetaData } from "../../../src/data/recorder";
 import { createMockComputedStyle } from "../../fixtures/computed-style";
@@ -147,6 +148,64 @@ describe("generateStatisticsChartData", () => {
     });
     const series = result!.datasets.filter((dataset) => dataset.data?.length);
     expect(series[0].data!.length).not.toBe(series[1].data!.length);
+    expect(series[0].sampling).toBe("minmax");
+  });
+
+  it("keeps dense stacked timestamps aligned through the chart render decision", () => {
+    const ids = ["sensor.charger", "sensor.pv"];
+    const start = FIXED_EPOCH_MS;
+    const period = 5 * 60 * 1000;
+    const count = 600;
+    const makeSeries = (skipGap: boolean) =>
+      Array.from({ length: count }, (_, index) => index)
+        .filter((index) => !skipGap || index < 210 || index > 390)
+        .map((index) => ({
+          start: start + index * period,
+          end: start + (index + 1) * period,
+          mean:
+            index === 90 ? 1000 : index === 450 ? 0 : 50 + ((index * 37) % 101),
+        }));
+    const statistics = {
+      [ids[0]]: makeSeries(true),
+      [ids[1]]: makeSeries(false),
+    };
+    const params = {
+      ...baseParams,
+      statisticsData: statistics,
+      statisticsMetaData: buildMetadata(ids),
+      statTypes: ["mean"],
+      chartType: "line-stack" as const,
+      period: "5minute",
+      endTime: new Date(start + (count - 1) * period),
+    };
+
+    const oldSeries = [
+      makeSeries(true).map(
+        ({ start: timestamp, mean }) => [timestamp, mean] as [number, number]
+      ),
+      makeSeries(false).map(
+        ({ start: timestamp, mean }) => [timestamp, mean] as [number, number]
+      ),
+    ];
+    const oldSamples = oldSeries.map((data) =>
+      downSampleLineData(data, 40).map(([timestamp]) => timestamp)
+    );
+    expect(oldSamples[0]).not.toEqual(oldSamples[1]);
+
+    const result = generateStatisticsChartData(params)!;
+    const stackedSeries = result.datasets.filter(
+      (dataset) => dataset.data?.length
+    );
+    expect(stackedSeries).toHaveLength(2);
+    expect(
+      stackedSeries.every((dataset) => dataset.sampling === undefined)
+    ).toBe(true);
+    const renderedSamples = stackedSeries.map((dataset) =>
+      (dataset.sampling === "minmax"
+        ? downSampleLineData(dataset.data as [number, number][], 40)
+        : dataset.data)!.map((point) => (point as [number, number | null])[0])
+    );
+    expect(renderedSamples[0]).toEqual(renderedSamples[1]);
   });
 
   it("matches snapshot for a bar chart with sum statistics", () => {

--- a/test/components/chart/statistics-chart-data.test.ts
+++ b/test/components/chart/statistics-chart-data.test.ts
@@ -169,7 +169,7 @@ describe("generateStatisticsChartData", () => {
       [ids[0]]: makeSeries(true),
       [ids[1]]: makeSeries(false),
     };
-    const params = {
+    const params: Parameters<typeof generateStatisticsChartData>[0] = {
       ...baseParams,
       statisticsData: statistics,
       statisticsMetaData: buildMetadata(ids),
@@ -179,19 +179,6 @@ describe("generateStatisticsChartData", () => {
       endTime: new Date(start + (count - 1) * period),
     };
 
-    const oldSeries = [
-      makeSeries(true).map(
-        ({ start: timestamp, mean }) => [timestamp, mean] as [number, number]
-      ),
-      makeSeries(false).map(
-        ({ start: timestamp, mean }) => [timestamp, mean] as [number, number]
-      ),
-    ];
-    const oldSamples = oldSeries.map((data) =>
-      downSampleLineData(data, 40).map(([timestamp]) => timestamp)
-    );
-    expect(oldSamples[0]).not.toEqual(oldSamples[1]);
-
     const result = generateStatisticsChartData(params)!;
     const stackedSeries = result.datasets.filter(
       (dataset) => dataset.data?.length
@@ -200,12 +187,67 @@ describe("generateStatisticsChartData", () => {
     expect(
       stackedSeries.every((dataset) => dataset.sampling === undefined)
     ).toBe(true);
-    const renderedSamples = stackedSeries.map((dataset) =>
-      (dataset.sampling === "minmax"
-        ? downSampleLineData(dataset.data as [number, number][], 40)
-        : dataset.data)!.map((point) => (point as [number, number | null])[0])
+    const independentlySampled = stackedSeries.map((dataset) =>
+      downSampleLineData(dataset.data as [number, number | null][], 40).map(
+        ([timestamp]) => timestamp
+      )
     );
-    expect(renderedSamples[0]).toEqual(renderedSamples[1]);
+    expect(independentlySampled[0]).not.toEqual(independentlySampled[1]);
+    const renderedTimestamps = stackedSeries.map((dataset) =>
+      dataset.data!.map((point) => (point as [number, number | null])[0])
+    );
+    expect(renderedTimestamps[0]).toEqual(renderedTimestamps[1]);
+  });
+
+  it("excludes hidden and clipped statistics from the stacked timeline", () => {
+    const ids = [
+      "sensor.charger",
+      "sensor.pv",
+      "sensor.hidden",
+      "sensor.future",
+    ];
+    const start = FIXED_EPOCH_MS;
+    const period = 5 * 60 * 1000;
+    const result = generateStatisticsChartData({
+      ...baseParams,
+      statisticsData: {
+        [ids[0]]: [
+          { start, end: start + period, mean: 10 },
+          { start: start + period, end: start + 2 * period, mean: 20 },
+        ],
+        [ids[1]]: [
+          { start, end: start + period, mean: 100 },
+          { start: start + period, end: start + 2 * period, mean: 200 },
+        ],
+        [ids[2]]: [
+          { start: start + period / 2, end: start + period, mean: 50 },
+        ],
+        [ids[3]]: [
+          { start: start + 2 * period, end: start + 3 * period, mean: 75 },
+        ],
+      },
+      statisticsMetaData: buildMetadata(ids),
+      statTypes: ["mean"],
+      chartType: "line-stack",
+      period: "5minute",
+      endTime: new Date(start + period),
+      hiddenStats: new Set([ids[2]]),
+    })!;
+    const series = result.datasets.filter((dataset) => dataset.data?.length);
+
+    expect(series).toHaveLength(2);
+    expect(series.map((dataset) => dataset.data)).toEqual([
+      [
+        [start, 10],
+        [start + period, 20],
+        [start + period, 20],
+      ],
+      [
+        [start, 100],
+        [start + period, 200],
+        [start + period, 200],
+      ],
+    ]);
   });
 
   it("matches snapshot for a bar chart with sum statistics", () => {

--- a/test/components/chart/statistics-chart-data.test.ts
+++ b/test/components/chart/statistics-chart-data.test.ts
@@ -123,6 +123,96 @@ describe("generateStatisticsChartData", () => {
     ]);
   });
 
+  it("keeps every stacked statistic type in its gap slot", () => {
+    const ids = ["sensor.charger", "sensor.pv"];
+    const start = FIXED_EPOCH_MS;
+    const period = 5 * 60 * 1000;
+    const statistics = {
+      [ids[0]]: [
+        { start, end: start + period, mean: 10, min: 1, max: 11 },
+        {
+          start: start + 2 * period,
+          end: start + 3 * period,
+          mean: 20,
+          min: 2,
+          max: 22,
+        },
+      ],
+      [ids[1]]: [
+        { start, end: start + period, mean: 100, min: 90, max: 110 },
+        {
+          start: start + period,
+          end: start + 2 * period,
+          mean: 101,
+          min: 91,
+          max: 111,
+        },
+        {
+          start: start + 2 * period,
+          end: start + 3 * period,
+          mean: 102,
+          min: 92,
+          max: 112,
+        },
+      ],
+    };
+
+    const result = generateStatisticsChartData({
+      ...baseParams,
+      statisticsData: statistics,
+      statisticsMetaData: buildMetadata(ids),
+      statTypes: ["mean", "min", "max"],
+      chartType: "line-stack",
+      period: "5minute",
+    })!;
+    const series = result.datasets.filter((dataset) => dataset.data?.length);
+
+    expect(series.map((dataset) => dataset.data)).toEqual([
+      [
+        [start, 10],
+        [start + period, 10],
+        [start + period, null],
+        [start + 2 * period, 20],
+        [start + 2 * period, 20],
+      ],
+      [
+        [start, 1],
+        [start + period, 1],
+        [start + period, null],
+        [start + 2 * period, 2],
+        [start + 2 * period, 2],
+      ],
+      [
+        [start, 11],
+        [start + period, 11],
+        [start + period, null],
+        [start + 2 * period, 22],
+        [start + 2 * period, 22],
+      ],
+      [
+        [start, 100],
+        [start + period, 101],
+        [start + period, 101],
+        [start + 2 * period, 102],
+        [start + 2 * period, 102],
+      ],
+      [
+        [start, 90],
+        [start + period, 91],
+        [start + period, 91],
+        [start + 2 * period, 92],
+        [start + 2 * period, 92],
+      ],
+      [
+        [start, 110],
+        [start + period, 111],
+        [start + period, 111],
+        [start + 2 * period, 112],
+        [start + 2 * period, 112],
+      ],
+    ]);
+  });
+
   it("keeps plain lines independently sampled", () => {
     const ids = ["sensor.charger", "sensor.pv"];
     const start = FIXED_EPOCH_MS;

--- a/test/components/chart/statistics-chart-data.test.ts
+++ b/test/components/chart/statistics-chart-data.test.ts
@@ -5,7 +5,10 @@
  */
 import { describe, expect, it } from "vitest";
 import { generateStatisticsChartData } from "../../../src/components/chart/statistics-chart-data";
-import { downSampleLineData } from "../../../src/components/chart/down-sample";
+import {
+  downSampleLineData,
+  downSampleAlignedLineData,
+} from "../../../src/components/chart/down-sample";
 import { StatisticMeanType } from "../../../src/data/recorder";
 import type { StatisticsMetaData } from "../../../src/data/recorder";
 import { createMockComputedStyle } from "../../fixtures/computed-style";
@@ -275,7 +278,7 @@ describe("generateStatisticsChartData", () => {
     );
     expect(stackedSeries).toHaveLength(2);
     expect(
-      stackedSeries.every((dataset) => dataset.sampling === undefined)
+      stackedSeries.every((dataset) => dataset.sampling === "minmax")
     ).toBe(true);
     const independentlySampled = stackedSeries.map((dataset) =>
       downSampleLineData(dataset.data as [number, number | null][], 40).map(
@@ -283,8 +286,13 @@ describe("generateStatisticsChartData", () => {
       )
     );
     expect(independentlySampled[0]).not.toEqual(independentlySampled[1]);
-    const renderedTimestamps = stackedSeries.map((dataset) =>
-      dataset.data!.map((point) => (point as [number, number | null])[0])
+    const sampled = downSampleAlignedLineData(
+      stackedSeries.map((dataset) => dataset.data as [number, number | null][]),
+      40
+    );
+    expect(sampled[0].length).toBeLessThan(300);
+    const renderedTimestamps = sampled.map((data) =>
+      data.map((point) => (point as [number, number | null])[0])
     );
     expect(renderedTimestamps[0]).toEqual(renderedTimestamps[1]);
   });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Stacked statistics lines become time-shifted when one entity has missing statistics. ECharts stacks these lines by data index, so a later value can be added to another entity's earlier timestamp.

Build a shared timeline from raw statistic boundaries before emitting datasets in `generateStatisticsChartData`. At render time, sample each aligned stack as a group using one shared set of original indices. Keep each member's extrema, each cumulative stack level's extrema according to its stack strategy, endpoints, and both sides of null transitions; long runs of padding do not retain every null. Group stacks by axes and keep the existing sampler for ordinary lines. Clear ECharts sampling after this shared selection so it cannot independently change the indices again.

Validation: 54 focused statistics/downsampling tests pass, including a generator-to-sampler regression and a 100,000-point mostly-null case. TypeScript and changed-file ESLint/Prettier checks pass. Browser replay of Radio UPS data retains matching timestamps and correct sums at 100 px and 366 px widths; hiding a member also works. An ECharts comparison across 100 seeded cases checks extrema at 400 stack levels with mixed stack strategies, negative values, zeros, and nulls.

In the two-series long-range browser probe, rendered points per series fell from 105,121 to 4,387. The 30-day probe fell from 8,641 to 1,900. In an alternating same-browser render comparison on the same data, preparation plus drawing took 60–62 ms with shared sampling versus 168–189 ms with sampling disabled (two runs per mode; excludes data generation and loading). Full ESLint still reports two import-extension errors in unchanged gallery files.

The benchmark harness now covers dense and mostly-null aligned stacks of two 100,000-point members. Three runs characterize the unchanged implementation: the third run measured 57.88 ms for dense stacks and 13.61 ms for mostly-null stacks. [Repeated baselines, throughput, error margins, and JSON reports](https://github.com/Komzpa/frontend/blob/d96301183a12e9396bbdb97511a657fa3a81d046/.github/pr-evidence/statistics-line-stack-gaps/aligned-benchmarks.md).

Null handling follows ECharts: `all` propagates a null preceding cumulative level, while sign-sensitive strategies skip it. The finite/null/finite regression keeps the actual minimum of 16; skipping the null in `all` would drop that point and raise the displayed minimum to 21.

## Screenshots

| Before | After |
| --- | --- |
| ![Before: stacked peak shifted to an earlier timestamp](https://raw.githubusercontent.com/Komzpa/frontend/18f587e745f325329d157b69109c6c8e3985b411/.github/pr-evidence/statistics-line-stack-gaps/before.png) | ![After: stacked peak aligned to the same timestamp](https://raw.githubusercontent.com/Komzpa/frontend/d96301183a12e9396bbdb97511a657fa3a81d046/.github/pr-evidence/statistics-line-stack-gaps/after-v3.png) |

The before image is the original dashboard failure. The updated after image uses saved Radio UPS recorder data in a local gallery build of this revision; theme and viewport differ.

<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: None.
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
