### PR TITLE
show up to 5 discrete buttons on fan cards

### DIFF
--- a/gallery/src/pages/lovelace/tile-card.ts
+++ b/gallery/src/pages/lovelace/tile-card.ts
@@ -12,7 +12,10 @@ import "../../components/demo-cards";
 import { mockIcons } from "../../../../demo/src/stubs/icons";
 import { ClimateEntityFeature } from "../../../../src/data/climate";
 import { FanEntityFeature } from "../../../../src/data/fan";
-import type { TileCardConfig } from "../../../../src/panels/lovelace/cards/types";
+import type {
+  GridCardConfig,
+  TileCardConfig,
+} from "../../../../src/panels/lovelace/cards/types";
 
 const ENTITIES = [
   {
@@ -161,6 +164,39 @@ const ENTITIES = [
         FanEntityFeature.DIRECTION +
         FanEntityFeature.SET_SPEED +
         FanEntityFeature.OSCILLATE,
+    },
+  },
+  {
+    entity_id: "fan.three_speed_fan",
+    state: "on",
+    attributes: {
+      friendly_name: "Desk fan",
+      device_class: "fan",
+      percentage: 67,
+      percentage_step: 100 / 3,
+      supported_features: FanEntityFeature.SET_SPEED,
+    },
+  },
+  {
+    entity_id: "fan.four_speed_fan",
+    state: "on",
+    attributes: {
+      friendly_name: "Bedroom fan",
+      device_class: "fan",
+      percentage: 50,
+      percentage_step: 25,
+      supported_features: FanEntityFeature.SET_SPEED,
+    },
+  },
+  {
+    entity_id: "fan.five_speed_fan",
+    state: "on",
+    attributes: {
+      friendly_name: "Attic fan",
+      device_class: "fan",
+      percentage: 80,
+      percentage_step: 20,
+      supported_features: FanEntityFeature.SET_SPEED,
     },
   },
 ];
@@ -333,6 +369,50 @@ const CONFIGS = [
     },
   },
   {
+    heading: "Fan speed feature (3 speeds)",
+    config: {
+      type: "tile",
+      entity: "fan.three_speed_fan",
+      features: [{ type: "fan-speed" }],
+    },
+  },
+  {
+    heading: "Fan speed feature (4 speeds)",
+    config: {
+      type: "tile",
+      entity: "fan.four_speed_fan",
+      features: [{ type: "fan-speed" }],
+    },
+  },
+  {
+    heading: "Fan speed feature (5 speeds)",
+    config: {
+      type: "tile",
+      entity: "fan.five_speed_fan",
+      features: [{ type: "fan-speed" }],
+    },
+  },
+  {
+    heading: "Fan speed feature (half width)",
+    config: {
+      type: "grid",
+      columns: 2,
+      square: false,
+      cards: [
+        {
+          type: "tile",
+          entity: "fan.four_speed_fan",
+          features: [{ type: "fan-speed" }],
+        },
+        {
+          type: "tile",
+          entity: "fan.five_speed_fan",
+          features: [{ type: "fan-speed" }],
+        },
+      ],
+    },
+  },
+  {
     heading: "Fan oscillate feature",
     config: {
       type: "tile",
@@ -418,7 +498,7 @@ const CONFIGS = [
       ],
     },
   },
-] satisfies DemoCardConfig<TileCardConfig>[];
+] satisfies DemoCardConfig<TileCardConfig | GridCardConfig>[];
 
 @customElement("demo-lovelace-tile-card")
 class DemoTile extends LitElement {

--- a/gallery/src/pages/more-info/fan.ts
+++ b/gallery/src/pages/more-info/fan.ts
@@ -21,6 +21,61 @@ const ENTITIES = [
         FanEntityFeature.SET_SPEED,
     },
   },
+  {
+    entity_id: "fan.one_speed_fan",
+    state: "on",
+    attributes: {
+      friendly_name: "One speed fan",
+      device_class: "fan",
+      percentage: 100,
+      percentage_step: 100,
+      supported_features: FanEntityFeature.SET_SPEED,
+    },
+  },
+  {
+    entity_id: "fan.two_speed_fan",
+    state: "on",
+    attributes: {
+      friendly_name: "Two speed fan",
+      device_class: "fan",
+      percentage: 50,
+      percentage_step: 50,
+      supported_features: FanEntityFeature.SET_SPEED,
+    },
+  },
+  {
+    entity_id: "fan.three_speed_fan",
+    state: "on",
+    attributes: {
+      friendly_name: "Three speed fan",
+      device_class: "fan",
+      percentage: 67,
+      percentage_step: 100 / 3,
+      supported_features: FanEntityFeature.SET_SPEED,
+    },
+  },
+  {
+    entity_id: "fan.four_speed_fan",
+    state: "on",
+    attributes: {
+      friendly_name: "Four speed fan",
+      device_class: "fan",
+      percentage: 50,
+      percentage_step: 25,
+      supported_features: FanEntityFeature.SET_SPEED,
+    },
+  },
+  {
+    entity_id: "fan.five_speed_fan",
+    state: "on",
+    attributes: {
+      friendly_name: "Five speed fan",
+      device_class: "fan",
+      percentage: 80,
+      percentage_step: 20,
+      supported_features: FanEntityFeature.SET_SPEED,
+    },
+  },
 ];
 
 @customElement("demo-more-info-fan")

--- a/src/data/fan.ts
+++ b/src/data/fan.ts
@@ -36,13 +36,42 @@ export interface FanEntity extends HassEntityBase {
 
 export type FanDirection = "forward" | "reverse";
 
-export type FanSpeed = "off" | "low" | "medium" | "high" | "on";
+// Named speeds are used when there are icons for every step. Fans with more
+// steps use numbered speeds ("1", "2", ...) instead.
+export type FanSpeed = "off" | "low" | "medium" | "high" | "on" | `${number}`;
 
-export const FAN_SPEEDS: Partial<Record<number, FanSpeed[]>> = {
+const FAN_SPEEDS_NAMED: Partial<Record<number, FanSpeed[]>> = {
   2: ["off", "on"],
   3: ["off", "low", "high"],
   4: ["off", "low", "medium", "high"],
 };
+
+export const FAN_SPEED_COUNT_MAX_FOR_BUTTONS = 6;
+
+export function computeFanSpeedCount(stateObj: FanEntity): number {
+  const step = stateObj.attributes.percentage_step ?? 1;
+  const speedCount = Math.round(100 / step) + 1;
+  return speedCount;
+}
+
+export function computeFanSpeeds(stateObj: FanEntity): FanSpeed[] | undefined {
+  const speedCount = computeFanSpeedCount(stateObj);
+  if (speedCount > FAN_SPEED_COUNT_MAX_FOR_BUTTONS) {
+    return undefined;
+  }
+  return (
+    FAN_SPEEDS_NAMED[speedCount] ?? [
+      "off",
+      ...Array.from(
+        { length: speedCount - 1 },
+        (_, index) => `${index + 1}` as const
+      ),
+    ]
+  );
+}
+
+export const isNumberedFanSpeed = (speed: FanSpeed): speed is `${number}` =>
+  !isNaN(Number(speed));
 
 export function fanPercentageToSpeed(
   stateObj: FanEntity,
@@ -50,9 +79,8 @@ export function fanPercentageToSpeed(
 ): FanSpeed {
   const step = stateObj.attributes.percentage_step ?? 1;
   const speedValue = Math.round(value / step);
-  const speedCount = Math.round(100 / step) + 1;
 
-  const speeds = FAN_SPEEDS[speedCount];
+  const speeds = computeFanSpeeds(stateObj);
   return speeds?.[speedValue] ?? "off";
 }
 
@@ -61,9 +89,8 @@ export function fanSpeedToPercentage(
   speed: FanSpeed
 ): number {
   const step = stateObj.attributes.percentage_step ?? 1;
-  const speedCount = Math.round(100 / step) + 1;
 
-  const speeds = FAN_SPEEDS[speedCount];
+  const speeds = computeFanSpeeds(stateObj);
 
   if (!speeds) {
     return 0;
@@ -76,27 +103,22 @@ export function fanSpeedToPercentage(
   return Math.floor(speedValue * step);
 }
 
-export function computeFanSpeedCount(stateObj: FanEntity): number {
-  const step = stateObj.attributes.percentage_step ?? 1;
-  const speedCount = Math.round(100 / step) + 1;
-  return speedCount;
-}
-
 export function computeFanSpeedIcon(
   stateObj: FanEntity,
   speed: FanSpeed
-): string {
-  const speedCount = computeFanSpeedCount(stateObj);
-  const speeds = FAN_SPEEDS[speedCount];
-  const index = speeds?.indexOf(speed) ?? 1;
-
-  return speed === "on"
-    ? mdiFan
-    : speed === "off"
-      ? mdiFanOff
-      : [mdiFanSpeed1, mdiFanSpeed2, mdiFanSpeed3][index - 1];
+): string | undefined {
+  if (speed === "on") {
+    return mdiFan;
+  }
+  if (speed === "off") {
+    return mdiFanOff;
+  }
+  if (isNumberedFanSpeed(speed)) {
+    return undefined;
+  }
+  const index = computeFanSpeeds(stateObj)?.indexOf(speed) ?? 1;
+  return [mdiFanSpeed1, mdiFanSpeed2, mdiFanSpeed3][index - 1];
 }
-export const FAN_SPEED_COUNT_MAX_FOR_BUTTONS = 4;
 
 export function computeFanSpeedStateDisplay(
   stateObj: FanEntity,

--- a/src/panels/lovelace/card-features/hui-fan-speed-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-fan-speed-card-feature.ts
@@ -12,6 +12,7 @@ import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { stateActive } from "../../../common/entity/state_active";
 import { supportsFeature } from "../../../common/entity/supports-feature";
+import { formatNumber } from "../../../common/number/format_number";
 import type { LocalizeFunc } from "../../../common/translations/localize";
 import "../../../components/ha-control-select";
 import type { ControlSelectOption } from "../../../components/ha-control-select";
@@ -26,13 +27,12 @@ import { UNAVAILABLE } from "../../../data/entity/entity";
 import { DOMAIN_ATTRIBUTES_UNITS } from "../../../data/entity/entity_attributes";
 import type { FanEntity, FanSpeed } from "../../../data/fan";
 import {
-  computeFanSpeedCount,
   computeFanSpeedIcon,
-  FAN_SPEED_COUNT_MAX_FOR_BUTTONS,
-  FAN_SPEEDS,
+  computeFanSpeeds,
   FanEntityFeature,
   fanPercentageToSpeed,
   fanSpeedToPercentage,
+  isNumberedFanSpeed,
 } from "../../../data/fan";
 import type { FrontendLocaleData } from "../../../data/translation";
 import type {
@@ -116,6 +116,11 @@ class HuiFanSpeedCardFeature extends LitElement implements LovelaceCardFeature {
     if (speed === "on" || speed === "off") {
       return this._formatters.formatEntityState(this._stateObj!, speed);
     }
+    if (isNumberedFanSpeed(speed)) {
+      return this._localize("ui.card.fan.speed.numbered", {
+        speed: formatNumber(speed, this._locale),
+      });
+    }
     return this._localize(`ui.card.fan.speed.${speed}`) || speed;
   }
 
@@ -129,19 +134,25 @@ class HuiFanSpeedCardFeature extends LitElement implements LovelaceCardFeature {
       return nothing;
     }
 
-    const speedCount = computeFanSpeedCount(this._stateObj);
+    const speeds = computeFanSpeeds(this._stateObj);
 
     const percentage = stateActive(this._stateObj)
       ? (this._stateObj.attributes.percentage ?? 0)
       : 0;
 
-    if (speedCount <= FAN_SPEED_COUNT_MAX_FOR_BUTTONS) {
-      const options = FAN_SPEEDS[speedCount]!.map<ControlSelectOption>(
-        (speed) => ({
-          value: speed,
-          label: this._localizeSpeed(speed),
-          path: computeFanSpeedIcon(this._stateObj!, speed),
-        })
+    if (speeds) {
+      const options = speeds.map<ControlSelectOption>((speed) =>
+        isNumberedFanSpeed(speed)
+          ? {
+              value: speed,
+              label: formatNumber(speed, this._locale),
+              ariaLabel: this._localizeSpeed(speed),
+            }
+          : {
+              value: speed,
+              ariaLabel: this._localizeSpeed(speed),
+              path: computeFanSpeedIcon(this._stateObj!, speed),
+            }
       );
 
       const speed = fanPercentageToSpeed(this._stateObj, percentage);
@@ -151,7 +162,6 @@ class HuiFanSpeedCardFeature extends LitElement implements LovelaceCardFeature {
           .options=${options}
           .value=${speed}
           @value-changed=${this._speedValueChanged}
-          hide-option-label
           .label=${computeAttributeNameDisplay(
             this._localize,
             this._stateObj,

--- a/src/state-control/fan/ha-state-control-fan-speed.ts
+++ b/src/state-control/fan/ha-state-control-fan-speed.ts
@@ -7,6 +7,7 @@ import { computeAttributeNameDisplay } from "../../common/entity/compute_attribu
 import type { HASSDomEvent } from "../../common/dom/fire_event";
 import { stateActive } from "../../common/entity/state_active";
 import { stateColorCss } from "../../common/entity/state_color";
+import { formatNumber } from "../../common/number/format_number";
 import "../../components/ha-control-select";
 import type { ControlSelectOption } from "../../components/ha-control-select";
 import "../../components/ha-control-slider";
@@ -20,12 +21,11 @@ import { UNAVAILABLE } from "../../data/entity/entity";
 import { DOMAIN_ATTRIBUTES_UNITS } from "../../data/entity/entity_attributes";
 import type { FanEntity, FanSpeed } from "../../data/fan";
 import {
-  computeFanSpeedCount,
   computeFanSpeedIcon,
-  FAN_SPEED_COUNT_MAX_FOR_BUTTONS,
-  FAN_SPEEDS,
+  computeFanSpeeds,
   fanPercentageToSpeed,
   fanSpeedToPercentage,
+  isNumberedFanSpeed,
 } from "../../data/fan";
 
 @customElement("ha-state-control-fan-speed")
@@ -91,22 +91,35 @@ export class HaStateControlFanSpeed extends LitElement {
     if (speed === "on" || speed === "off") {
       return this._formatters.formatEntityState(this.stateObj, speed);
     }
+    if (isNumberedFanSpeed(speed)) {
+      return this._i18n.localize("ui.card.fan.speed.numbered", {
+        speed: formatNumber(speed, this._i18n.locale),
+      });
+    }
     return this._i18n.localize(`ui.card.fan.speed.${speed}`) || speed;
   }
 
   protected render() {
     const color = stateColorCss(this.stateObj);
 
-    const speedCount = computeFanSpeedCount(this.stateObj);
+    const speeds = computeFanSpeeds(this.stateObj);
 
-    if (speedCount <= FAN_SPEED_COUNT_MAX_FOR_BUTTONS) {
-      const options = FAN_SPEEDS[speedCount]!.map<ControlSelectOption>(
-        (speed) => ({
-          value: speed,
-          label: this._localizeSpeed(speed),
-          path: computeFanSpeedIcon(this.stateObj, speed),
-        })
-      ).reverse();
+    if (speeds) {
+      const options = speeds
+        .map<ControlSelectOption>((speed) =>
+          isNumberedFanSpeed(speed)
+            ? {
+                value: speed,
+                label: formatNumber(speed, this._i18n.locale),
+                ariaLabel: this._localizeSpeed(speed),
+              }
+            : {
+                value: speed,
+                label: this._localizeSpeed(speed),
+                path: computeFanSpeedIcon(this.stateObj, speed),
+              }
+        )
+        .reverse();
 
       return html`
         <ha-control-select

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -180,7 +180,8 @@
         "speed": {
           "low": "Low",
           "medium": "Medium",
-          "high": "High"
+          "high": "High",
+          "numbered": "Speed {speed}"
         }
       },
       "humidifier": {

--- a/test/data/fan.test.ts
+++ b/test/data/fan.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { FanEntity } from "../../src/data/fan";
+import {
+  computeFanSpeedIcon,
+  computeFanSpeeds,
+  fanPercentageToSpeed,
+  fanSpeedToPercentage,
+} from "../../src/data/fan";
+
+const fan = (percentage_step?: number): FanEntity =>
+  ({
+    entity_id: "fan.test",
+    state: "on",
+    attributes: { percentage_step },
+  }) as FanEntity;
+
+describe("computeFanSpeeds", () => {
+  it("uses named speeds when icons exist for every step", () => {
+    expect(computeFanSpeeds(fan(100))).toEqual(["off", "on"]);
+    expect(computeFanSpeeds(fan(50))).toEqual(["off", "low", "high"]);
+    expect(computeFanSpeeds(fan(100 / 3))).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("uses numbered speeds for fans with more steps", () => {
+    expect(computeFanSpeeds(fan(25))).toEqual(["off", "1", "2", "3", "4"]);
+    expect(computeFanSpeeds(fan(20))).toEqual(["off", "1", "2", "3", "4", "5"]);
+  });
+
+  it("returns undefined when there are too many steps for buttons", () => {
+    expect(computeFanSpeeds(fan(100 / 6))).toBeUndefined();
+    expect(computeFanSpeeds(fan())).toBeUndefined();
+  });
+});
+
+describe("fan speed and percentage conversion", () => {
+  it("round-trips named speeds", () => {
+    const stateObj = fan(100 / 3);
+    expect(fanPercentageToSpeed(stateObj, 67)).toBe("medium");
+    expect(fanSpeedToPercentage(stateObj, "medium")).toBe(66);
+    expect(fanPercentageToSpeed(stateObj, 66)).toBe("medium");
+  });
+
+  it("round-trips numbered speeds", () => {
+    const stateObj = fan(25);
+    expect(fanPercentageToSpeed(stateObj, 0)).toBe("off");
+    expect(fanPercentageToSpeed(stateObj, 75)).toBe("3");
+    expect(fanSpeedToPercentage(stateObj, "4")).toBe(100);
+  });
+});
+
+describe("computeFanSpeedIcon", () => {
+  it("has icons for named speeds but not numbered ones", () => {
+    expect(computeFanSpeedIcon(fan(100 / 3), "high")).toBeTypeOf("string");
+    expect(computeFanSpeedIcon(fan(25), "off")).toBeTypeOf("string");
+    expect(computeFanSpeedIcon(fan(25), "2")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The current fan card will add buttons for up to three discrete speeds (low, medium, high), but if there's a fourth discrete speed, it will fall back to the percentage slider. Looking at the code, it appears that the rationale, which is solid, is that [the mdi icons only go up to 3](https://pictogrammers.com/library/mdi/?q=fan-speed). This PR switches it to use numbers for fans that have 4 or 5 speeds, with 6 or more it will continue to fall back to the slider.

In the gallery, one card at half width still has just over 28px per button, so this is still a pretty good sized target.

This comes up occasionally in discussions, a few recent examples:
[this discussion](https://community.home-assistant.io/t/4-speed-template-fan-possible/865690/8) led to [an issue](https://github.com/home-assistant/frontend/issues/24694), which was closed as stale.
[this person had the same issue](https://www.reddit.com/r/homeassistant/comments/1c5fxqo/is_there_a_way_to_access_all_four_of_my_fans/), and was confused because they didn't realize the slider could control the speed.


## Screenshots

This gallery shot illustrates all states of the fan card with various discrete speeds

<img width="872" height="610" alt="image" src="https://github.com/user-attachments/assets/0369a5ca-9522-4015-b5a6-7959c8496693" />

And the more info dialog:
<img width="946" height="884" alt="image" src="https://github.com/user-attachments/assets/675d689f-a2bb-431a-b50a-bed3bd9ea140" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #24694
- This PR is related to issue or discussion: https://community.home-assistant.io/t/4-speed-template-fan-possible/865690/8 https://www.reddit.com/r/homeassistant/comments/1c5fxqo/is_there_a_way_to_access_all_four_of_my_fans/
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr] ??
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
